### PR TITLE
docs: open marketplace client (@objectstack/cloud-connection) + os package install

### DIFF
--- a/content/docs/build/marketplace.mdx
+++ b/content/docs/build/marketplace.mdx
@@ -11,10 +11,38 @@ fastest way to put real software in front of users on day one.
 
 ## How it works
 
-Every ObjectOS runtime ships with the `MarketplaceProxy` and
-`MarketplaceInstallLocal` plugins enabled by default. When you open
-Console (`/_console/`), the marketplace tab queries the configured app
-catalog and shows installable apps.
+The marketplace client is the open-source `@objectstack/cloud-connection`
+package. Cloud-managed environments and the self-hosted ObjectOS image
+ship it wired up out of the box; a stack you assemble yourself enables
+it with a few lines of config:
+
+```ts
+import {
+  MarketplaceProxyPlugin,
+  MarketplaceInstallLocalPlugin,
+  RuntimeConfigPlugin,
+  resolveCloudUrl,
+} from '@objectstack/cloud-connection';
+
+const catalogUrl = resolveCloudUrl(); // OS_CLOUD_URL; 'off' disables
+
+plugins: [
+  ...(catalogUrl ? [
+    new MarketplaceProxyPlugin({ controlPlaneUrl: catalogUrl }),
+    new MarketplaceInstallLocalPlugin({ controlPlaneUrl: catalogUrl }),
+  ] : []),
+  new RuntimeConfigPlugin({ controlPlaneUrl: '', singleEnvironment: true, installLocal: true }),
+]
+```
+
+The browse/install *mechanism* is open; the catalog *service* (org
+catalogs, review, paid distribution) is provided by whichever control
+plane `OS_CLOUD_URL` points at. Once an app is installed it lives in
+your runtime's own kernel — nothing at runtime depends on the catalog
+staying reachable.
+
+When you open Console (`/_console/`), the marketplace tab queries the
+configured app catalog and shows installable apps.
 
 ```text
 You ─→ Console ─→ Marketplace tab ─→ pick app ─→ Install
@@ -100,6 +128,24 @@ Every published app is immutable. Updates produce a new version. The
 runtime tracks installed version + available updates per app. Users see
 an "Update available" badge in Console when a new version is published
 to a catalog they're tracking.
+
+## Installing from the CLI
+
+Console is the primary install surface, but the same install-local
+endpoint is scriptable for CI and air-gapped operations:
+
+```bash
+# Catalog mode — the runtime resolves the package from its configured catalog
+os package install com.acme.crm --runtime http://localhost:3000 \
+  --email admin@example.com --password …
+
+# Air-gapped mode — send a compiled artifact inline, no catalog round-trip
+os package install ./dist/objectstack.json --runtime http://localhost:3000 \
+  --email admin@example.com --password …
+```
+
+The credentials are an account on the **target runtime** (not your
+cloud login) — the same authorization Console install uses.
 
 ## Permissions
 

--- a/content/docs/build/packages.mdx
+++ b/content/docs/build/packages.mdx
@@ -120,8 +120,13 @@ environment login. You never need to know an environment id to install.
 | Path | How |
 |---|---|
 | Console (recommended) | Sign in to the environment → **Marketplace** → pick the package → **Install**. Installs into the current environment. |
-| REST | `POST /api/v1/marketplace/install-local` (body: `{ packageId, versionId? }`) |
-| Air-gapped | Mount the compiled `dist/objectstack.json` artifact (see [Air-gapped](/docs/deploy/air-gapped)) |
+| CLI → running runtime | `os package install com.acme.crm --runtime <url>` — the runtime resolves the package from its configured catalog and merges it into its own kernel |
+| CLI air-gapped | `os package install ./dist/objectstack.json --runtime <url>` — compiled artifact sent inline, no catalog round-trip |
+| REST | `POST /api/v1/marketplace/install-local` (body: `{ packageId, versionId? }` or `{ manifest }`) |
+| Air-gapped (boot-time) | Mount the compiled `dist/objectstack.json` artifact (see [Air-gapped](/docs/deploy/air-gapped)) |
+
+Package ids in install commands are the stable manifest id
+(`com.acme.crm`) — you never need the internal `pkg_…` row id.
 
 > **CI shortcut.** Pipelines that deploy to a *known* environment can publish
 > and install in one step: `os package publish --env <id> --install

--- a/content/docs/deploy/air-gapped.mdx
+++ b/content/docs/deploy/air-gapped.mdx
@@ -56,6 +56,20 @@ If the customer uses OIDC/SSO, the identity provider must be reachable
 from the air-gapped network. If not, use local email/password auth or an
 identity provider hosted inside the same network.
 
+## Installing additional packages
+
+A running air-gapped instance can take additional packages without any
+catalog connectivity — hand the compiled artifact to the install CLI
+and it is sent inline and merged into the live kernel (no restart):
+
+```bash
+os package install ./dist/objectstack.json --runtime https://os.internal.example \
+  --email admin@example.com --password …
+```
+
+The manifest is cached on the runtime host under
+`.objectstack/installed-packages/` and re-registers on every boot.
+
 ## Upgrade process
 
 Treat artifacts as immutable:

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -160,6 +160,10 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
+os package install <id|file>  # install into a RUNNING runtime: catalog id
+                              # (com.acme.crm) or a compiled artifact JSON
+                              # (air-gapped, inline). --runtime / --email /
+                              # --password identify the runtime to install into
 os publish                    # publish to ObjectStack Cloud
 os rollback <revision>        # activate a previous artifact revision
 ```


### PR DESCRIPTION
ADR-0008 落地后的官网文档对齐(英文 master;locale 走翻译流水线):

- **marketplace.mdx**:「How it works」改为事实——市场客户端 = 开源 `@objectstack/cloud-connection`,显式 wire(附配置片段);装完的 app 在运行时自己内核里,运行期不依赖目录可达。新增「Installing from the CLI」(catalog / 气隙双模式)
- **packages.mdx**:Installing 表补两条 CLI 行;注明安装命令用稳定 manifest id(`com.acme.crm`),永远不需要内部 `pkg_…` id
- **reference/cli.mdx**:收录 `os package install`
- **deploy/air-gapped.mdx**:运行中实例的 inline 安装段(零目录连通性)

对应实现:framework#1748/#1755 + cloud#238/#240/#241(全部已合并,本地栈+浏览器 E2E 验证过)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)