### PR TITLE
docs(field-types): correct type count (48) and fold barcode into qrcode

### DIFF
--- a/content/docs/reference/field-types.de.mdx
+++ b/content/docs/reference/field-types.de.mdx
@@ -5,7 +5,7 @@ description: Jeder Feldtyp, den du auf einem Objekt deklarieren kannst — was e
 
 # Feldtypen
 
-53 integrierte Feldtypen, gruppiert nach Familie. Das vollständige Zod-Schema befindet sich in
+48 integrierte Feldtypen, gruppiert nach Familie. Das vollständige Zod-Schema befindet sich in
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — diese Seite ist eine praktische Zusammenfassung.
 
 ## Kerneigenschaften (jedes Feld)
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N Sterne — `max`, `icon` |
 | `slider` | begrenzte Zahl mit Schieberegler-UI |
 | `signature` | gezeichnete Unterschrift, als Bild gespeichert |
-| `qrcode` | rendert den Wert als QR-Code — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | rendert den Wert als QR-Code oder Barcode (EAN / UPC / Code128) |
 | `progress` | abgeleiteter Prozentwert als Balken dargestellt |
 | `tags` | frei wählbares Tag-Array mit Autovervollständigung |
 | `vector` | Embedding-Spalte — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.es.mdx
+++ b/content/docs/reference/field-types.es.mdx
@@ -5,7 +5,7 @@ description: Cada tipo de campo que puedes declarar en un objeto — qué almace
 
 # Tipos de campo
 
-53 tipos de campo integrados, agrupados por familia. El esquema Zod completo está en
+48 tipos de campo integrados, agrupados por familia. El esquema Zod completo está en
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — esta página es un resumen práctico.
 
 ## Propiedades fundamentales (cada campo)
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N estrellas — `max`, `icon` |
 | `slider` | número acotado con interfaz de control deslizante |
 | `signature` | firma dibujada, almacenada como imagen |
-| `qrcode` | renderiza el valor como un código QR — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | renderiza el valor como un código QR o de barras (EAN / UPC / Code128) |
 | `progress` | porcentaje derivado renderizado como una barra |
 | `tags` | arreglo de etiquetas de formato libre con autocompletado |
 | `vector` | columna de embedding — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.fr.mdx
+++ b/content/docs/reference/field-types.fr.mdx
@@ -5,7 +5,7 @@ description: Chaque type de champ que vous pouvez déclarer sur un objet — ce 
 
 # Types de champ
 
-53 types de champ intégrés, regroupés par famille. Le schéma Zod complet se trouve dans
+48 types de champ intégrés, regroupés par famille. Le schéma Zod complet se trouve dans
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — cette page en est un résumé pratique.
 
 ## Propriétés fondamentales (chaque champ)
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N étoiles — `max`, `icon` |
 | `slider` | nombre borné avec interface à curseur |
 | `signature` | signature dessinée, stockée sous forme d'image |
-| `qrcode` | affiche la valeur sous forme de QR — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | affiche la valeur sous forme de QR ou code-barres (EAN / UPC / Code128) |
 | `progress` | pourcentage dérivé affiché sous forme de barre |
 | `tags` | tableau de tags libres avec autocomplétion |
 | `vector` | colonne d'embedding — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.ja.mdx
+++ b/content/docs/reference/field-types.ja.mdx
@@ -5,7 +5,7 @@ description: オブジェクトに宣言できるすべてのフィールドタ�
 
 # フィールドタイプ
 
-53 個の組み込みフィールドタイプを、ファミリーごとに分類しています。完全な Zod スキーマは
+48 個の組み込みフィールドタイプを、ファミリーごとに分類しています。完全な Zod スキーマは
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) にあります — このページは実用的なサマリーです。
 
 ## コアプロパティ（すべてのフィールド）
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1〜N 個の星 — `max`, `icon` |
 | `slider` | スライダー UI を持つ範囲付き数値 |
 | `signature` | 手書き署名。画像として格納 |
-| `qrcode` | 値を QR としてレンダリング — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | 値を QR またはバーコード（EAN / UPC / Code128）としてレンダリング |
 | `progress` | 導出されたパーセントをバーとして表示 |
 | `tags` | オートコンプリート付きの自由形式タグ配列 |
 | `vector` | 埋め込みカラム — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.ko.mdx
+++ b/content/docs/reference/field-types.ko.mdx
@@ -5,7 +5,7 @@ description: 객체에 선언할 수 있는 모든 필드 타입 — 저장하�
 
 # 필드 타입
 
