### PR TITLE
chore(deps): upgrade @objectstack to 8.0.1 and bump ObjectOS One to 8.0.1

### DIFF
--- a/apps/objectos-one/package.json
+++ b/apps/objectos-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectos/one",
-  "version": "7.9.0",
+  "version": "8.0.1",
   "private": true,
   "license": "Apache-2.0",
   "description": "ObjectOS One — all-in-one local distribution (Tauri shell + bundled Node runtime + DB).",

--- a/apps/objectos-one/src-tauri/Cargo.lock
+++ b/apps/objectos-one/src-tauri/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "objectos-one"
-version = "7.9.0"
+version = "8.0.1"
 dependencies = [
  "dirs 5.0.1",
  "libc",

--- a/apps/objectos-one/src-tauri/Cargo.toml
+++ b/apps/objectos-one/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "objectos-one"
-version = "7.9.0"
+version = "8.0.1"
 description = "ObjectOS One shell"
 edition = "2021"
 rust-version = "1.77"

--- a/apps/objectos-one/src-tauri/tauri.conf.json
+++ b/apps/objectos-one/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ObjectOS",
-  "version": "7.9.0",
+  "version": "8.0.1",
   "identifier": "ai.objectstack.objectos",
   "build": {
     "frontendDist": "../src",

--- a/apps/objectos/objectstack.config.ts
+++ b/apps/objectos/objectstack.config.ts
@@ -6,34 +6,38 @@
  * `@objectstack/*` packages on npm; this repository deliberately
  * contains no protocol code of its own.
  *
- * Boot mode is governed by environment variables:
+ * As of @objectstack 8.0 the runtime ships a single-tenant *standalone*
+ * stack (`createStandaloneStack`); the 7.x cloud-connected, hostname-routed
+ * multi-tenant wrapper (`createObjectOSStack`) has been removed from the
+ * public runtime API. A cloud deployment now points `OS_ARTIFACT_FILE` at a
+ * published artifact URL — `artifactPath` accepts `http(s)://` sources and
+ * is fetched lazily by the loader.
  *
- *   OS_CLOUD_URL        — Artifact API base URL (cloud-connected mode)
- *   OS_ENVIRONMENT_ID   — Environment/project to serve (legacy: OS_PROJECT_ID)
- *   OS_ARTIFACT_FILE    — Path to a local dist/objectstack.json (offline mode)
- *   OS_BUSINESS_DB_URL  — Per-project business database
- *   OS_CACHE_DIR        — Local artifact cache (default: /var/cache/objectos)
+ * Boot is governed by environment variables (all optional — sensible
+ * defaults are applied by `createStandaloneStack`):
  *
- * If OS_CLOUD_URL is absent, ObjectOS defaults to local file-backed mode.
- * Enterprise plugins live in ../../packages/* and can be appended to the
- * default plugin manifest below.
+ *   OS_ARTIFACT_FILE    — Path or URL to a compiled `dist/objectstack.json`
+ *                         (default: <cwd>/dist/objectstack.json)
+ *   OS_ENVIRONMENT_ID   — Environment/project to serve (legacy: OS_PROJECT_ID;
+ *                         default: proj_local)
+ *   OS_BUSINESS_DB_URL  — Per-project business database (legacy: OS_DATABASE_URL;
+ *                         default: file-backed sqlite under the ObjectStack home)
+ *
+ * Artifact hot-reload follows `NODE_ENV` (on outside production). Enterprise
+ * plugins live in ../../packages/* and can be appended to the returned
+ * plugin manifest below.
  */
 
-import { createObjectOSStack } from '@objectstack/runtime';
+import { createStandaloneStack } from '@objectstack/runtime';
 
-const cloudUrl = process.env.OS_CLOUD_URL;
 const artifactFile = process.env.OS_ARTIFACT_FILE;
 const environmentId =
   process.env.OS_ENVIRONMENT_ID ?? process.env.OS_PROJECT_ID;
+const databaseUrl =
+  process.env.OS_BUSINESS_DB_URL ?? process.env.OS_DATABASE_URL;
 
-export default await createObjectOSStack({
-  controlPlaneUrl: cloudUrl ?? 'file',
-  controlPlaneApiKey: process.env.OS_CLOUD_API_KEY,
-  fileConfig: artifactFile
-    ? {
-        artifactPath: artifactFile,
-        environmentId,
-        watch: process.env.OS_WATCH_ARTIFACT === '1',
-      }
-    : undefined,
+export default await createStandaloneStack({
+  artifactPath: artifactFile,
+  environmentId,
+  databaseUrl,
 });

--- a/apps/objectos/package.json
+++ b/apps/objectos/package.json
@@ -13,14 +13,14 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@objectstack/cli": "^7.9.0",
-    "@objectstack/core": "^7.9.0",
-    "@objectstack/driver-memory": "^7.9.0",
-    "@objectstack/driver-sql": "^7.9.0",
-    "@objectstack/metadata": "^7.9.0",
-    "@objectstack/objectql": "^7.9.0",
-    "@objectstack/runtime": "^7.9.0",
-    "@objectstack/spec": "^7.9.0"
+    "@objectstack/cli": "^8.0.1",
+    "@objectstack/core": "^8.0.1",
+    "@objectstack/driver-memory": "^8.0.1",
+    "@objectstack/driver-sql": "^8.0.1",
+    "@objectstack/metadata": "^8.0.1",
+    "@objectstack/objectql": "^8.0.1",
+    "@objectstack/runtime": "^8.0.1",
+    "@objectstack/spec": "^8.0.1"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/content/docs/configure/api-access.de.mdx
+++ b/content/docs/configure/api-access.de.mdx
@@ -25,6 +25,8 @@ Wichtige Schnittstellen:
 | `/api/v1/actions/<object>/<action>` | Eine deklarative Aktion aufrufen (POST) |
 | `/api/v1/auth/*` | Authentifizierung (Anmeldung, Sitzungen, OAuth, OIDC) |
 | `/api/v1/meta/*` | Metadaten-APIs (Objekte, Felder, Ansichten), sofern aktiviert |
+| `/api/v1/keys` | Erzeugt einen nur einmal angezeigten `sys_api_key` für den aufrufenden Benutzer (POST) |
+| `/api/v1/mcp` | Model-Context-Protocol-Server über Streamable HTTP, wenn `OS_MCP_SERVER_ENABLED=true` |
 | `/api/v1/health` | Liveness-/Readiness-Probe (keine Authentifizierung) |
 
 Das Präfix lautet standardmäßig `/api/v1` (der API-`basePath` von `/api` plus
@@ -51,20 +53,32 @@ selbst wird gehasht gespeichert — nur das `prefix` und Metadaten bleiben
 abfragbar, sodass ein durchgesickerter Schlüssel nicht aus der Datenbank
 rekonstruiert werden kann.
 
-So stellen Sie einen Schlüssel aus:
+Es gibt zwei Wege, einen Schlüssel auszustellen:
 
-1. Melden Sie sich als Administrator bei **Console → API Keys** an.
-2. Wählen Sie den besitzenden Benutzer (der API-Aufruf erbt die
-   Berechtigungen und den Datensatzzugriff dieses Benutzers).
-3. Legen Sie optional ein Ablaufdatum fest.
-4. Kopieren Sie das angezeigte Geheimnis **einmalig** — es wird nicht erneut
-   angezeigt.
+- **Console** — melden Sie sich als Administrator bei **Console → API Keys**
+  an, wählen Sie den besitzenden Benutzer, legen Sie optional ein Ablaufdatum
+  fest und kopieren Sie das angezeigte Geheimnis **einmalig**.
+- **Self-Service-Endpunkt** — `POST /api/v1/keys` erzeugt einen Schlüssel für
+  den authentifizierten Aufrufer und gibt das rohe Geheimnis genau einmal
+  zurück. Der Schlüssel ist an den eigenen Benutzer des Aufrufers gebunden und
+  kann daher nicht zur Identitätsübernahme verwendet werden:
 
-Verwenden Sie den Schlüssel als Bearer-Token:
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+Übergeben Sie den Schlüssel bei nachfolgenden Anfragen als Bearer-Token, als
+`x-api-key`-Header oder als `Authorization: ApiKey`. Die REST-Daten- und
+Metadaten-APIs authentifizieren ihn über denselben Verifier wie MCP, unter den
+Berechtigungen und der Datensatz-Sicherheit des Schlüsselinhabers:
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 Um einen Schlüssel zu widerrufen, führen Sie die Aktion `revoke_api_key` für

--- a/content/docs/configure/api-access.es.mdx
+++ b/content/docs/configure/api-access.es.mdx
@@ -25,6 +25,8 @@ Superficies destacadas:
 | `/api/v1/actions/<object>/<action>` | Invocar una acción declarativa (POST) |
 | `/api/v1/auth/*` | Autenticación (inicio de sesión, sesiones, OAuth, OIDC) |
 | `/api/v1/meta/*` | APIs de metadatos (objetos, campos, vistas) cuando está habilitado |
+| `/api/v1/keys` | Genera un `sys_api_key` de un solo uso para el usuario que llama (POST) |
+| `/api/v1/mcp` | Servidor Model Context Protocol sobre Streamable HTTP, cuando `OS_MCP_SERVER_ENABLED=true` |
 | `/api/v1/health` | Sonda de liveness/readiness (sin autenticación) |
 
 El prefijo es `/api/v1` de forma predeterminada (el `basePath` de la API,
@@ -51,19 +53,32 @@ de la clave en sí se almacena cifrado (hash) — solo el `prefix` y los
 metadatos permanecen consultables, de modo que una clave filtrada no puede
 reconstruirse a partir de la base de datos.
 
-Para emitir una clave:
+Emite una clave de dos maneras:
 
-1. Inicia sesión en **Console → API Keys** como administrador.
-2. Elige el usuario propietario (la llamada a la API hereda los permisos
-   y el acceso a registros de ese usuario).
-3. Opcionalmente, establece una fecha de expiración.
-4. Copia el secreto mostrado **una sola vez** — no se vuelve a mostrar.
+- **Console** — inicia sesión en **Console → API Keys** como administrador,
+  elige el usuario propietario, opcionalmente establece una fecha de
+  expiración y copia el secreto mostrado **una sola vez**.
+- **Endpoint de autoservicio** — `POST /api/v1/keys` genera una clave para el
+  llamante autenticado y devuelve el secreto en bruto exactamente una vez. La
+  clave queda fijada al propio usuario del llamante, por lo que no puede usarse
+  para suplantar otra identidad:
 
-Usa la clave como token bearer:
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+Pasa la clave en las solicitudes posteriores como token bearer, como cabecera
+`x-api-key` o como `Authorization: ApiKey`. Las API REST de datos y metadatos
+la autentican con el mismo verificador que MCP, bajo los permisos y la
+seguridad a nivel de registro del propietario de la clave:
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 Para revocar una clave, ejecuta la acción `revoke_api_key` en el registro

--- a/content/docs/configure/api-access.fr.mdx
+++ b/content/docs/configure/api-access.fr.mdx
@@ -25,6 +25,8 @@ Surfaces notables :
 | `/api/v1/actions/<object>/<action>` | Invoquer une action déclarative (POST) |
 | `/api/v1/auth/*` | Authentification (connexion, sessions, OAuth, OIDC) |
 | `/api/v1/meta/*` | API de métadonnées (objets, champs, vues) lorsqu'elles sont activées |
+| `/api/v1/keys` | Génère une `sys_api_key` affichée une seule fois pour l'utilisateur appelant (POST) |
+| `/api/v1/mcp` | Serveur Model Context Protocol via Streamable HTTP, lorsque `OS_MCP_SERVER_ENABLED=true` |
 | `/api/v1/health` | Sonde de vivacité/disponibilité (sans authentification) |
 
 Le préfixe est `/api/v1` par défaut (le `basePath` de l'API `/api` plus la
@@ -51,20 +53,34 @@ valeur de la clé elle-même est stockée hachée — seuls le `prefix` et les
 métadonnées restent interrogeables, de sorte qu'une clé divulguée ne peut
 pas être reconstituée à partir de la base de données.
 
-Pour émettre une clé :
+Émettez une clé de deux façons :
 
-1. Connectez-vous à **Console → API Keys** en tant qu'administrateur.
-2. Choisissez l'utilisateur propriétaire (l'appel API hérite des
-   permissions et de l'accès aux enregistrements de cet utilisateur).
-3. Définissez éventuellement une date d'expiration.
-4. Copiez le secret affiché **une seule fois** — il n'est plus affiché par
-   la suite.
+- **Console** — connectez-vous à **Console → API Keys** en tant
+  qu'administrateur, choisissez l'utilisateur propriétaire, définissez
+  éventuellement une date d'expiration et copiez le secret affiché **une seule
+  fois**.
+- **Endpoint en libre-service** — `POST /api/v1/keys` génère une clé pour
+  l'appelant authentifié et renvoie le secret brut exactement une fois. La clé
+  est rattachée au propre utilisateur de l'appelant et ne peut donc pas servir
+  à usurper une autre identité :
 
-Utilisez la clé comme jeton bearer :
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+Passez la clé sur les requêtes suivantes comme jeton bearer, comme en-tête
+`x-api-key` ou comme `Authorization: ApiKey`. Les API REST de données et de
+métadonnées l'authentifient via le même vérificateur que MCP, sous les
+permissions et la sécurité au niveau des enregistrements du propriétaire de la
+clé :
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 Pour révoquer une clé, exécutez l'action `revoke_api_key` sur

--- a/content/docs/configure/api-access.ja.mdx
+++ b/content/docs/configure/api-access.ja.mdx
@@ -24,6 +24,8 @@ https://<project-domain>/api/v1
 | `/api/v1/actions/<object>/<action>` | 宣言的アクションの呼び出し（POST） |
 | `/api/v1/auth/*` | 認証（サインイン、セッション、OAuth、OIDC） |
 | `/api/v1/meta/*` | 有効化されている場合のメタデータ API（オブジェクト、フィールド、ビュー） |
+| `/api/v1/keys` | 呼び出しユーザー向けに一度だけ表示される `sys_api_key` を発行（POST） |
+| `/api/v1/mcp` | `OS_MCP_SERVER_ENABLED=true` のとき、Streamable HTTP 経由の Model Context Protocol サーバー |
 | `/api/v1/health` | 死活／準備状態のプローブ（認証不要） |
 
 プレフィックスのデフォルトは `/api/v1`（API の `basePath` である `/api` と
@@ -48,19 +50,32 @@ API キーはファーストクラスの `sys_api_key` レコードです。キ�
 ハッシュ化して保存され、クエリ可能なのは `prefix` とメタデータのみです。
 そのため、漏洩したキーをデータベースから復元することはできません。
 
-キーを発行するには:
+キーは次の 2 つの方法で発行できます:
 
-1. 管理者として **Console → API Keys** にサインインします。
-2. 所有ユーザーを選択します（API 呼び出しはそのユーザーの権限と
-   レコードアクセスを継承します）。
-3. 必要に応じて有効期限を設定します。
-4. 表示されたシークレットを**一度だけ**コピーします。再表示はされません。
+- **Console** — 管理者として **Console → API Keys** にサインインし、所有
+  ユーザーを選択し、必要に応じて有効期限を設定して、表示されたシークレットを
+  **一度だけ**コピーします。
+- **セルフサービスエンドポイント** — `POST /api/v1/keys` は認証済みの呼び出し元
+  に対してキーを発行し、生のシークレットをちょうど一度だけ返します。キーは
+  呼び出し元自身のユーザーに固定されるため、別の ID へのなりすましには使用
+  できません:
 
-キーは bearer トークンとして使用します:
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+以降のリクエストでは、キーを bearer トークン、`x-api-key` ヘッダー、または
+`Authorization: ApiKey` として渡します。REST のデータ／メタデータ API はいずれも
+MCP と同じ検証器で認証し、キー所有者の権限とレコードレベルセキュリティの下で
+実行されます:
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 キーを失効させるには、対応する `sys_api_key` レコードに対して

--- a/content/docs/configure/api-access.ko.mdx
+++ b/content/docs/configure/api-access.ko.mdx
@@ -24,6 +24,8 @@ https://<project-domain>/api/v1
 | `/api/v1/actions/<object>/<action>` | 선언적 액션 호출 (POST) |
 | `/api/v1/auth/*` | 인증 (로그인, 세션, OAuth, OIDC) |
 | `/api/v1/meta/*` | 활성화된 경우 메타데이터 API (오브젝트, 필드, 뷰) |
+| `/api/v1/keys` | 호출 사용자를 위해 한 번만 표시되는 `sys_api_key` 발급 (POST) |
+| `/api/v1/mcp` | `OS_MCP_SERVER_ENABLED=true`일 때 Streamable HTTP를 통한 Model Context Protocol 서버 |
 | `/api/v1/health` | 활성/준비 상태 프로브 (인증 없음) |
 
 접두사는 기본적으로 `/api/v1`(API `basePath`인 `/api`에 `version`인 `v1`을
@@ -48,19 +50,30 @@ API 키는 일급 `sys_api_key` 레코드입니다. 키 값 자체는 해시되�
 저장되며 `prefix`와 메타데이터만 쿼리할 수 있으므로, 유출된 키를
 데이터베이스에서 재구성할 수 없습니다.
 
-키를 발급하려면:
+키는 두 가지 방법으로 발급할 수 있습니다:
 
-1. 관리자 권한으로 **Console → API Keys**에 로그인합니다.
-2. 소유 사용자를 선택합니다(API 호출은 해당 사용자의 권한 및 레코드
-   액세스를 상속합니다).
-3. 선택적으로 만료일을 설정합니다.
-4. 표시된 비밀 키를 **한 번** 복사합니다 — 다시 표시되지 않습니다.
+- **Console** — 관리자 권한으로 **Console → API Keys**에 로그인하고, 소유
+  사용자를 선택하고, 선택적으로 만료일을 설정한 다음, 표시된 비밀 키를 **한 번**
+  복사합니다.
+- **셀프 서비스 엔드포인트** — `POST /api/v1/keys`는 인증된 호출자를 위해 키를
+  발급하고 원본 비밀 키를 정확히 한 번 반환합니다. 키는 호출자 본인의 사용자에
+  고정되므로 다른 ID를 사칭하는 데 사용할 수 없습니다:
 
-키를 bearer 토큰으로 사용합니다:
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+이후 요청에서는 키를 bearer 토큰, `x-api-key` 헤더 또는 `Authorization: ApiKey`로
+전달합니다. REST 데이터 및 메타데이터 API는 모두 MCP와 동일한 검증기로 이를
+인증하며, 키 소유자의 권한과 레코드 수준 보안 아래에서 실행됩니다:
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 키를 취소하려면 해당 `sys_api_key` 레코드에서 `revoke_api_key` 액션을

--- a/content/docs/configure/api-access.mdx
+++ b/content/docs/configure/api-access.mdx
@@ -24,6 +24,8 @@ Notable surfaces:
 | `/api/v1/actions/<object>/<action>` | Invoke a declarative action (POST) |
 | `/api/v1/auth/*` | Authentication (sign-in, sessions, OAuth, OIDC) |
 | `/api/v1/meta/*` | Metadata APIs (objects, fields, views) when enabled |
+| `/api/v1/keys` | Mint a show-once `sys_api_key` for the calling user (POST) |
+| `/api/v1/mcp` | Model Context Protocol server over Streamable HTTP, when `OS_MCP_SERVER_ENABLED=true` |
 | `/api/v1/health` | Liveness/readiness probe (no auth) |
 
 The prefix defaults to `/api/v1` (the API `basePath` of `/api` plus the
@@ -49,19 +51,32 @@ API keys are first-class `sys_api_key` records. The key value itself is
 stored hashed — only the `prefix` and metadata remain queryable, so a
 leaked key cannot be reconstructed from the database.
 
-To issue a key:
+Issue a key in either of two ways:
 
-1. Sign in to **Console → API Keys** as an administrator.
-2. Choose the owning user (the API call inherits that user's
-   permissions and record access).
-3. Optionally set an expiration date.
-4. Copy the displayed secret **once** — it is not shown again.
+- **Console** — sign in to **Console → API Keys** as an administrator,
+  choose the owning user, optionally set an expiration date, and copy the
+  displayed secret **once**.
+- **Self-serve endpoint** — `POST /api/v1/keys` mints a key for the
+  authenticated caller and returns the raw secret exactly once. The key is
+  pinned to the caller's own user, so it cannot be used to impersonate
+  another identity:
 
-Use the key as a bearer token:
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+Pass the key on subsequent requests as a bearer token, an `x-api-key`
+header, or `Authorization: ApiKey`. The REST data and metadata APIs all
+authenticate it through the same verifier as MCP, under the key owner's
+permissions and record-level security:
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 To revoke a key, run the `revoke_api_key` action on the corresponding

--- a/content/docs/configure/api-access.zh-Hans.mdx
+++ b/content/docs/configure/api-access.zh-Hans.mdx
@@ -22,6 +22,8 @@ https://<project-domain>/api/v1
 | `/api/v1/actions/<object>/<action>` | 调用声明式 action（POST） |
 | `/api/v1/auth/*` | 身份验证（登录、会话、OAuth、OIDC） |
 | `/api/v1/meta/*` | 元数据 API（对象、字段、视图），在启用时可用 |
+| `/api/v1/keys` | 为当前调用用户生成只显示一次的 `sys_api_key`（POST） |
+| `/api/v1/mcp` | 当 `OS_MCP_SERVER_ENABLED=true` 时，通过 Streamable HTTP 提供的 Model Context Protocol 服务器 |
 | `/api/v1/health` | 存活/就绪探针（无需身份验证） |
 
 前缀默认为 `/api/v1`（即 API 的 `basePath` `/api` 加上 `version` `v1`），并且可在 ObjectOS stack 上配置。
@@ -42,18 +44,28 @@ https://<project-domain>/api/v1
 
 API 密钥是一等公民 `sys_api_key` 记录。密钥值本身以哈希形式存储——只有 `prefix` 和元数据保持可查询，因此即便密钥泄露也无法从数据库中还原。
 
-签发一个密钥：
+签发密钥有两种方式：
 
-1. 以管理员身份登录 **Console → API Keys**。
-2. 选择所属用户（API 调用会继承该用户的权限和记录访问）。
-3. 可选地设置过期日期。
-4. **仅这一次**复制显示出的密钥——之后不会再显示。
+- **Console**——以管理员身份登录 **Console → API Keys**，选择所属用户，
+  可选地设置过期日期，并**仅这一次**复制显示出的密钥。
+- **自助端点**——`POST /api/v1/keys` 为已认证的调用方生成密钥，并只返回一次
+  原始密钥。该密钥绑定到调用方自身的用户，因此无法用于冒充其他身份：
 
-将密钥作为 bearer 令牌使用：
+  ```bash
+  curl -X POST https://app.example.com/api/v1/keys \
+    -H "Authorization: Bearer <session-or-access-token>" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "etl-pipeline"}'
+  # → { "id": "...", "name": "etl-pipeline", "prefix": "os_pk_…", "key": "os_pk_live_…" }
+  ```
+
+在后续请求中，可将密钥作为 bearer 令牌、`x-api-key` 请求头或
+`Authorization: ApiKey` 传递。REST 数据与元数据 API 都通过与 MCP 相同的校验器
+对其认证，并以密钥所有者的权限与记录级安全运行：
 
 ```bash
 curl https://app.example.com/api/v1/data/account \
-  -H "Authorization: Bearer os_pk_live_…"
+  -H "x-api-key: os_pk_live_…"
 ```
 
 要撤销某个密钥，请在对应的 `sys_api_key` 记录上运行 `revoke_api_key` action（Console UI 中也提供）。撤销会在下一次请求时立即生效。

--- a/content/docs/reference/environment-variables.de.mdx
+++ b/content/docs/reference/environment-variables.de.mdx
@@ -24,16 +24,19 @@ Verwenden Sie Systemeinstellungen für anwendungsbezogene Konfiguration, die von
 
 | Variable | Erforderlich | Beschreibung |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | Dateimodus | Pfad zu einer lokal kompilierten `objectstack.json`. Wird vom ObjectOS-App-Wrapper gelesen und als `fileConfig.artifactPath` weitergeleitet. |
-| `OS_ARTIFACT_PATH` | Alternative | Framework-Name für denselben Pfad oder eine `http(s)://`-URL. Wird direkt von `@objectstack/runtime` berücksichtigt (CLI `dev`/`start`, Standalone-Modus). |
-| `OS_PROJECT_ID` | Optional | Veralteter Alias für `OS_ENVIRONMENT_ID`, der vom ObjectOS-Wrapper aus Gründen der Abwärtskompatibilität akzeptiert wird. Bevorzugen Sie `OS_ENVIRONMENT_ID` in neuen Deployments. |
-| `OS_ENVIRONMENT_ID` | Optional | Umgebungs-ID für den Standalone-/dateibasierten Modus (Standard `proj_local`). Wird auch zur Ableitung des projektspezifischen Auth-Geheimnisses verwendet. Der ObjectOS-Wrapper akzeptiert außerdem den veralteten Alias `OS_PROJECT_ID`. |
+| `OS_ARTIFACT_FILE` | Dateimodus | Pfad oder `http(s)://`-URL zu einer kompilierten `objectstack.json`. Wird von der ObjectOS-Konfiguration gelesen und als `artifactPath` an `createStandaloneStack` übergeben. Für cloud-verbundene Deployments auf eine veröffentlichte Artifact-URL zeigen lassen. |
+| `OS_ARTIFACT_PATH` | Alternative | Framework-Name für denselben Pfad oder dieselbe URL, direkt von `@objectstack/runtime` berücksichtigt (CLI `dev`/`start`). Standard: `<cwd>/dist/objectstack.json`. |
+| `OS_PROJECT_ID` | Optional | Veralteter Alias für `OS_ENVIRONMENT_ID`, der von der ObjectOS-Konfiguration aus Gründen der Abwärtskompatibilität akzeptiert wird. Bevorzugen Sie `OS_ENVIRONMENT_ID` in neuen Deployments. |
+| `OS_ENVIRONMENT_ID` | Optional | Umgebungs-ID für den Standalone-Stack (Standard `proj_local`). Wird auch zur Ableitung des projektspezifischen Auth-Geheimnisses verwendet. Die ObjectOS-Konfiguration akzeptiert außerdem den veralteten Alias `OS_PROJECT_ID`. |
 | `OS_ORGANIZATION_ID` | Optional | Standard-Organisations-ID für den dateibasierten Modus (Standard `org_local`). |
-| `OS_WATCH_ARTIFACT` | Nein | Auf `1` setzen, um das lokale Artefakt bei Änderungen neu zu laden. Nur in der Entwicklung verwenden. |
-| `OS_CLOUD_URL` | Cloud-Modus | Basis-URL der Steuerungsebene für die Hostnamenauflösung und den Artefaktabruf. Auf `off` oder `local` setzen, um cloud-verbundenes Verhalten abzuwählen. |
-| `OS_CLOUD_API_KEY` | Optional | Bearer-Token für den Zugriff auf die private Artefakt-API der Steuerungsebene. |
+| `OS_MCP_SERVER_ENABLED` | Nein | Auf `true` setzen, um den Model-Context-Protocol-Server über Streamable HTTP unter `/api/v1/mcp` bereitzustellen (8.0+). Standardmäßig aus — der Endpunkt gibt `404` zurück, bis er aktiviert ist, und erfordert dann einen authentifizierten Principal. |
+| `OS_CLOUD_URL` | Optional | Basis-URL der Steuerungsebene für den Marketplace-Proxy und die lokale Paketinstallation. Auf `off` oder `local` setzen, um Marketplace-Funktionen zu deaktivieren. Wird in der Standalone-Distribution nicht mehr für das Hostname-Routing des Host-Stacks verwendet. |
 | `OS_MULTI_ORG_ENABLED` | Nein | Auf `true` setzen, um Multi-Mandanten-Routing / Organisationswechsel zu aktivieren (Standard `false`). Veralteter Alias: `OS_MULTI_TENANT`. |
 | `OS_RUNTIME_PORT` | Nur Dev | Localhost-Port, der zum Aufbau von Plattform-SSO-Callback-URLs bei der Entwicklung auf `http://localhost:<port>` verwendet wird. |
+
+> **Artefakt-Hot-Reload.** Der Standalone-Stack lädt das lokale Artefakt außerhalb
+> der Produktion automatisch neu (gesteuert durch `NODE_ENV`); das explizite
+> `OS_WATCH_ARTIFACT=1`-Flag aus 7.x ist nicht mehr erforderlich.
 
 ## Cache
 

--- a/content/docs/reference/environment-variables.es.mdx
+++ b/content/docs/reference/environment-variables.es.mdx
@@ -24,16 +24,19 @@ Use la configuración del sistema para la configuración de la aplicación edita
 
 | Variable | Obligatoria | Descripción |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | Modo archivo | Ruta a un archivo `objectstack.json` compilado localmente. Leído por el envoltorio de la aplicación ObjectOS y reenviado como `fileConfig.artifactPath`. |
-| `OS_ARTIFACT_PATH` | Alternativa | Nombre a nivel de framework para la misma ruta o URL `http(s)://`. Reconocido directamente por `@objectstack/runtime` (CLI `dev`/`start`, modo independiente). |
-| `OS_PROJECT_ID` | Opcional | Alias heredado de `OS_ENVIRONMENT_ID`, aceptado por el envoltorio de ObjectOS por compatibilidad con versiones anteriores. Prefiera `OS_ENVIRONMENT_ID` en los nuevos despliegues. |
-| `OS_ENVIRONMENT_ID` | Opcional | Id de entorno para el modo independiente/respaldado por archivo (por defecto `proj_local`). También se usa para derivar el secreto de autenticación por proyecto. El envoltorio de ObjectOS también acepta el alias heredado `OS_PROJECT_ID`. |
+| `OS_ARTIFACT_FILE` | Modo archivo | Ruta o URL `http(s)://` a un `objectstack.json` compilado. Leído por la configuración de ObjectOS y pasado como `artifactPath` a `createStandaloneStack`. Apúntelo a una URL de artefacto publicada en la nube para despliegues conectados a la nube. |
+| `OS_ARTIFACT_PATH` | Alternativa | Nombre a nivel de framework para la misma ruta o URL, reconocido directamente por `@objectstack/runtime` (CLI `dev`/`start`). Por defecto `<cwd>/dist/objectstack.json`. |
+| `OS_PROJECT_ID` | Opcional | Alias heredado de `OS_ENVIRONMENT_ID`, aceptado por la configuración de ObjectOS por compatibilidad con versiones anteriores. Prefiera `OS_ENVIRONMENT_ID` en los nuevos despliegues. |
+| `OS_ENVIRONMENT_ID` | Opcional | Id de entorno para el stack independiente (por defecto `proj_local`). También se usa para derivar el secreto de autenticación por proyecto. La configuración de ObjectOS también acepta el alias heredado `OS_PROJECT_ID`. |
 | `OS_ORGANIZATION_ID` | Opcional | Id de organización por defecto para el modo respaldado por archivo (por defecto `org_local`). |
-| `OS_WATCH_ARTIFACT` | No | Establézcalo en `1` para recargar el artefacto local cuando cambie. Úselo solo en desarrollo. |
-| `OS_CLOUD_URL` | Modo nube | URL base del plano de control para la resolución de nombres de host y la obtención de artefactos. Establézcalo en `off` o `local` para excluirse del comportamiento conectado a la nube. |
-| `OS_CLOUD_API_KEY` | Opcional | Token portador para el acceso privado a la API de artefactos del plano de control. |
+| `OS_MCP_SERVER_ENABLED` | No | Establézcalo en `true` para exponer el servidor Model Context Protocol sobre Streamable HTTP en `/api/v1/mcp` (8.0+). Desactivado por defecto: el endpoint devuelve `404` hasta que se habilita y, una vez activo, requiere un principal autenticado. |
+| `OS_CLOUD_URL` | Opcional | URL base del plano de control para el proxy del marketplace y la instalación local de paquetes. Establézcalo en `off` o `local` para deshabilitar las funciones del marketplace. Ya no se usa para el enrutamiento por nombre de host del host-stack en la distribución independiente. |
 | `OS_MULTI_ORG_ENABLED` | No | Establézcalo en `true` para habilitar el enrutamiento multiinquilino / cambio de organización (por defecto `false`). Alias heredado: `OS_MULTI_TENANT`. |
 | `OS_RUNTIME_PORT` | Solo desarrollo | Puerto de localhost utilizado para construir las URL de callback de SSO de plataforma al desarrollar en `http://localhost:<port>`. |
+
+> **Recarga en caliente del artefacto.** El stack independiente recarga el artefacto
+> local automáticamente fuera de producción (controlado por `NODE_ENV`); el indicador
+> explícito `OS_WATCH_ARTIFACT=1` de 7.x ya no es necesario.
 
 ## Caché
 

--- a/content/docs/reference/environment-variables.fr.mdx
+++ b/content/docs/reference/environment-variables.fr.mdx
@@ -24,16 +24,19 @@ Utilisez les paramètres système pour la configuration applicative modifiable p
 
 | Variable | Requis | Description |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | Mode fichier | Chemin vers un `objectstack.json` compilé localement. Lu par le wrapper de l'application ObjectOS et transmis en tant que `fileConfig.artifactPath`. |
-| `OS_ARTIFACT_PATH` | Alternative | Nom au niveau du framework pour le même chemin ou une URL `http(s)://`. Pris en charge directement par `@objectstack/runtime` (CLI `dev`/`start`, mode autonome). |
-| `OS_PROJECT_ID` | Optionnel | Alias hérité pour `OS_ENVIRONMENT_ID`, accepté par le wrapper ObjectOS pour des raisons de rétrocompatibilité. Préférez `OS_ENVIRONMENT_ID` dans les nouveaux déploiements. |
-| `OS_ENVIRONMENT_ID` | Optionnel | Identifiant d'environnement pour le mode autonome/adossé à un fichier (par défaut `proj_local`). Également utilisé pour dériver le secret d'authentification par projet. Le wrapper ObjectOS accepte aussi l'alias hérité `OS_PROJECT_ID`. |
+| `OS_ARTIFACT_FILE` | Mode fichier | Chemin ou URL `http(s)://` vers un `objectstack.json` compilé. Lu par la configuration ObjectOS et transmis en tant que `artifactPath` à `createStandaloneStack`. Pointez-le vers une URL d'artefact publiée pour les déploiements connectés au cloud. |
+| `OS_ARTIFACT_PATH` | Alternative | Nom au niveau du framework pour le même chemin ou la même URL, pris en charge directement par `@objectstack/runtime` (CLI `dev`/`start`). Par défaut `<cwd>/dist/objectstack.json`. |
+| `OS_PROJECT_ID` | Optionnel | Alias hérité pour `OS_ENVIRONMENT_ID`, accepté par la configuration ObjectOS pour des raisons de rétrocompatibilité. Préférez `OS_ENVIRONMENT_ID` dans les nouveaux déploiements. |
+| `OS_ENVIRONMENT_ID` | Optionnel | Identifiant d'environnement pour le stack autonome (par défaut `proj_local`). Également utilisé pour dériver le secret d'authentification par projet. La configuration ObjectOS accepte aussi l'alias hérité `OS_PROJECT_ID`. |
 | `OS_ORGANIZATION_ID` | Optionnel | Identifiant d'organisation par défaut pour le mode adossé à un fichier (par défaut `org_local`). |
-| `OS_WATCH_ARTIFACT` | Non | Définissez-le à `1` pour recharger l'artefact local lorsqu'il change. À utiliser uniquement en développement. |
-| `OS_CLOUD_URL` | Mode cloud | URL de base du plan de contrôle pour la résolution des noms d'hôte et la récupération des artefacts. Définissez-le à `off` ou `local` pour désactiver le comportement connecté au cloud. |
-| `OS_CLOUD_API_KEY` | Optionnel | Jeton Bearer pour l'accès privé à l'API Artifact du plan de contrôle. |
+| `OS_MCP_SERVER_ENABLED` | Non | Définissez-le à `true` pour exposer le serveur Model Context Protocol via Streamable HTTP sur `/api/v1/mcp` (8.0+). Désactivé par défaut : l'endpoint renvoie `404` jusqu'à activation, puis requiert un principal authentifié. |
+| `OS_CLOUD_URL` | Optionnel | URL de base du plan de contrôle pour le proxy du marketplace et l'installation locale de paquets. Définissez-le à `off` ou `local` pour désactiver les fonctionnalités du marketplace. N'est plus utilisé pour le routage par nom d'hôte du host-stack dans la distribution autonome. |
 | `OS_MULTI_ORG_ENABLED` | Non | Définissez-le à `true` pour activer le routage multi-locataire / le changement d'organisation (par défaut `false`). Alias hérité : `OS_MULTI_TENANT`. |
 | `OS_RUNTIME_PORT` | Dev uniquement | Port localhost utilisé pour construire les URL de rappel SSO de la plateforme lors du développement sur `http://localhost:<port>`. |
+
+> **Rechargement à chaud de l'artefact.** Le stack autonome recharge automatiquement
+> l'artefact local hors production (piloté par `NODE_ENV`) ; le drapeau explicite
+> `OS_WATCH_ARTIFACT=1` de 7.x n'est plus requis.
 
 ## Cache
 

--- a/content/docs/reference/environment-variables.ja.mdx
+++ b/content/docs/reference/environment-variables.ja.mdx
@@ -24,16 +24,19 @@ description: ObjectOS ランタイムの環境変数リファレンス。
 
 | 変数 | 必須 | 説明 |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | ファイルモード | ローカルでコンパイルされた `objectstack.json` へのパス。ObjectOS アプリラッパーによって読み取られ、`fileConfig.artifactPath` として転送されます。 |
-| `OS_ARTIFACT_PATH` | 代替 | 同じパスまたは `http(s)://` URL に対するフレームワークレベルの名前。`@objectstack/runtime` によって直接処理されます（CLI `dev`/`start`、スタンドアロンモード）。 |
-| `OS_PROJECT_ID` | 任意 | `OS_ENVIRONMENT_ID` のレガシーエイリアスで、後方互換性のために ObjectOS ラッパーが受け付けます。新しいデプロイメントでは `OS_ENVIRONMENT_ID` を優先してください。 |
-| `OS_ENVIRONMENT_ID` | 任意 | スタンドアロン／ファイルバックモード用の環境 id（デフォルト `proj_local`）。プロジェクトごとの認証シークレットの導出にも使用されます。ObjectOS ラッパーはレガシーエイリアス `OS_PROJECT_ID` も受け付けます。 |
+| `OS_ARTIFACT_FILE` | ファイルモード | コンパイル済み `objectstack.json` へのパスまたは `http(s)://` URL。ObjectOS の設定によって読み取られ、`artifactPath` として `createStandaloneStack` に渡されます。クラウド接続デプロイでは公開済みのクラウド artifact URL を指定します。 |
+| `OS_ARTIFACT_PATH` | 代替 | 同じパスまたは URL に対するフレームワークレベルの名前。`@objectstack/runtime` によって直接処理されます（CLI `dev`/`start`）。デフォルトは `<cwd>/dist/objectstack.json`。 |
+| `OS_PROJECT_ID` | 任意 | `OS_ENVIRONMENT_ID` のレガシーエイリアスで、後方互換性のために ObjectOS の設定が受け付けます。新しいデプロイメントでは `OS_ENVIRONMENT_ID` を優先してください。 |
+| `OS_ENVIRONMENT_ID` | 任意 | standalone stack の環境 id（デフォルト `proj_local`）。プロジェクトごとの認証シークレットの導出にも使用されます。ObjectOS の設定はレガシーエイリアス `OS_PROJECT_ID` も受け付けます。 |
 | `OS_ORGANIZATION_ID` | 任意 | ファイルバックモードのデフォルト組織 id（デフォルト `org_local`）。 |
-| `OS_WATCH_ARTIFACT` | いいえ | `1` に設定すると、ローカルアーティファクトが変更されたときに再読み込みします。開発時のみ使用してください。 |
-| `OS_CLOUD_URL` | クラウドモード | ホスト名解決とアーティファクト取得のためのコントロールプレーンのベース URL。クラウド接続動作をオプトアウトするには `off` または `local` に設定します。 |
-| `OS_CLOUD_API_KEY` | 任意 | プライベートコントロールプレーンの Artifact API アクセス用のベアラートークン。 |
+| `OS_MCP_SERVER_ENABLED` | いいえ | `true` に設定すると、Model Context Protocol サーバーを Streamable HTTP 経由で `/api/v1/mcp` に公開します（8.0+）。デフォルトはオフ——有効化するまでエンドポイントは `404` を返し、有効化後は認証済みプリンシパルが必要です。 |
+| `OS_CLOUD_URL` | 任意 | marketplace プロキシとローカルパッケージインストールのためのコントロールプレーンのベース URL。`off` または `local` に設定すると marketplace 機能を無効化できます。standalone ディストリビューションでは host stack のホスト名ルーティングには使用されなくなりました。 |
 | `OS_MULTI_ORG_ENABLED` | いいえ | マルチテナントルーティング／組織切り替えを有効にするには `true` に設定します（デフォルト `false`）。レガシーエイリアス: `OS_MULTI_TENANT`。 |
 | `OS_RUNTIME_PORT` | 開発のみ | `http://localhost:<port>` で開発する際にプラットフォーム SSO のコールバック URL を構築するために使用するローカルホストポート。 |
+
+> **Artifact のホットリロード。** standalone stack は本番以外（`NODE_ENV` で制御）で
+> ローカル artifact を自動的に再読み込みします。7.x の明示的な
+> `OS_WATCH_ARTIFACT=1` フラグは不要になりました。
 
 ## キャッシュ
 

--- a/content/docs/reference/environment-variables.ko.mdx
+++ b/content/docs/reference/environment-variables.ko.mdx
@@ -24,16 +24,19 @@ description: ObjectOS 런타임 환경 변수 참조.
 
 | 변수 | 필수 | 설명 |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | 파일 모드 | 로컬에서 컴파일된 `objectstack.json`의 경로. ObjectOS 앱 래퍼가 읽어 `fileConfig.artifactPath`로 전달합니다. |
-| `OS_ARTIFACT_PATH` | 대안 | 동일한 경로 또는 `http(s)://` URL에 대한 프레임워크 수준의 이름. `@objectstack/runtime`이 직접 처리합니다(CLI `dev`/`start`, 독립 실행형 모드). |
-| `OS_PROJECT_ID` | 선택 | `OS_ENVIRONMENT_ID`의 레거시 별칭으로, 하위 호환성을 위해 ObjectOS 래퍼에서 허용됩니다. 새 배포에서는 `OS_ENVIRONMENT_ID`를 사용하는 것이 좋습니다. |
-| `OS_ENVIRONMENT_ID` | 선택 | 독립 실행형/파일 기반 모드의 환경 id(기본값 `proj_local`). 프로젝트별 인증 시크릿을 파생하는 데에도 사용됩니다. ObjectOS 래퍼는 레거시 별칭 `OS_PROJECT_ID`도 허용합니다. |
+| `OS_ARTIFACT_FILE` | 파일 모드 | 컴파일된 `objectstack.json`의 경로 또는 `http(s)://` URL. ObjectOS 구성이 읽어 `artifactPath`로 `createStandaloneStack`에 전달합니다. 클라우드 연결 배포에서는 게시된 클라우드 artifact URL을 가리키게 하세요. |
+| `OS_ARTIFACT_PATH` | 대안 | 동일한 경로 또는 URL에 대한 프레임워크 수준의 이름으로, `@objectstack/runtime`이 직접 처리합니다(CLI `dev`/`start`). 기본값 `<cwd>/dist/objectstack.json`. |
+| `OS_PROJECT_ID` | 선택 | `OS_ENVIRONMENT_ID`의 레거시 별칭으로, 하위 호환성을 위해 ObjectOS 구성에서 허용됩니다. 새 배포에서는 `OS_ENVIRONMENT_ID`를 사용하는 것이 좋습니다. |
+| `OS_ENVIRONMENT_ID` | 선택 | standalone stack의 환경 id(기본값 `proj_local`). 프로젝트별 인증 시크릿을 파생하는 데에도 사용됩니다. ObjectOS 구성은 레거시 별칭 `OS_PROJECT_ID`도 허용합니다. |
 | `OS_ORGANIZATION_ID` | 선택 | 파일 기반 모드의 기본 조직 id(기본값 `org_local`). |
-| `OS_WATCH_ARTIFACT` | 아니오 | 로컬 아티팩트가 변경될 때 다시 로드하려면 `1`로 설정합니다. 개발 환경에서만 사용하세요. |
-| `OS_CLOUD_URL` | 클라우드 모드 | 호스트명 확인 및 아티팩트 가져오기를 위한 컨트롤 플레인 기본 URL. 클라우드 연결 동작을 사용하지 않으려면 `off` 또는 `local`로 설정합니다. |
-| `OS_CLOUD_API_KEY` | 선택 | 비공개 컨트롤 플레인 Artifact API 접근을 위한 Bearer 토큰. |
+| `OS_MCP_SERVER_ENABLED` | 아니오 | `true`로 설정하면 Model Context Protocol 서버를 Streamable HTTP로 `/api/v1/mcp`에 노출합니다(8.0+). 기본값은 꺼짐 — 활성화하기 전에는 엔드포인트가 `404`를 반환하며, 활성화 후에는 인증된 주체가 필요합니다. |
+| `OS_CLOUD_URL` | 선택 | marketplace 프록시 및 로컬 패키지 설치를 위한 컨트롤 플레인 기본 URL. `off` 또는 `local`로 설정하면 marketplace 기능을 비활성화합니다. standalone 배포판에서는 더 이상 host stack의 호스트명 라우팅에 사용되지 않습니다. |
 | `OS_MULTI_ORG_ENABLED` | 아니오 | 멀티 테넌트 라우팅/조직 전환을 활성화하려면 `true`로 설정합니다(기본값 `false`). 레거시 별칭: `OS_MULTI_TENANT`. |
 | `OS_RUNTIME_PORT` | 개발 전용 | `http://localhost:<port>`에서 개발할 때 플랫폼 SSO 콜백 URL을 구성하는 데 사용되는 localhost 포트. |
+
+> **Artifact 핫 리로드.** standalone stack은 프로덕션이 아닌 환경에서(`NODE_ENV`로 제어)
+> 로컬 artifact를 자동으로 다시 로드합니다. 7.x의 명시적 `OS_WATCH_ARTIFACT=1`
+> 플래그는 더 이상 필요하지 않습니다.
 
 ## 캐시
 

--- a/content/docs/reference/environment-variables.mdx
+++ b/content/docs/reference/environment-variables.mdx
@@ -24,16 +24,19 @@ Use system settings for tenant/user-editable application configuration.
 
 | Variable | Required | Description |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | File mode | Path to a local compiled `objectstack.json`. Read by the ObjectOS app wrapper and forwarded as `fileConfig.artifactPath`. |
-| `OS_ARTIFACT_PATH` | Alternative | Framework-level name for the same path or `http(s)://` URL. Honoured by `@objectstack/runtime` directly (CLI `dev`/`start`, standalone mode). |
-| `OS_PROJECT_ID` | Optional | Legacy alias for `OS_ENVIRONMENT_ID`, accepted by the ObjectOS wrapper for backward compatibility. Prefer `OS_ENVIRONMENT_ID` in new deployments. |
-| `OS_ENVIRONMENT_ID` | Optional | Environment id for standalone/file-backed mode (default `proj_local`). Also used to derive the per-project auth secret. The ObjectOS wrapper also accepts the legacy alias `OS_PROJECT_ID`. |
+| `OS_ARTIFACT_FILE` | File mode | Path or `http(s)://` URL to a compiled `objectstack.json`. Read by the ObjectOS config and passed as `artifactPath` to `createStandaloneStack`. Point this at a published cloud artifact URL for cloud-connected deployments. |
+| `OS_ARTIFACT_PATH` | Alternative | Framework-level name for the same path or URL, honoured by `@objectstack/runtime` directly (CLI `dev`/`start`). Defaults to `<cwd>/dist/objectstack.json`. |
+| `OS_PROJECT_ID` | Optional | Legacy alias for `OS_ENVIRONMENT_ID`, accepted by the ObjectOS config for backward compatibility. Prefer `OS_ENVIRONMENT_ID` in new deployments. |
+| `OS_ENVIRONMENT_ID` | Optional | Environment id for the standalone stack (default `proj_local`). Also used to derive the per-project auth secret. The ObjectOS config also accepts the legacy alias `OS_PROJECT_ID`. |
 | `OS_ORGANIZATION_ID` | Optional | Default organization id for file-backed mode (default `org_local`). |
-| `OS_WATCH_ARTIFACT` | No | Set to `1` to reload the local artifact when it changes. Use only in development. |
-| `OS_CLOUD_URL` | Cloud mode | Control-plane base URL for hostname resolution and artifact fetch. Set to `off` or `local` to opt out of cloud-connected behaviour. |
-| `OS_CLOUD_API_KEY` | Optional | Bearer token for private control-plane Artifact API access. |
+| `OS_MCP_SERVER_ENABLED` | No | Set to `true` to expose the Model Context Protocol server over Streamable HTTP at `/api/v1/mcp` (8.0+). Off by default — the endpoint returns `404` until enabled, and requires an authenticated principal once on. |
+| `OS_CLOUD_URL` | Optional | Control-plane base URL for the marketplace proxy and local package install. Set to `off` or `local` to disable marketplace features. No longer used for host-stack hostname routing in the standalone distribution. |
 | `OS_MULTI_ORG_ENABLED` | No | Set to `true` to enable multi-tenant routing / organization switching (default `false`). Legacy alias: `OS_MULTI_TENANT`. |
 | `OS_RUNTIME_PORT` | Dev only | Localhost port used to build platform-SSO callback URLs when developing on `http://localhost:<port>`. |
+
+> **Artifact hot-reload.** The standalone stack reloads the local artifact
+> automatically outside production (gated by `NODE_ENV`); the explicit
+> `OS_WATCH_ARTIFACT=1` flag from 7.x is no longer required.
 
 ## Cache
 

--- a/content/docs/reference/environment-variables.zh-Hans.mdx
+++ b/content/docs/reference/environment-variables.zh-Hans.mdx
@@ -21,16 +21,18 @@ description: ObjectOS 运行时环境变量参考。
 
 | 变量 | 是否必需 | 说明 |
 |---|---:|---|
-| `OS_ARTIFACT_FILE` | 文件模式 | 本地已编译 `objectstack.json` 的路径。由 ObjectOS 应用 wrapper 读取并转发为 `fileConfig.artifactPath`。 |
-| `OS_ARTIFACT_PATH` | 备选 | 同一路径或 `http(s)://` URL 的框架级名称。`@objectstack/runtime` 直接识别（CLI `dev`/`start`、独立模式）。 |
-| `OS_PROJECT_ID` | 可选 | `OS_ENVIRONMENT_ID` 的旧别名,ObjectOS wrapper 为向后兼容接受。新部署中优先使用 `OS_ENVIRONMENT_ID`。 |
-| `OS_ENVIRONMENT_ID` | 可选 | 独立/文件支持模式下的环境 id（默认 `proj_local`）。也用于派生项目级 auth 密钥。ObjectOS wrapper 也接受旧别名 `OS_PROJECT_ID`。 |
+| `OS_ARTIFACT_FILE` | 文件模式 | 已编译 `objectstack.json` 的路径或 `http(s)://` URL。由 ObjectOS 配置读取,并作为 `artifactPath` 传给 `createStandaloneStack`。云连接部署可将其指向已发布的云端 artifact URL。 |
+| `OS_ARTIFACT_PATH` | 备选 | 同一路径或 URL 的框架级名称,由 `@objectstack/runtime` 直接识别（CLI `dev`/`start`）。默认 `<cwd>/dist/objectstack.json`。 |
+| `OS_PROJECT_ID` | 可选 | `OS_ENVIRONMENT_ID` 的旧别名,ObjectOS 配置为向后兼容接受。新部署中优先使用 `OS_ENVIRONMENT_ID`。 |
+| `OS_ENVIRONMENT_ID` | 可选 | standalone stack 的环境 id（默认 `proj_local`）。也用于派生项目级 auth 密钥。ObjectOS 配置也接受旧别名 `OS_PROJECT_ID`。 |
 | `OS_ORGANIZATION_ID` | 可选 | 文件支持模式下的默认组织 id（默认 `org_local`）。 |
-| `OS_WATCH_ARTIFACT` | 否 | 设为 `1` 时在本地 artifact 变更时重载。仅用于开发。 |
-| `OS_CLOUD_URL` | Cloud 模式 | 用于主机名解析和 artifact 拉取的控制平面基础 URL。设为 `off` 或 `local` 退出云端联动行为。 |
-| `OS_CLOUD_API_KEY` | 可选 | 用于私有控制平面 Artifact API 访问的 Bearer token。 |
+| `OS_MCP_SERVER_ENABLED` | 否 | 设为 `true` 以通过 Streamable HTTP 在 `/api/v1/mcp` 暴露 Model Context Protocol 服务器（8.0+）。默认关闭——开启前端点返回 `404`,开启后需要已认证的主体。 |
+| `OS_CLOUD_URL` | 可选 | marketplace 代理与本地 package 安装的控制平面基础 URL。设为 `off` 或 `local` 可禁用 marketplace 功能。在 standalone 分发中不再用于 host stack 的主机名路由。 |
 | `OS_MULTI_ORG_ENABLED` | 否 | 设为 `true` 以启用多租户路由/组织切换（默认 `false`）。旧别名:`OS_MULTI_TENANT`。 |
 | `OS_RUNTIME_PORT` | 仅开发 | 当在 `http://localhost:<port>` 开发时,用于构建平台 SSO 回调 URL 的本地端口。 |
+
+> **Artifact 热重载。** standalone stack 在非生产环境下（由 `NODE_ENV` 控制）
+> 自动重载本地 artifact;不再需要 7.x 的显式 `OS_WATCH_ARTIFACT=1` 标志。
 
 ## 缓存
 

--- a/content/docs/resources/changelog.de.mdx
+++ b/content/docs/resources/changelog.de.mdx
@@ -51,30 +51,44 @@ Abonnieren Sie Releases auf GitHub, um benachrichtigt zu werden.
 
 ## Aktuelle Highlights
 
-### 4.0.x — aktueller Release-Zug
+### 8.0.x — aktueller Release-Zug
 
-- **42 Pakete** auf npm unter `@objectstack/*` veröffentlicht.
-- Console erhielt vollständige Konfigurationsseiten für Einstellungen (AI, Storage,
-  Knowledge).
-- Embedder-Dienst: 10 Anbieter (`openai`, `azure`, 阿里通义,
-  智谱, 硅基流动, 火山, MiniMax, Ollama, benutzerdefiniert).
-- Live-Einstellungen → Runtime-Bridge — wechseln Sie den Anbieter in Console, mit
-  In-Process-Austausch ohne Neustart.
+ObjectOS One und der gebündelte Server laufen jetzt auf `@objectstack` **8.0.1**.
 
-### 5.0 (kommend) — Umbenennung `project` → `environment`
+- **MCP über Streamable HTTP** — jede Bereitstellung kann als netzwerkerreichbarer
+  [Model-Context-Protocol](https://modelcontextprotocol.io)-Server fungieren.
+  Aktivierung über `OS_MCP_SERVER_ENABLED=true`; der Endpunkt liegt unter
+  `/api/v1/mcp` mit fail-closed-Authentifizierung (anonyme Anfragen werden
+  abgelehnt). Das Plugin wurde von `@objectstack/plugin-mcp-server` zu
+  `@objectstack/mcp` umbenannt.
+- **Self-Service-API-Keys** — `POST /api/v1/keys` erzeugt einen nur einmal
+  angezeigten `sys_api_key`. Die REST-Daten- und Metadaten-APIs (`/api/v1/data`,
+  `/api/v1/meta`) authentifizieren API-Keys jetzt über denselben Verifier wie MCP
+  und laufen mit den Berechtigungen und der Datensatz-Sicherheit des
+  Key-Inhabers.
+- **Feldbezogene Bedingungsregeln** — `visibleWhen`, `readonlyWhen` und
+  `requiredWhen` werden serverseitig von ObjectQL durchgesetzt, nicht nur in der
+  Formular-UI.
+- **Wiederverwendbarer RLS-Lesefilter** — `security.getReadFilter(object, context)`
+  stellt den Datensatzzugriffs-Lesebereich bereit; Analytics-Datasets, Dashboards
+  und Berichte greifen darauf zu und schließen fail-closed, wenn der Bereich nicht
+  sicher angewendet werden kann.
+- **Standalone-Host-Stack** — die Runtime liefert einen single-tenant
+  `createStandaloneStack`-Host; der cloud-verbundene, hostname-geroutete
+  `createObjectOSStack`-Wrapper aus 7.x wurde entfernt. Eine Cloud-Bereitstellung
+  verweist `OS_ARTIFACT_FILE` jetzt auf eine veröffentlichte Artifact-URL.
 
-Das Runtime-Konzept, das früher *Project* hieß, wird durchgängig in *Environment*
-umbenannt. Betroffen sind:
+### 5.0 — Umbenennung `project` → `environment` (veröffentlicht)
+
+Das Runtime-Konzept, das früher *Project* hieß, wurde durchgängig in *Environment*
+umbenannt. Betroffen waren:
 
 - CLI-Flags: `--environment` / `-e`
 - HTTP-Pfade: `/api/v1/environments/:environmentId/...`
 - Header: `X-Environment-Id`
-- Umgebungsvariablen: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` bleibt als Alias in 4.x erhalten, entfernt in 5.0)
+- Umgebungsvariablen: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` bleibt als veralteter Alias erhalten)
 - DB-Spalten: `environment_id`
 - JSON-Schemas: `EnvironmentArtifact`
-
-Keine Aliase oder Deprecation-Shims. Planen Sie das Upgrade sorgfältig — siehe den
-5.0-Migrationsleitfaden zum Release.
 
 ## Upgrade
 

--- a/content/docs/resources/changelog.es.mdx
+++ b/content/docs/resources/changelog.es.mdx
@@ -51,30 +51,44 @@ Suscríbete a las versiones en GitHub para recibir notificaciones.
 
 ## Aspectos destacados recientes
 
-### 4.0.x — tren de versiones actual
+### 8.0.x — tren de versiones actual
 
-- **42 paquetes** publicados en npm bajo `@objectstack/*`.
-- Console incorporó páginas completas de configuración (AI, Storage,
-  Knowledge).
-- Servicio de incrustación: 10 proveedores (`openai`, `azure`, 阿里通义,
-  智谱, 硅基流动, 火山, MiniMax, Ollama, personalizado).
-- Puente de configuración en vivo → runtime: cambia el proveedor en Console,
-  con intercambio en proceso sin reinicio.
+ObjectOS One y el servidor incluido ahora se ejecutan sobre `@objectstack` **8.0.1**.
 
-### 5.0 (próximamente) — cambio de nombre de `project` a `environment`
+- **MCP sobre Streamable HTTP**: cada despliegue puede actuar como un servidor
+  [Model Context Protocol](https://modelcontextprotocol.io) accesible por red.
+  Actívalo con `OS_MCP_SERVER_ENABLED=true`; el endpoint se sirve en `/api/v1/mcp`
+  con autenticación fail-closed (las solicitudes anónimas se rechazan). El plugin
+  pasó a llamarse de `@objectstack/plugin-mcp-server` a `@objectstack/mcp`.
+- **Claves de API autoservicio**: `POST /api/v1/keys` genera una `sys_api_key`
+  que se muestra una sola vez. Las API REST de datos y metadatos (`/api/v1/data`,
+  `/api/v1/meta`) ahora autentican las claves de API con el mismo verificador que
+  MCP, ejecutándose bajo los permisos y la seguridad a nivel de registro del
+  propietario de la clave.
+- **Reglas condicionales por campo**: `visibleWhen`, `readonlyWhen` y
+  `requiredWhen` se aplican en el servidor mediante ObjectQL, no solo en la UI del
+  formulario.
+- **Filtro de lectura RLS reutilizable**: `security.getReadFilter(object, context)`
+  expone el alcance de lectura del acceso a registros; los datasets de analítica,
+  los paneles y los informes se conectan a él y fallan en cerrado cuando el alcance
+  no puede aplicarse de forma segura.
+- **Stack de host autónomo**: el runtime incluye un host
+  `createStandaloneStack` de inquilino único; se eliminó el wrapper
+  `createObjectOSStack` de 7.x, conectado a la nube y enrutado por hostname. Un
+  despliegue en la nube ahora apunta `OS_ARTIFACT_FILE` a una URL de artefacto
+  publicada.
 
-El concepto de runtime antes llamado *Project* pasa a llamarse *Environment*
-en todo el sistema. Afecta a:
+### 5.0 — cambio de nombre de `project` a `environment` (publicado)
+
+El concepto de runtime antes llamado *Project* pasó a llamarse *Environment*
+en todo el sistema. Afectó a:
 
 - Indicadores de CLI: `--environment` / `-e`
 - Rutas HTTP: `/api/v1/environments/:environmentId/...`
 - Cabeceras: `X-Environment-Id`
-- Variables de entorno: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` se mantiene como alias en 4.x, eliminado en 5.0)
+- Variables de entorno: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` se mantiene como alias obsoleto)
 - Columnas de BD: `environment_id`
 - Esquemas JSON: `EnvironmentArtifact`
-
-Sin alias ni adaptadores de compatibilidad. Planifica la actualización con
-cuidado: consulta la guía de migración a 5.0 en el lanzamiento.
 
 ## Actualización
 

--- a/content/docs/resources/changelog.fr.mdx
+++ b/content/docs/resources/changelog.fr.mdx
@@ -52,30 +52,44 @@ Abonnez-vous aux versions sur GitHub pour être notifié.
 
 ## Points marquants récents
 
-### 4.0.x — train de versions actuel
+### 8.0.x — train de versions actuel
 
-- **42 paquets** publiés sur npm sous `@objectstack/*`.
-- La Console a obtenu des pages de paramètres de Configuration complètes
-  (AI, Storage, Knowledge).
-- Service d'embedder : 10 fournisseurs (`openai`, `azure`, 阿里通义,
-  智谱, 硅基流动, 火山, MiniMax, Ollama, personnalisé).
-- Pont paramètres en direct → runtime — changez de fournisseur dans la
-  Console, échange en cours de processus sans redémarrage.
+ObjectOS One et le serveur intégré tournent désormais sur `@objectstack` **8.0.1**.
 
-### 5.0 (à venir) — renommage de `project` → `environment`
+- **MCP via Streamable HTTP** — chaque déploiement peut agir comme un serveur
+  [Model Context Protocol](https://modelcontextprotocol.io) accessible via le
+  réseau. Activez-le avec `OS_MCP_SERVER_ENABLED=true` ; l'endpoint est servi sur
+  `/api/v1/mcp` avec une authentification fail-closed (les requêtes anonymes sont
+  rejetées). Le plugin a été renommé de `@objectstack/plugin-mcp-server` en
+  `@objectstack/mcp`.
+- **Clés d'API en libre-service** — `POST /api/v1/keys` génère une `sys_api_key`
+  affichée une seule fois. Les API REST de données et de métadonnées
+  (`/api/v1/data`, `/api/v1/meta`) authentifient désormais les clés d'API via le
+  même vérificateur que MCP, en s'exécutant sous les permissions et la sécurité au
+  niveau des enregistrements du propriétaire de la clé.
+- **Règles conditionnelles au niveau des champs** — `visibleWhen`, `readonlyWhen`
+  et `requiredWhen` sont appliquées côté serveur par ObjectQL, et pas seulement
+  dans l'UI du formulaire.
+- **Filtre de lecture RLS réutilisable** — `security.getReadFilter(object, context)`
+  expose la portée de lecture de l'accès aux enregistrements ; les datasets
+  d'analytique, les tableaux de bord et les rapports s'y connectent et échouent en
+  mode fermé lorsque la portée ne peut pas être appliquée en toute sécurité.
+- **Stack hôte autonome** — le runtime fournit un hôte `createStandaloneStack`
+  mono-locataire ; le wrapper `createObjectOSStack` de 7.x, connecté au cloud et
+  routé par hostname, a été supprimé. Un déploiement cloud pointe désormais
+  `OS_ARTIFACT_FILE` vers une URL d'artefact publiée.
 
-Le concept de runtime autrefois appelé *Project* est renommé en
-*Environment* partout. Cela affecte :
+### 5.0 — renommage de `project` → `environment` (publié)
+
+Le concept de runtime autrefois appelé *Project* a été renommé en
+*Environment* partout. Cela a affecté :
 
 - Drapeaux CLI : `--environment` / `-e`
 - Chemins HTTP : `/api/v1/environments/:environmentId/...`
 - En-têtes : `X-Environment-Id`
-- Variables d'environnement : `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` conservé comme alias en 4.x, supprimé en 5.0)
+- Variables d'environnement : `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` conservé comme alias déprécié)
 - Colonnes de base de données : `environment_id`
 - Schémas JSON : `EnvironmentArtifact`
-
-Aucun alias ni adaptateur de dépréciation. Prévoyez une mise à niveau
-soigneuse — voir le guide de migration 5.0 à sa sortie.
 
 ## Mise à niveau
 

--- a/content/docs/resources/changelog.ja.mdx
+++ b/content/docs/resources/changelog.ja.mdx
@@ -49,25 +49,39 @@ GitHub でリリースを購読すると、通知を受け取れます。
 
 ## 最近のハイライト
 
-### 4.0.x — 現行リリーストレイン
+### 8.0.x — 現行リリーストレイン
 
-- **42 個のパッケージ** を `@objectstack/*` 配下で npm に公開。
-- Console に完全な Configuration 設定ページ(AI、Storage、Knowledge)を追加。
-- Embedder サービス: 10 のプロバイダー(`openai`、`azure`、阿里通義、智谱、硅基流动、火山、MiniMax、Ollama、custom)。
-- ライブ設定 → ランタイムのブリッジ — Console でプロバイダーを変更すると、再起動なしでプロセス内で切り替わります。
+ObjectOS One とバンドル版サーバーは `@objectstack` **8.0.1** 上で動作します。
 
-### 5.0(予定) — `project` → `environment` への名称変更
+- **MCP over Streamable HTTP** — すべてのデプロイがネットワーク到達可能な
+  [Model Context Protocol](https://modelcontextprotocol.io) サーバーとして機能できます。
+  `OS_MCP_SERVER_ENABLED=true` で有効化すると、エンドポイントは `/api/v1/mcp` で提供され、
+  fail-closed 認証(匿名リクエストは拒否)が適用されます。プラグインは
+  `@objectstack/plugin-mcp-server` から `@objectstack/mcp` に名称変更されました。
+- **セルフサービス API キー** — `POST /api/v1/keys` は一度だけ表示される
+  `sys_api_key` を発行します。REST のデータ/メタデータ API(`/api/v1/data`、
+  `/api/v1/meta`)は MCP と同じ検証器で API キーを認証し、キー所有者の権限と
+  レコードレベルセキュリティの下で実行されます。
+- **フィールド単位の条件ルール** — `visibleWhen`、`readonlyWhen`、`requiredWhen` は
+  フォーム UI だけでなく、ObjectQL によってサーバー側で強制されます。
+- **再利用可能な RLS 読み取りフィルター** — `security.getReadFilter(object, context)` が
+  レコードアクセスの読み取り範囲を公開します。分析データセット、ダッシュボード、レポートは
+  これにブリッジし、範囲を安全に適用できない場合は fail closed になります。
+- **スタンドアロン host スタック** — ランタイムはシングルテナントの
+  `createStandaloneStack` host を提供します。7.x のクラウド接続・ホスト名ルーティング型の
+  `createObjectOSStack` ラッパーは削除されました。クラウドデプロイでは
+  `OS_ARTIFACT_FILE` を公開済みの artifact URL に向けます。
 
-これまで *Project* と呼ばれていたランタイムの概念が、全体を通して *Environment* に名称変更されます。影響範囲:
+### 5.0 — `project` → `environment` への名称変更(リリース済み)
+
+これまで *Project* と呼ばれていたランタイムの概念が、全体を通して *Environment* に名称変更されました。影響範囲:
 
 - CLI フラグ: `--environment` / `-e`
 - HTTP パス: `/api/v1/environments/:environmentId/...`
 - ヘッダー: `X-Environment-Id`
-- 環境変数: `OS_ENVIRONMENT_ID`(`OS_PROJECT_ID` は 4.x ではエイリアスとして維持され、5.0 で削除)
+- 環境変数: `OS_ENVIRONMENT_ID`(`OS_PROJECT_ID` は非推奨のエイリアスとして維持)
 - DB カラム: `environment_id`
 - JSON スキーマ: `EnvironmentArtifact`
-
-エイリアスや非推奨用のシムはありません。慎重にアップグレードを計画してください。リリース時の 5.0 移行ガイドを参照してください。
 
 ## アップグレード
 

--- a/content/docs/resources/changelog.ko.mdx
+++ b/content/docs/resources/changelog.ko.mdx
@@ -51,30 +51,40 @@ ObjectOS는 **[유의적 버전(Semantic Versioning)](https://semver.org/)**을 
 
 ## 주요 변경 사항
 
-### 4.0.x — 현재 릴리스 트레인
+### 8.0.x — 현재 릴리스 트레인
 
-- **42개 패키지**가 `@objectstack/*` 아래 npm에 게시되었습니다.
-- Console에 완전한 Configuration 설정 페이지(AI, Storage,
-  Knowledge)가 추가되었습니다.
-- Embedder 서비스: 10개 공급자(`openai`, `azure`, 阿里通义,
-  智谱, 硅基流动, 火山, MiniMax, Ollama, custom).
-- 실시간 설정 → 런타임 브리지 — Console에서 공급자를 변경하면 재시작 없이
-  프로세스 내에서 교체됩니다.
+ObjectOS One과 번들 서버는 이제 `@objectstack` **8.0.1** 기반으로 동작합니다.
 
-### 5.0 (예정) — `project` → `environment` 이름 변경
+- **MCP over Streamable HTTP** — 모든 배포가 네트워크로 접근 가능한
+  [Model Context Protocol](https://modelcontextprotocol.io) 서버로 동작할 수 있습니다.
+  `OS_MCP_SERVER_ENABLED=true`로 활성화하면 엔드포인트가 `/api/v1/mcp`에서 제공되며
+  fail-closed 인증(익명 요청 거부)이 적용됩니다. 플러그인은
+  `@objectstack/plugin-mcp-server`에서 `@objectstack/mcp`로 이름이 변경되었습니다.
+- **셀프 서비스 API 키** — `POST /api/v1/keys`는 한 번만 표시되는 `sys_api_key`를
+  발급합니다. REST 데이터 및 메타데이터 API(`/api/v1/data`, `/api/v1/meta`)는 이제
+  MCP와 동일한 검증기로 API 키를 인증하며, 키 소유자의 권한과 레코드 수준 보안 아래에서
+  실행됩니다.
+- **필드 단위 조건 규칙** — `visibleWhen`, `readonlyWhen`, `requiredWhen`이 폼 UI뿐
+  아니라 ObjectQL에 의해 서버 측에서 강제됩니다.
+- **재사용 가능한 RLS 읽기 필터** — `security.getReadFilter(object, context)`가 레코드
+  접근의 읽기 범위를 노출합니다. 분석 데이터셋, 대시보드, 보고서가 여기에 브리지되며
+  범위를 안전하게 적용할 수 없으면 fail closed 됩니다.
+- **독립형 host 스택** — 런타임은 단일 테넌트 `createStandaloneStack` host를
+  제공합니다. 7.x의 클라우드 연결·호스트명 라우팅 방식 `createObjectOSStack` 래퍼는
+  제거되었습니다. 클라우드 배포는 이제 `OS_ARTIFACT_FILE`을 게시된 artifact URL로
+  지정합니다.
+
+### 5.0 — `project` → `environment` 이름 변경 (출시됨)
 
 이전에 *Project*라고 불리던 런타임 개념이 전반에 걸쳐 *Environment*로
-이름이 변경됩니다. 영향 범위:
+이름이 변경되었습니다. 영향 범위:
 
 - CLI 플래그: `--environment` / `-e`
 - HTTP 경로: `/api/v1/environments/:environmentId/...`
 - 헤더: `X-Environment-Id`
-- 환경 변수: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID`는 4.x에서 별칭으로 유지되며 5.0에서 제거됨)
+- 환경 변수: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID`는 사용 중단된 별칭으로 유지됨)
 - DB 컬럼: `environment_id`
 - JSON 스키마: `EnvironmentArtifact`
-
-별칭이나 사용 중단 호환 레이어는 없습니다. 신중하게 업그레이드를 계획하세요 —
-릴리스 시 5.0 마이그레이션 가이드를 참고하세요.
 
 ## 업그레이드
 

--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -51,30 +51,40 @@ Subscribe to releases on GitHub to get notified.
 
 ## Recent highlights
 
-### 4.0.x — current release train
+### 8.0.x — current release train
 
-- **42 packages** published to npm under `@objectstack/*`.
-- Console gained complete Configuration settings pages (AI, Storage,
-  Knowledge).
-- Embedder service: 10 providers (`openai`, `azure`, 阿里通义,
-  智谱, 硅基流动, 火山, MiniMax, Ollama, custom).
-- Live settings → runtime bridge — change provider in Console, in-process
-  swap without restart.
+ObjectOS One and the bundled server now ship on `@objectstack` **8.0.1**.
 
-### 5.0 (upcoming) — `project` → `environment` rename
+- **MCP over Streamable HTTP** — every deployment can act as a
+  network-reachable [Model Context Protocol](https://modelcontextprotocol.io)
+  server. Opt in with `OS_MCP_SERVER_ENABLED=true`; the endpoint is served at
+  `/api/v1/mcp` with fail-closed auth (anonymous requests are rejected). The
+  plugin was renamed `@objectstack/plugin-mcp-server` → `@objectstack/mcp`.
+- **Self-serve API keys** — `POST /api/v1/keys` mints a show-once
+  `sys_api_key`. The REST data and metadata APIs (`/api/v1/data`,
+  `/api/v1/meta`) now authenticate API keys through the same verifier as MCP,
+  running under the key owner's permissions and record-level security.
+- **Field-level conditional rules** — `visibleWhen`, `readonlyWhen`, and
+  `requiredWhen` are enforced server-side by ObjectQL, not just in the form UI.
+- **Reusable RLS read filter** — `security.getReadFilter(object, context)`
+  exposes the record-access read scope; analytics datasets, dashboards, and
+  reports bridge to it and fail closed when the scope cannot be applied.
+- **Standalone host stack** — the runtime ships a single-tenant
+  `createStandaloneStack` host; the 7.x cloud-connected, hostname-routed
+  `createObjectOSStack` wrapper was removed. A cloud deployment now points
+  `OS_ARTIFACT_FILE` at a published artifact URL.
 
-The runtime concept formerly called *Project* is renamed to *Environment*
-throughout. Affects:
+### 5.0 — `project` → `environment` rename (shipped)
+
+The runtime concept formerly called *Project* was renamed to *Environment*
+throughout. Affected:
 
 - CLI flags: `--environment` / `-e`
 - HTTP paths: `/api/v1/environments/:environmentId/...`
 - Headers: `X-Environment-Id`
-- Env vars: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` kept as alias on 4.x, removed in 5.0)
+- Env vars: `OS_ENVIRONMENT_ID` (`OS_PROJECT_ID` kept as a deprecated alias)
 - DB columns: `environment_id`
 - JSON schemas: `EnvironmentArtifact`
-
-No aliases or deprecation shims. Plan to upgrade carefully — see the
-5.0 migration guide on release.
 
 ## Upgrading
 

--- a/content/docs/resources/changelog.zh-Hans.mdx
+++ b/content/docs/resources/changelog.zh-Hans.mdx
@@ -51,31 +51,40 @@ ObjectOS 遵循 **[语义化版本](https://semver.org/)**：`MAJOR.MINOR.PATCH`
 
 ## 近期亮点
 
-### 4.0.x —— 当前发布列车
+### 8.0.x —— 当前发布列车
 
-- 已向 npm 发布 **42 个包**，命名空间为 `@objectstack/*`。
-- Console 增加了完整的 Configuration 设置页面（AI、Storage、
-  Knowledge）。
-- Embedder 服务：10 个 provider（`openai`、`azure`、阿里通义、
-  智谱、硅基流动、火山、MiniMax、Ollama、自定义）。
-- 在线设置 → 运行时桥接 —— 在 Console 中切换 provider，进程内
-  原地替换，无需重启。
+ObjectOS One 与捆绑的 server 现已基于 `@objectstack` **8.0.1**。
 
-### 5.0（即将发布）—— `project` → `environment` 重命名
+- **MCP over Streamable HTTP** —— 每个部署都可作为网络可达的
+  [Model Context Protocol](https://modelcontextprotocol.io) 服务器。
+  通过 `OS_MCP_SERVER_ENABLED=true` 开启；端点位于 `/api/v1/mcp`，采用
+  fail-closed 鉴权（匿名请求被拒绝）。插件已从
+  `@objectstack/plugin-mcp-server` 重命名为 `@objectstack/mcp`。
+- **自助 API key** —— `POST /api/v1/keys` 生成只显示一次的
+  `sys_api_key`。REST 数据与元数据 API（`/api/v1/data`、`/api/v1/meta`）
+  现在通过与 MCP 相同的校验器认证 API key，并以 key 所有者的权限与
+  记录级安全运行。
+- **字段级条件规则** —— `visibleWhen`、`readonlyWhen`、`requiredWhen`
+  由 ObjectQL 在服务端强制执行，而不仅在表单 UI 中生效。
+- **可复用的 RLS 读取过滤器** —— `security.getReadFilter(object, context)`
+  暴露记录访问的读取范围；分析数据集、仪表盘与报表均桥接到它，无法安全
+  应用范围时 fail closed。
+- **Standalone host stack** —— 运行时改为单租户的
+  `createStandaloneStack` host;7.x 那种按 hostname 路由的云连接
+  `createObjectOSStack` 封装已移除。云部署改为让 `OS_ARTIFACT_FILE`
+  指向已发布的 artifact URL。
 
-运行时中原称 *Project* 的概念将在全栈范围内重命名为 *Environment*。
+### 5.0 —— `project` → `environment` 重命名（已发布）
+
+运行时中原称 *Project* 的概念已在全栈范围内重命名为 *Environment*。
 影响范围：
 
 - CLI 参数：`--environment` / `-e`
 - HTTP 路径：`/api/v1/environments/:environmentId/...`
 - 请求头：`X-Environment-Id`
-- 环境变量：`OS_ENVIRONMENT_ID`（4.x 中保留 `OS_PROJECT_ID` 作为
-  别名，5.0 中移除）
+- 环境变量：`OS_ENVIRONMENT_ID`（`OS_PROJECT_ID` 保留为已弃用的别名）
 - 数据库列名：`environment_id`
 - JSON schema：`EnvironmentArtifact`
-
-不会保留别名或弃用 shim。请谨慎计划升级 —— 详见发布时的 5.0 迁移
-指南。
 
 ## 升级
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,29 +85,29 @@ importers:
   apps/objectos:
     dependencies:
       '@objectstack/cli':
-        specifier: ^7.9.0
-        version: 7.9.0(@aws-sdk/client-s3@3.984.0)(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@aws-sdk/client-s3@3.984.0)(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/core':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/driver-memory':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/driver-sql':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/metadata':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/objectql':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
       '@objectstack/runtime':
-        specifier: ^7.9.0
-        version: 7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^8.0.1
+        version: 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@objectstack/spec':
-        specifier: ^7.9.0
-        version: 7.9.0(ai@6.0.193(zod@4.4.3))
+        specifier: ^8.0.1
+        version: 8.0.1(ai@6.0.193(zod@4.4.3))
     devDependencies:
       '@types/node':
         specifier: ^25.9.1
@@ -1431,35 +1431,35 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@objectstack/account@7.9.0':
-    resolution: {integrity: sha512-lC+ANEr7Cll2gA4xXp9WWfFywkLg1UlxtdH4P/QdEP5CgwTZqjexBFHU2bF3+L1bfHJgsiaOxeCrWRPlj2krlg==}
+  '@objectstack/account@8.0.1':
+    resolution: {integrity: sha512-hio0SB54+dZJDVkpjU1OZ6Sft3Y1/6gBw0XLZmTqpKxRD6L5Upc/WJ9iL0o55hLvlFKB1d+PotaAtPFK9V6YWg==}
 
-  '@objectstack/cli@7.9.0':
-    resolution: {integrity: sha512-2K+g5rmGcM/XxeZwwzsJfvgH9hwN2bOMy1uyxGAn7rZ1xlqAfQpNkPi0C7Px6BYT1xnF6OHmmtiGa2a1I1DfmQ==}
+  '@objectstack/cli@8.0.1':
+    resolution: {integrity: sha512-aMuZHCcLQ3ZB19utH8Rf5lMch9q1LfqMbpBwAawhl79P7QcDR+bX/xMprASM81m2kYhTT+La0dMadM6gkwgjnA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@objectstack/client@7.9.0':
-    resolution: {integrity: sha512-fnTmsaVWRxaFH/2CclpWK7mI45HLYgNUdHcKHxojBjkOYnbwOqP0FpQIrx+07oJyCT0ghKK2Y61qRsM+DeTdrg==}
+  '@objectstack/client@8.0.1':
+    resolution: {integrity: sha512-fLObUYXfa6XmoutgLK5SRthROKM16PTbMyOntiIoGI76zOHbsbZNa8FyDnSV7kEnjWERjBlEedjgT9201Pvnyg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/console@7.9.0':
-    resolution: {integrity: sha512-UtTxT7w+LxG050zYP13RLBDM8pfiOBXa0LKlE/7Yx0Se4BjAXOFzgldzB6J40c8JuE9dMvekqcG/cjn+3T0FNw==}
+  '@objectstack/console@8.0.1':
+    resolution: {integrity: sha512-d4I0hLRgJKV45MZanPWsCEyXxj7zzZMcjxdIBAc/g+CYWxS8i/dMgi5cuGnQxxPyopmElyadxoFav2tA3kScaA==}
 
-  '@objectstack/core@7.9.0':
-    resolution: {integrity: sha512-mZXkHiBiCJNHFxNKrHJNfYvJbO1mJX8fmRmtHXwvBawGsr8l/Q/iHk4pbZMEXxoL/YJK8EdEaerJ4/tGhJhmXg==}
+  '@objectstack/core@8.0.1':
+    resolution: {integrity: sha512-222khmv9KMBCI1dfjy2jknK9kpv/+RD9kcmNCrRApEzRQ5/TbE75UCM+T245yse61K7ez8CV0py/Yr5KJNj6FA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-memory@7.9.0':
-    resolution: {integrity: sha512-+IztM5AKlcSGFOhVNRVGPTc+l7+o6X8xNj1ML1ekq5Xr4mUpN94eqmuaU+GMHuawqiYbPLj2ULLhIV3rMN5f+w==}
+  '@objectstack/driver-memory@8.0.1':
+    resolution: {integrity: sha512-rl3arNAOPotnlRi3PIkcN+597PBUXFdizfijjDOIMbi18KCCaMnFJY+rbk9ASfJv+kfN6L18S2EKSF6CnYoA6w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-mongodb@7.9.0':
-    resolution: {integrity: sha512-aVft/1HzJAfp5bLh3w/I0t1CrIjrRLghKexrG+Y02vciJFyKyabeluPGBO7wwFV+egLKsdDUpQnLdabC6mo07A==}
+  '@objectstack/driver-mongodb@8.0.1':
+    resolution: {integrity: sha512-+qdeMt2gYT2NUO7WzoFYbZMvOLjy6n9N7Cs0QRGHFyNOAR9HRlGe/V97dpsmzDAiRDRXDsqdM3Z/shrEJykxZg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/driver-sql@7.9.0':
-    resolution: {integrity: sha512-EUw6v7zpHb/BIM++uXGPldt3Acr86IjYtSRwuQ93qwEPbil14LxQ7fiSeGjDatyOpLkGgOYaV3Iony00RUqUtQ==}
+  '@objectstack/driver-sql@8.0.1':
+    resolution: {integrity: sha512-2kT8VSqDQK1P1hQ2P84FE38fLrD75O9VxZZdLr20IfJI/kUn+klx0KLiu7dGCog7nDic3iSIxamsfxxh3fbSAA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       mysql2: ^3.0.0
@@ -1476,15 +1476,19 @@ packages:
       tedious:
         optional: true
 
-  '@objectstack/driver-sqlite-wasm@7.9.0':
-    resolution: {integrity: sha512-h3v5wArDq8CA/5cEKK9ihnUwFf2Sd7dXtaOS6yvEq6Y0XyhXywfiHBQmLz96bBwm1OWcNNjC0EZcHV68qTsGcQ==}
+  '@objectstack/driver-sqlite-wasm@8.0.1':
+    resolution: {integrity: sha512-C0bFYRRRyJJB5nJNCoreLWINf4qVEMaZivnioKFkex2Ycb3uwydFedyV7JwAertTjFXXoFaSI54KAXMV+4/Qfg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/formula@7.9.0':
-    resolution: {integrity: sha512-58RShr27FiB/zNydIRi+pEkmnnR/lQe3uWlS/5o6J5UHtLERSRTPv0qqHiMIjHvLGVtx3qUeSnnGBVrFQJeqPA==}
+  '@objectstack/formula@8.0.1':
+    resolution: {integrity: sha512-e/CfchRGxnJW4JB1sDAaNKCAj0kbM83fSpzDmn3UMppG89aW9gSyMiB9TvaOnB35iOxsyhTeZ8R9E/rwEEfmfg==}
 
-  '@objectstack/metadata-core@7.9.0':
-    resolution: {integrity: sha512-yx1C2n/E227URt4WmhmPkKrGThTTPRtcIC8sscxEp9/pPfeONuUJ2+KExieMp0KmMlZco22dPDxsN19u2QI1Fg==}
+  '@objectstack/mcp@8.0.1':
+    resolution: {integrity: sha512-KjJftJySVYvC0E4545iCDXgQLAo0FoxEQbXrXNpy1Yp5DtAYsEZESQodkqy0EJppxmtnXAqLD31k1fgjJUESjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@objectstack/metadata-core@8.0.1':
+    resolution: {integrity: sha512-VWrtvYm1pFoYXR2szmFXshNP6LSJ9sXiQPXtoOuKdZ6092Lt1wnSRrKR5RH5TpSaavXEdsidBffGI4NPp2Ej9A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       vitest: ^4.0.0
@@ -1492,83 +1496,79 @@ packages:
       vitest:
         optional: true
 
-  '@objectstack/metadata-fs@7.9.0':
-    resolution: {integrity: sha512-+JvRuHWWnBI/k0MfwoOy1Xjts72i7sgWGkotq1p30D3pv9elv3rcMhiWVEnG/qcuX9L31tug4QA8ww0UwS7iaw==}
+  '@objectstack/metadata-fs@8.0.1':
+    resolution: {integrity: sha512-SdVofg5Bj21U5ZkCwSuHAAMjQqtto5SXZNnSrxzvJfh5Cq3AwG2d3RbWaJ+ev/dZeRJG5yuHiEhpdQJP+eOHGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/metadata@7.9.0':
-    resolution: {integrity: sha512-O+F2E75DlM0fThYXQyRbkwdXc/obylr85T02REg6rmDxhct7Y+5VUB53jD4STEcM9qIkLKIsU8CV+piAtOo3UQ==}
+  '@objectstack/metadata@8.0.1':
+    resolution: {integrity: sha512-wR6xSJbpSEDPRNMSBbLUyi+NtWsa0TVttgNJrZHqkb1+yLDGUc4K9NT0Et59nVqvVj5AjuC00Mk5uwzLxcxhPA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/objectql@7.9.0':
-    resolution: {integrity: sha512-eQMxyLcMCuLQfPojyxqkp1O2B8mXx6WeQQaF4PKBZdIdVcEJ01GmLXFyy+M48lQLuVsDAc5OWIp91WgHskyVQQ==}
+  '@objectstack/objectql@8.0.1':
+    resolution: {integrity: sha512-c/n6OLYxC6rfipQjyVXy51u/N7wnWYp9hyllfv6kmujwK56yWKkY8iycAqboyCErgmPahuqW1LLdHjE1gmUiGw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/observability@7.9.0':
-    resolution: {integrity: sha512-otKxWBFPaI78Z/yTqnkxOIh+7zuGfrqIctUMF1fgjlgfmgmYVKTCVWZaKz/8fAXPk5fA9CofIBJyQPNF9ruJSw==}
+  '@objectstack/observability@8.0.1':
+    resolution: {integrity: sha512-XwUu5ZzcbJ+AwQ9Nyw17KfIq+WWsIBgAfqrTaTlqEB4tGHXUHEwGIgYcLS9eGDwS9H92ZhrTOY4kh9n7CdLhDg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/platform-objects@7.9.0':
-    resolution: {integrity: sha512-5EgZyee34SiBzjl4ern1K4CZzCFtCbl2npoNEF/56aRSdCsSCAE/yqgf1r2kIqJhbtZ+mEFOUnuoOdLLqeGFSA==}
+  '@objectstack/platform-objects@8.0.1':
+    resolution: {integrity: sha512-3qOTeedtN78oyA4Oe/G21Lrf/H8nKa0oGsb8VoscS0nwdKmqRG4vlKplv998voEqro1HwIjvf5KZvQ1HBomVKw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-approvals@7.9.0':
-    resolution: {integrity: sha512-KLVrS86G8BS1gKC0rLcELcWyZu6lgmCqbtjKuCa9GY1/kdwUdjH0zL9oBT/bDnLXCyd4iLVWmOV4gbUO2Oe3OA==}
+  '@objectstack/plugin-approvals@8.0.1':
+    resolution: {integrity: sha512-PCrqaTeEgQK+kDfEx4PUsaba9u9Ry/HFPrsx1xWkNS1sglfJG+LFqQEPHxUCDXIlap7hcj6gQtXJl42vVgZnPg==}
 
-  '@objectstack/plugin-audit@7.9.0':
-    resolution: {integrity: sha512-S/dHeb+t7e/6+jSVK3VH4FkdKFOhW2zdjgKviAiRYS9ufSs3mNdT7vNlUYQ5zUCWgyLQxM0xJ2oqOh7QzTkD7Q==}
+  '@objectstack/plugin-audit@8.0.1':
+    resolution: {integrity: sha512-VqeC1xnLz1SPVo6+jOnPiWgJaiOPdXipyS6leS/wIVO6h+BcHR4e9XnQefYlB+ikVUeZwl6WM2iVHE48IatNuQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-auth@7.9.0':
-    resolution: {integrity: sha512-vNSZeQm8DOaFstEptjjbphnHtyq5UeLMOWqxDvmlYlUfYd6TQhP+3M+v5G183nFhlazICyTz3ISs+gHQAr81hQ==}
+  '@objectstack/plugin-auth@8.0.1':
+    resolution: {integrity: sha512-nLk3/lentF5qZ72X0c/fC5b8Ne/COg6dgwgUUscN8QQIR3EvHPsSWAeLOsrBVqb74v/ShxE81GkbxC0pK81fOQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-email@7.9.0':
-    resolution: {integrity: sha512-j0KPa4iU+phxBEvyWCdpz5aYgLM2cOpwWRkzCTkNdTQYqW6dqTqkoRqAVtK6x5u0eF6BLnLrwPeAhIS1j9hy7A==}
+  '@objectstack/plugin-email@8.0.1':
+    resolution: {integrity: sha512-psYJmJDp3LCYWCOk8b1ygVbjcYfYw+BVDeXAEl0LvkMPrPa/ugxAIcDINPSmZluTdL1BjionOSb/ohboHr/g+Q==}
 
-  '@objectstack/plugin-hono-server@7.9.0':
-    resolution: {integrity: sha512-0YS3m4YkuExGXaT+XTanwQH3LYlDPoeJPYz85aNDnLTnPyCOPaWfYWR9lEYmyzmLQGbXibQFa2KkOdGo4o9jNQ==}
+  '@objectstack/plugin-hono-server@8.0.1':
+    resolution: {integrity: sha512-l2RKsunYIzxIU9emWxGVDOonoDDItiE/PDEA0qoBwUG2jUH4pkEahIaUKVgri9NZetKtp9ulKnHTHcDlzqpe7g==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-mcp-server@7.9.0':
-    resolution: {integrity: sha512-nCJ8did56pDzlVRYwByquAq54tpFzBR7DA8ms8YasIhBgYpbMZzMhCjzPYwwXIhg/E2z9pSTjOP42Df1S68HCg==}
+  '@objectstack/plugin-org-scoping@8.0.1':
+    resolution: {integrity: sha512-PrrOzZbwW61AiPvDylSsSduR8Fi19l1pRjKk4e4VMSoJUiM9H+mdYxVtiANT+rpdEUxmjCl4tA1uv5WrGbkksA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-org-scoping@7.9.0':
-    resolution: {integrity: sha512-OEKHWEZ51MnPkdLUdjHuAjTq0SodITA+4kgpWXKFK0C/2xiaTKwIO7YRsI3rSBLBE8n2hM5yBTf4S0OKAY7/9Q==}
+  '@objectstack/plugin-reports@8.0.1':
+    resolution: {integrity: sha512-500DjcpmmjtmvOUsrfwK+faGshBfoRAaXdfxzEjwHoFZfXTBX1Uc12YoTySoxQyuXoXE3Lw9OBARAyYiELss8Q==}
+
+  '@objectstack/plugin-security@8.0.1':
+    resolution: {integrity: sha512-NaEozXRvGH06UhFz2CVoKq8YoPc5OTTeoMk3IQ+kiUMz1w0Ky4dwTkXJzd9zW9aWL8cMQ9ezpC1oNQBVcaMo4Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-reports@7.9.0':
-    resolution: {integrity: sha512-myhHqm7sEIiXpPK8Kbo/zYLuQTqG7qLMleYNEyP45DVoil3fYdIJn6dyF1AqANY/OMgX1n0wvuyRsDZPn/dvow==}
+  '@objectstack/plugin-sharing@8.0.1':
+    resolution: {integrity: sha512-7vpjAG1uV0cgcxhnEB05WyjGhwlYT7ezufo+83ya9kxJdORnyo8wPHsQ5bnuntOdz0aTtn5WTvS4nQVlZoxkaw==}
 
-  '@objectstack/plugin-security@7.9.0':
-    resolution: {integrity: sha512-tLqUDv+hgXLUJPVvCxPZIwXdCQXyS2rooU9wIv5BSIPXQhkVdN94T+tL3Q1VRwAfxW3SFTzLVqGHp45oPvbTRw==}
+  '@objectstack/plugin-trigger-record-change@8.0.1':
+    resolution: {integrity: sha512-dvedWALQ78q6cqfwVskZmwcml4f7FsifgqYosNkQWVDW4yE+6em4Gro3ert8XmMBQomFl85SttHf6VdiOiZoYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-sharing@7.9.0':
-    resolution: {integrity: sha512-wr9N8uovaCua3AGhDevvFMoli631BosHitjZ11rNa2E/l37phowm2BWG01DzdWolwsF9jQZ19ogxMY6L3cM5WQ==}
-
-  '@objectstack/plugin-trigger-record-change@7.9.0':
-    resolution: {integrity: sha512-xwAJLgmO0qBpQdM1WXkgrhiDRg2GkH+v4l2tOVg4D4hK0R8CSC0ONbntep/P7lGcpn+Byx1DiXCMgKpmT0I24A==}
+  '@objectstack/plugin-trigger-schedule@8.0.1':
+    resolution: {integrity: sha512-xMiICt1+v/afoTZ8hy/e1Wyi2NEYFQkLxtqxMC72AtIYT6caHJFJLAvzn15Y1nQeMs4tQAJh8t23n1+6hZ8cxQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-trigger-schedule@7.9.0':
-    resolution: {integrity: sha512-KFLsS811wMq7GhxmFECnnAuc1IDgyBcj8J+dGpTy8ZqPj0YUsTNv6n5eyc2eNFpTD0f7HaVfoWdqSDQqqf23WQ==}
+  '@objectstack/plugin-webhooks@8.0.1':
+    resolution: {integrity: sha512-UMzvj2UDm2wJcKQ4yCdOnWxQj/rL/rni90ZkDFwJaVqdstRWmNE/gVUssPvPKTNuA2HxC4+rQdIUfXRQMZvmtQ==}
+
+  '@objectstack/rest@8.0.1':
+    resolution: {integrity: sha512-YA05taXQs3Rzz/DHlF5XBb9BKcmevDHhSA+YmXX8gTIwsuxWQgYG1YyrnWAPBNByyTwCHXqaT/bcBOE0IZ2Wlg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/plugin-webhooks@7.9.0':
-    resolution: {integrity: sha512-a5VyDAyI6JoHB8LVKqapF9x2sGkVXe9Op/CwhOf6GMOKY58fB5oXOxr5sowSnY8Wtw6bIG0w2QZFQMMXRvMzIw==}
-
-  '@objectstack/rest@7.9.0':
-    resolution: {integrity: sha512-uK0YL8NYhM8K2e/vQCiDJbKf5+EAFFCDKDkDe5XDGrOz6aIzdPG/o3o7ins07A2ZXUf3hfFtjIcpW3bLaBAl1Q==}
+  '@objectstack/runtime@8.0.1':
+    resolution: {integrity: sha512-fY5DtKCexgM5AjQnd363wamvLPS88SrDeK7mF84YDoVksD7JmCyeoMzeLQAGm3kOj3dX2F5uEE39m64pUeL+4w==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/runtime@7.9.0':
-    resolution: {integrity: sha512-g8tzwSwepCgD3KfTjcvZlBkAH2jTrrgDSw4DwZCEW6yluMflb/6Mdpxi/JtfifO82mj2u7Adt823U8a98vAbLQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@objectstack/service-ai@7.9.0':
-    resolution: {integrity: sha512-IRBFXCg7PWgm0oLBhDhTbpwwrv7BOd8Vl+d9INXdNrIA+5cxyZLJzej02lSVPVXRmE2gZlAT/5SlVMmmxau2NA==}
+  '@objectstack/service-ai@8.0.1':
+    resolution: {integrity: sha512-i1dj3BV8O/C8ENFDmEzEgIQ7iVt7WPetmRUz5JRYFM+ubeErVwaJAm1JAn/HJ6SRQl7i7fO+fgjWSLvlUr6THA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@ai-sdk/anthropic': ^3.0.0
@@ -1585,58 +1585,58 @@ packages:
       '@ai-sdk/openai':
         optional: true
 
-  '@objectstack/service-analytics@7.9.0':
-    resolution: {integrity: sha512-6xaahDzIEsHtkzI42ZEqsX2U5KY+MwBhVtZ2EW6FmYimivDiuXRk1FbkyOOQurWgt7+qnLM3mv1hdqt5aP28Ew==}
+  '@objectstack/service-analytics@8.0.1':
+    resolution: {integrity: sha512-3DWT/kmeM/U4wOzrk2yO1vyrlkij8KLhQIuhbDCth+Xwwj94U4YaPs8JbdmfsSEfec+D5YGnfGaagdk0Q87ejw==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-automation@7.9.0':
-    resolution: {integrity: sha512-Zq0cHPWv2q4EBjvnRA5SSTLMnety+oxjBSg2FKCvQR4/7YRWj2jxaxsA3MR2YeGdDhx8lkIKT0NCmv6kcQp4Mg==}
+  '@objectstack/service-automation@8.0.1':
+    resolution: {integrity: sha512-eiZQH/FGh5Mj1I5EYtn8FGRibWTusM9+SbiE90F02BJ4CSC56PlJ5lXJofyktme+EQf+yQsS/Ck30fAkMZpXYg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cache@7.9.0':
-    resolution: {integrity: sha512-38o0YuLcsu3QG4iztN3YxEukpwhITmC05rm5FCLodoR9M/8TUl+Y7Wi0cchGqWwNh7fXpQxtwg6fM3njjQNkmQ==}
+  '@objectstack/service-cache@8.0.1':
+    resolution: {integrity: sha512-ZZzseZzvflsa2NyC1JUvGUVbq/BYBdQpop3jqZ4W7lqquueiHkN3ffbHGnSf7HJL++/fkwMKKZiDahSecCg7kA==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-cluster@7.9.0':
-    resolution: {integrity: sha512-BPxkM2JoOcMW+OS+OU7ArsKbOleDSdq/C2VbB7GpETWFzDZr3yRTe/r5kORNlr2klv+O5Gs4Yy510ObrzU1H9Q==}
+  '@objectstack/service-cluster@8.0.1':
+    resolution: {integrity: sha512-FR8cHaM/45Ez9VICsp8B1KtwBNlyotqmuazgnT7vJ7FySMRyGKjcWw03Ua8pgYQFYwSpKOl73esgljBCeOuAXw==}
 
-  '@objectstack/service-datasource@7.9.0':
-    resolution: {integrity: sha512-+Kg3BYYzLgmF2mjk2Zqw2usVuMy36ZnQk08SV71NCdu8SxUffNmi7V9pMk1lIbwyqH2Ho+LQntNrOFFX+2QMzg==}
+  '@objectstack/service-datasource@8.0.1':
+    resolution: {integrity: sha512-kKR0m3YlUw9/Kk4YfjLWqixKYLg5an0G/yNIJxBSrTSAz/9c9XNzfyon5QWvhJg5EPoY/01VKvlGxbcqh1guVA==}
 
-  '@objectstack/service-feed@7.9.0':
-    resolution: {integrity: sha512-hcFKiZQ7a7LVRlJkAQdS2GhqgSZSWjv+wmAffk6oedoAEI7hssa4xvYYr+wOO9FMNebIT/ywQPXPftNA5C3aeQ==}
+  '@objectstack/service-feed@8.0.1':
+    resolution: {integrity: sha512-nGIxnV5qXpp9dL7njuTXq/TA2dAZMFddAcRHhdH9q8qyVdO2DcOi8n4MSaaqdALUnNbwTCLImEuhVTxF+Yo15A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-i18n@7.9.0':
-    resolution: {integrity: sha512-GCWTJqg3pt8LmQca5Ksj7jI5fwXzZqgKOmrVtuVlHO4ElrUgfs5RP0zCMEESZ5UnD7e4BRxO5mi5QlUldT2FEA==}
+  '@objectstack/service-i18n@8.0.1':
+    resolution: {integrity: sha512-h1YjPxHURiLyIc3Mf7dOJ1pgVtnkHxh3ppWuW650pXYo4F4Ys5gbsNNxUD1fuJhGQiQaycBPfADw/0BdK+wv+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-job@7.9.0':
-    resolution: {integrity: sha512-9shrMQe3IXI4OBfDivxWRSh6+L7Jw3gH+t5cFHvx2e9XXX5xRRi7Z2PZ0LC2nB3r0M0u1/d/9PTXZry905TqZA==}
+  '@objectstack/service-job@8.0.1':
+    resolution: {integrity: sha512-KlTBzR/RL8yIMp4qxpkaoZYYsktAedq1GbgNxTDCWL9wbRGL7S0GNvvG1/dPbg71jgDNIzYUdFjfWCwj5upHkg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-messaging@7.9.0':
-    resolution: {integrity: sha512-y/gyQfLK3wuMKhLLZ/FsOF9TngAw1Of2nbIxqI4MJ8164vLb7WsuT8M0P4TAMose5TVGAeRhXifQYRpCjd+elQ==}
+  '@objectstack/service-messaging@8.0.1':
+    resolution: {integrity: sha512-k3q4RyxOEy3U0NxYfVCGcQsi2cNXsvqjNrvUMrMh9Fuew6WHOeuUJ3ftChfOR8EzYHdT/OH/8VYzQjxmKVxNwQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-package@7.9.0':
-    resolution: {integrity: sha512-KeuriI1cI4m2pOT10/q6CqVHi5C9TzSyvZM20iurwU2ZoGmSOj2zSgABs8g8wF6aiK5I3unWyKkHNwjlIDQt9w==}
+  '@objectstack/service-package@8.0.1':
+    resolution: {integrity: sha512-hTxON2MnrFAHDRNKXYudG0qoSOYbTvpYG7qeo19NnT+lWvvMGcL/9v02SQzjIWZEaV+wsubF0bArdaD2qI5vyQ==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-queue@7.9.0':
-    resolution: {integrity: sha512-FIRtrTuviiJo1uXgOu6q9+QIER+9yyymMIZ+9STcIO19JHg+BK5hU1FeU1Do8rqEoolg/EdZhrT+BazPZxv8cw==}
+  '@objectstack/service-queue@8.0.1':
+    resolution: {integrity: sha512-WoOvd+3IQODws99OIwIXQ4armhW0N7JiRQG8Vip6y6s+OFQkZgB5/IG7xtxPHQAAgfmdSDKsNvteeZd2MTK5kg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-realtime@7.9.0':
-    resolution: {integrity: sha512-McTXveFxw+vDDbqb/grVERNloL0FDpTbUAKqQBJTNhYVXh3c0GHJ86aIK1vfx5Wuz3G6tUchBNcc2YJZN2CHDA==}
+  '@objectstack/service-realtime@8.0.1':
+    resolution: {integrity: sha512-btZGq/ap0Gzl7Ftd886XgMbLclqTbIuAi4B1g1mpAQja8fHQahRiYo/5UW6UXiWlSf4mKOidRrWpmQpjACVR4A==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-settings@7.9.0':
-    resolution: {integrity: sha512-hOy7WBfiycjM0crTUO0Hc0nFq+NdhkEW957voObwRF3M/lljyygdw9ObxU+s6tmPXKIukG7qW7AGeCX5W10ZZA==}
+  '@objectstack/service-settings@8.0.1':
+    resolution: {integrity: sha512-/Kco/IfvdeMzioPP7UrkqTTVHatrtoHDr2R0VTDvC7jMV2HZORqdFgBWGVmLdY9xUF59I1OP/FxgwtfoT6ixAg==}
     engines: {node: '>=18.0.0'}
 
-  '@objectstack/service-storage@7.9.0':
-    resolution: {integrity: sha512-x84mVW9o/pmKmtyGYrooKNASokK7d+qkyqJ2mtnrD4zNQRcY1/OQRKxHKzdffzOTSSL0/iEWYl62UKOSmoEakg==}
+  '@objectstack/service-storage@8.0.1':
+    resolution: {integrity: sha512-SOnvpditPPf4AdaqKCXHPxqQXGw0k3UD67RDTHouk2N+JKoa+Sx0osS0TzhkhrVwha4Kxdvu0M+tyWh0DAGbcA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@aws-sdk/client-s3': ^3.0.0
@@ -1647,8 +1647,8 @@ packages:
       '@aws-sdk/s3-request-presigner':
         optional: true
 
-  '@objectstack/spec@7.9.0':
-    resolution: {integrity: sha512-B/tEB4Xggdwck9v4d97dB+K3dOjgjjm/TALcRqSFotRmBs3hbsiLXxKYMsyhl71E57/DNxwwikaZ3inwOi+ZUA==}
+  '@objectstack/spec@8.0.1':
+    resolution: {integrity: sha512-ZTHxY0TJIGDGNNd+i5Jzl8KQEA4wxgm46WTICrrYEybdsUnSkuOEKSW3lH0IBB8vI9Dx8/yUtKw77Di9NDfkAw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       ai: ^6.0.0
@@ -1656,8 +1656,8 @@ packages:
       ai:
         optional: true
 
-  '@objectstack/types@7.9.0':
-    resolution: {integrity: sha512-5tV3ToT7fmYMUH6Jgz+m9kXv5A+l/WXd1GGk+7t1LXLdS8d5Urg9GWb0EUh+A/6Ximi5mwLeA1x2+JzLThQJ6A==}
+  '@objectstack/types@8.0.1':
+    resolution: {integrity: sha512-1oA7/z2k9UkdopRCmEHLVj5bpQJxBZt3qBI8TxN81LhDzTBibI4Bl5qBJiUPc7ClNQuCQHrUjRD/NTadSkq7Dw==}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.11.4':
@@ -6484,53 +6484,53 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@objectstack/account@7.9.0': {}
+  '@objectstack/account@8.0.1': {}
 
-  '@objectstack/cli@7.9.0(@aws-sdk/client-s3@3.984.0)(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/cli@8.0.1(@aws-sdk/client-s3@3.984.0)(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@ai-sdk/gateway': 3.0.121(zod@4.4.3)
-      '@objectstack/account': 7.9.0
-      '@objectstack/client': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/console': 7.9.0
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-memory': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-mongodb': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.9.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/objectql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-approvals': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-audit': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-email': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-hono-server': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-mcp-server': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-org-scoping': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-reports': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-security': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-sharing': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-trigger-record-change': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-trigger-schedule': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-webhooks': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/rest': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/runtime': 7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/service-ai': 7.9.0(@ai-sdk/gateway@3.0.121(zod@4.4.3))
-      '@objectstack/service-analytics': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-automation': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-cache': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-datasource': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-feed': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-job': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-messaging': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-package': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-queue': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-realtime': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-settings': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-storage': 7.9.0(@aws-sdk/client-s3@3.984.0)(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/account': 8.0.1
+      '@objectstack/client': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/console': 8.0.1
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/mcp': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-approvals': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-audit': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-email': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-hono-server': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-reports': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-sharing': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-trigger-record-change': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-trigger-schedule': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-webhooks': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/runtime': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/service-ai': 8.0.1(@ai-sdk/gateway@3.0.121(zod@4.4.3))
+      '@objectstack/service-analytics': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-automation': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-cache': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-datasource': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-feed': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-job': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-queue': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-realtime': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-settings': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-storage': 8.0.1(@aws-sdk/client-s3@3.984.0)(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       '@oclif/core': 4.11.4
       bundle-require: 5.1.0(esbuild@0.28.0)
       chalk: 5.6.2
@@ -6590,34 +6590,34 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/client@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/client@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/console@7.9.0': {}
+  '@objectstack/console@8.0.1': {}
 
-  '@objectstack/core@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/core@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-memory@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-memory@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       mingo: 7.2.1
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/driver-mongodb@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-mongodb@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       mongodb: 7.2.0
       nanoid: 5.1.11
     transitivePeerDependencies:
@@ -6630,10 +6630,10 @@ snapshots:
       - snappy
       - socks
 
-  '@objectstack/driver-sql@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/driver-sql@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
     optionalDependencies:
@@ -6645,11 +6645,11 @@ snapshots:
       - pg-query-stream
       - supports-color
 
-  '@objectstack/driver-sqlite-wasm@7.9.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)':
+  '@objectstack/driver-sqlite-wasm@8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       knex: 3.2.10(better-sqlite3@12.10.0)
       nanoid: 5.1.11
       sql.js: 1.14.1
@@ -6665,36 +6665,48 @@ snapshots:
       - supports-color
       - tedious
 
-  '@objectstack/formula@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/formula@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@marcbachmann/cel-js': 7.6.1
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-core@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/mcp@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - ai
+      - supports-color
+
+  '@objectstack/metadata-core@8.0.1(ai@6.0.193(zod@4.4.3))':
+    dependencies:
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/metadata-fs@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/metadata-fs@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))
       chokidar: 5.0.0
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/metadata@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/metadata@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-fs': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-fs': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       chokidar: 5.0.0
       glob: 13.0.6
       js-yaml: 4.2.0
@@ -6703,62 +6715,62 @@ snapshots:
       - ai
       - vitest
 
-  '@objectstack/objectql@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/objectql@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       ajv: 8.20.0
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/observability@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/observability@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/platform-objects@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/platform-objects@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/metadata-core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/plugin-approvals@7.9.0(ai@6.0.193(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata-core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-audit@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-approvals@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata-core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-auth@7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/plugin-audit@8.0.1(ai@6.0.193(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/plugin-auth@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@better-auth/core': 1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/oauth-provider': 1.6.13(@better-auth/core@1.6.13(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(better-auth@1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(better-call@1.3.5(zod@4.4.3))
       '@noble/hashes': 2.2.0
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       better-auth: 1.6.13(@opentelemetry/api@1.9.1)(better-sqlite3@12.10.0)(mongodb@7.2.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     transitivePeerDependencies:
       - '@better-auth/utils'
@@ -6790,127 +6802,115 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/plugin-email@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-email@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-hono-server@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-hono-server@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@hono/node-server': 2.0.4(hono@4.12.23)
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       hono: 4.12.23
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-mcp-server@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-org-scoping@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - ai
-      - supports-color
-
-  '@objectstack/plugin-org-scoping@7.9.0(ai@6.0.193(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-reports@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-reports@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-security@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-security@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-sharing@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-sharing@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/objectql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/plugin-trigger-record-change@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-trigger-record-change@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-trigger-schedule@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-trigger-schedule@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/plugin-webhooks@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/plugin-webhooks@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-messaging': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-messaging': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/rest@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/rest@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-package': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-package': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       zod: 4.4.3
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/runtime@7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@objectstack/runtime@8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-memory': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/driver-sqlite-wasm': 7.9.0(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/metadata': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/objectql': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-auth': 7.9.0(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@objectstack/plugin-org-scoping': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/plugin-security': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/rest': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-cluster': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/service-i18n': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-memory': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-sqlite-wasm': 8.0.1(ai@6.0.193(zod@4.4.3))(better-sqlite3@12.10.0)
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/metadata': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/objectql': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-auth': 8.0.1(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(ai@6.0.193(zod@4.4.3))(better-call@1.3.5(zod@4.4.3))(better-sqlite3@12.10.0)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.2.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/plugin-org-scoping': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/plugin-security': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/rest': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-cluster': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/service-i18n': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       quickjs-emscripten: 0.32.0
       zod: 4.4.3
     optionalDependencies:
-      '@objectstack/driver-mongodb': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/driver-mongodb': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@better-auth/utils'
@@ -6954,141 +6954,141 @@ snapshots:
       - vitest
       - vue
 
-  '@objectstack/service-ai@7.9.0(@ai-sdk/gateway@3.0.121(zod@4.4.3))':
+  '@objectstack/service-ai@8.0.1(@ai-sdk/gateway@3.0.121(zod@4.4.3))':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
       ai: 6.0.193(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@ai-sdk/gateway': 3.0.121(zod@4.4.3)
 
-  '@objectstack/service-analytics@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-analytics@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-automation@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-automation@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/formula': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/formula': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cache@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-cache@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-cluster@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-cluster@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-datasource@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-datasource@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-feed@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-feed@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-i18n@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-i18n@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-job@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-job@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
       croner: 10.0.1
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-messaging@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-messaging@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-package@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-package@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/service-queue@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-queue@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-    transitivePeerDependencies:
-      - ai
-      - vitest
-
-  '@objectstack/service-realtime@7.9.0(ai@6.0.193(zod@4.4.3))':
-    dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-settings@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-realtime@8.0.1(ai@6.0.193(zod@4.4.3))':
+    dependencies:
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+    transitivePeerDependencies:
+      - ai
+      - vitest
+
+  '@objectstack/service-settings@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       '@noble/ciphers': 2.2.0
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/platform-objects': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/types': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/platform-objects': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/types': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
       - vitest
 
-  '@objectstack/service-storage@7.9.0(@aws-sdk/client-s3@3.984.0)(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/service-storage@8.0.1(@aws-sdk/client-s3@3.984.0)(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/core': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/observability': 7.9.0(ai@6.0.193(zod@4.4.3))
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/core': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/observability': 8.0.1(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     optionalDependencies:
       '@aws-sdk/client-s3': 3.984.0
     transitivePeerDependencies:
       - ai
 
-  '@objectstack/spec@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/spec@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
       zod: 4.4.3
     optionalDependencies:
       ai: 6.0.193(zod@4.4.3)
 
-  '@objectstack/types@7.9.0(ai@6.0.193(zod@4.4.3))':
+  '@objectstack/types@8.0.1(ai@6.0.193(zod@4.4.3))':
     dependencies:
-      '@objectstack/spec': 7.9.0(ai@6.0.193(zod@4.4.3))
+      '@objectstack/spec': 8.0.1(ai@6.0.193(zod@4.4.3))
     transitivePeerDependencies:
       - ai
 


### PR DESCRIPTION
## What

Upgrade `@objectstack` to the latest **8.0.1** (major bump from 7.9.0), release **ObjectOS One 8.0.1**, and refresh the official docs for the real 8.0 surface — including all six translations.

## Dependency upgrade
- All eight `@objectstack/*` deps in `@objectos/server` bumped `^7.9.0 → ^8.0.1`; lockfile refreshed (clean resolve, no leftover 7.x, no stale `plugin-mcp-server`).

## Breaking change handled (7.x → 8.0)
- 8.0 removed the cloud-connected, hostname-routed `createObjectOSStack` wrapper from `@objectstack/runtime` (type-check caught it).
- `apps/objectos/objectstack.config.ts` migrated to the single-tenant **`createStandaloneStack`** host, mapping the existing env-var contract: `OS_ARTIFACT_FILE → artifactPath` (now also accepts an `http(s)://` cloud artifact URL), `OS_ENVIRONMENT_ID/OS_PROJECT_ID → environmentId`, `OS_BUSINESS_DB_URL/OS_DATABASE_URL → databaseUrl`.
- The cli-internal `@objectstack/plugin-mcp-server → @objectstack/mcp` rename does **not** affect ObjectOS (no direct import).

## ObjectOS One 8.0.1
- `sync-version` propagated the resolved cli version to `package.json`, `tauri.conf.json`, `Cargo.toml`; `Cargo.lock` synced too. `sync-version:check` passes.

## Verification
- `type-check` passes.
- `pnpm smoke:runtime` boots clean on 8.0.1 — artifact loaded, **26 plugins**, server ready, `/api/v1/health` OK.

## Docs (English + de/es/fr/ja/ko/zh-Hans)
- **changelog** — new "8.0.x current release train": MCP over Streamable HTTP, self-serve API keys, field conditional rules, RLS read filter, standalone host; marked the 5.0 environment rename as shipped.
- **environment-variables** — added `OS_MCP_SERVER_ENABLED`; corrected the now-inaccurate `fileConfig`/`OS_CLOUD_URL` wording; noted artifact HMR now follows `NODE_ENV`.
- **api-access** — documented `POST /api/v1/keys`, `x-api-key` / `Authorization: ApiKey` auth, and the `/api/v1/mcp` endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)