### PR TITLE
fix(docs): deploy on blog changes, correct GitHub repo, stop cross-locale homepage caching

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'apps/docs/**'
       - 'content/docs/**'
+      - 'content/blog/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export const gitConfig = {
   user: 'objectstack-ai',
-  repo: 'spec',
+  repo: 'objectos',
   branch: 'main',
 };
 

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -157,7 +157,16 @@ export default function middleware(request: NextRequest) {
     const url = new URL(request.url);
     // Handle root path specially to avoid double slashes
     url.pathname = pathname === '/' ? `/${i18n.defaultLanguage}` : `/${i18n.defaultLanguage}${pathname}`;
-    return NextResponse.rewrite(url);
+    const response = NextResponse.rewrite(url);
+    // This is a locale-negotiated response for a prefix-less path (e.g. "/").
+    // The underlying page is statically cached with a long s-maxage, but the
+    // *result here depends on the visitor's language* — so it must never be
+    // stored in a shared cache, or the CDN would serve this (default-locale)
+    // HTML to every visitor and non-English browsers would stop being
+    // redirected to their localized path. Mark it private so the edge skips it
+    // and middleware re-runs language detection on every request.
+    response.headers.set('Cache-Control', 'private, no-cache, must-revalidate');
+    return response;
   }
 
   // For non-default languages, redirect to the localized path


### PR DESCRIPTION
Three fixes prompted by issues seen on the live site (objectos.ai).

## 1. Blog changes never deployed
`deploy-docs.yml` only triggered on `content/docs/**`. The expanded blog post (#12) only touched `content/blog/**`, so **no deploy fired** — the live blog still shows the old short version. Added `content/blog/**` to the path filter.

## 2. Wrong GitHub repo
`gitConfig.repo` was `'spec'`, so the navbar GitHub link and the docs *edit this page* link pointed at `github.com/objectstack-ai/spec`. Corrected to **`objectos`**, where this content actually lives.

## 3. Chinese (and other) browsers not redirected from the homepage
The redirect logic is actually correct — a cache-**miss** request proves it:
```
$ curl -sD- -o/dev/null -H 'Accept-Language: zh-CN,zh;q=0.9' https://www.objectos.ai/
HTTP/2 307
location: /zh-Hans
set-cookie: FD_LOCALE=zh-Hans; Path=/; SameSite=lax
```
The bug is caching: the prefix-less `/` (default/English) is served with `cache-control: s-maxage=31536000` and **no `Vary: Accept-Language`**. A shared cache stores that English homepage at `/` and serves it to everyone, so non-English visitors never hit the middleware redirect. Fix: mark the default-locale rewrite response `private, no-cache, must-revalidate` so the edge never shares it and middleware re-runs language detection on every request.

## After merge
This PR touches `apps/docs/**` and `.github/workflows/deploy-docs.yml`, so merging will **trigger a docs deploy** that also publishes the already-merged expanded blog post. Verification post-deploy: hit `/` with a `zh-CN` Accept-Language and confirm the 307, and confirm the navbar GitHub link resolves to `/objectos`.

Build: `pnpm --filter docs build` → green (509 static pages).