-패밀리별로 분류된 53가지 기본 제공 필드 타입. 전체 Zod 스키마는
+패밀리별로 분류된 48가지 기본 제공 필드 타입. 전체 Zod 스키마는
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts)에 있으며, 이 페이지는 실용적인 요약입니다.
 
 ## 핵심 속성 (모든 필드)
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N 별점 — `max`, `icon` |
 | `slider` | 슬라이더 UI를 갖춘 범위 제한 숫자 |
 | `signature` | 그려진 서명, 이미지로 저장 |
-| `qrcode` | 값을 QR로 렌더링 — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | 값을 QR 또는 바코드(EAN / UPC / Code128)로 렌더링 |
 | `progress` | 막대로 렌더링되는 파생 백분율 |
 | `tags` | 자동 완성이 있는 자유 형식 태그 배열 |
 | `vector` | 임베딩 컬럼 — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.mdx
+++ b/content/docs/reference/field-types.mdx
@@ -5,7 +5,7 @@ description: Every field type you can declare on an object — what it stores, w
 
 # Field Types
 
-53 built-in field types, grouped by family. The full Zod schema is in
+48 built-in field types, grouped by family. The full Zod schema is in
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — this page is a working summary.
 
 ## Core properties (every field)
@@ -166,8 +166,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N stars — `max`, `icon` |
 | `slider` | bounded number with slider UI |
 | `signature` | drawn signature, stored as image |
-| `qrcode` | renders the value as a QR — `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 — `barcodeFormat` |
+| `qrcode` | renders the value as a QR or barcode (EAN / UPC / Code128) |
 | `progress` | derived percent rendered as a bar |
 | `tags` | free-form tag array with autocomplete |
 | `vector` | embedding column — `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |

--- a/content/docs/reference/field-types.zh-Hans.mdx
+++ b/content/docs/reference/field-types.zh-Hans.mdx
@@ -5,7 +5,7 @@ description: 你可以在对象上声明的所有字段类型 —— 存储什�
 
 # 字段类型
 
-53 个内置字段类型,按家族分组。完整的 Zod schema 在
+48 个内置字段类型,按家族分组。完整的 Zod schema 在
 [`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) —— 本页为工作摘要。
 
 ## 核心属性（每个字段都有）
@@ -165,8 +165,7 @@ fileAttachmentConfig: {
 | `rating` | 1–N 星 —— `max`、`icon` |
 | `slider` | 带滑块 UI 的有界数字 |
 | `signature` | 手绘签名,存为图像 |
-| `qrcode` | 将值渲染为 QR —— `qrErrorCorrection: 'L' \| 'M' \| 'Q' \| 'H'` |
-| `barcode` | EAN/UPC/Code128 —— `barcodeFormat` |
+| `qrcode` | 将值渲染为 QR 或条形码（EAN / UPC / Code128） |
 | `progress` | 派生百分比,以进度条渲染 |
 | `tags` | 带自动完成的自由标签数组 |
 | `vector` | 嵌入列 —— `vectorConfig: { dimensions, distanceMetric: 'cosine' \| 'euclidean', indexed, indexType: 'hnsw' \| 'ivfflat' }` |


### PR DESCRIPTION
Follow-up cleanup after the 9.7.0 upgrade ([#23](https://github.com/objectstack-ai/objectos/pull/23)) — three verified field-type-reference nits that were skipped as low-confidence and then confirmed against the framework spec.

- **Type count** — the page claimed "53 built-in field types"; the spec `FieldType` enum (`packages/spec/src/data/field.zod.ts`) has **48**. Corrected.
- **`barcode` is not a type** — only `qrcode` is in the enum; it covers QR + barcode formats. Removed the bogus `barcode` row and folded its use-case (EAN / UPC / Code128) into `qrcode`.
- **Pruned display knobs** — `qrErrorCorrection` / `barcodeFormat` were pruned as dead surface (no runtime reader; renderers ignore them), so they're dropped from the `qrcode` description.

English + all six translations (de/es/fr/ja/ko/zh-Hans). `apps/docs` `type-check` (fumadocs-mdx + tsc) passes.

> Note: the same dead-surface prune also left a few other stale display knobs in this table (`code` `theme`/`lineNumbers`, `color` `colorFormat`/`presetColors`, `rating` `allowHalf`, …). Those are out of scope here; a dedicated display-knob sync pass can follow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
