### PR TITLE
feat(server): marketplace + Console SPA deps for self-host runtime (ADR-0020 T1)

### DIFF
--- a/apps/objectos/objectstack.config.ts
+++ b/apps/objectos/objectstack.config.ts
@@ -23,9 +23,19 @@
  *   OS_BUSINESS_DB_URL  — Per-project business database (legacy: OS_DATABASE_URL;
  *                         default: file-backed sqlite under the ObjectStack home)
  *
- * Artifact hot-reload follows `NODE_ENV` (on outside production). Enterprise
- * plugins live in ../../packages/* and can be appended to the returned
- * plugin manifest below.
+ * Artifact hot-reload follows `NODE_ENV` (on outside production).
+ *
+ * NOTE — marketplace + Console SPA are intentionally NOT wired here. The
+ * `objectstack` CLI (dev / serve / start, which every entry point — Docker and
+ * the ObjectOS One desktop via one.mjs — routes through) auto-provisions them
+ * on top of this standalone stack: it injects marketplace browse/install +
+ * cloud-connection + runtime-config from `@objectstack/cloud-connection`
+ * (gated on `resolveCloudUrl()`; `OS_CLOUD_URL=off` → fully offline, nothing
+ * mounts) and serves the `@objectstack/console` SPA at `/_console/`. Both
+ * packages are declared as dependencies so this distribution pins their
+ * versions. Re-adding them to `plugins` below would double-mount; only wire
+ * them explicitly here if a future framework drops the CLI auto-injection
+ * (ADR-0006 Phase 4).
  */
 
 import { createStandaloneStack } from '@objectstack/runtime';

--- a/apps/objectos/package.json
+++ b/apps/objectos/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@objectstack/cli": "^10.2.0",
+    "@objectstack/cloud-connection": "^10.2.0",
+    "@objectstack/console": "^10.2.0",
     "@objectstack/core": "^10.2.0",
     "@objectstack/driver-memory": "^10.2.0",
     "@objectstack/driver-sql": "^10.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,12 @@ importers:
       '@objectstack/cli':
         specifier: ^10.2.0
         version: 10.2.0(@aws-sdk/client-s3@3.984.0)(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(ai@6.0.208(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.11.1)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.3.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/cloud-connection':
+        specifier: ^10.2.0
+        version: 10.2.0(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(ai@6.0.208(zod@4.4.3))(better-call@1.3.6(zod@4.4.3))(better-sqlite3@12.11.1)(jose@6.2.3)(kysely@0.29.2)(mongodb@7.3.0)(nanostores@1.3.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@objectstack/console':
+        specifier: ^10.2.0
+        version: 10.2.0
       '@objectstack/core':
         specifier: ^10.2.0
         version: 10.2.0(ai@6.0.208(zod@4.4.3))


### PR DESCRIPTION
## ADR-0020 T1 — grow `@objectos/server` into the open-source self-host runtime

Makes `apps/objectos` a complete open-source self-host runtime distribution (marketplace client + Console SPA), per ADR-0020.

### What changed
- **`apps/objectos/package.json`** — pin two deps so the distribution explicitly carries them:
  - `@objectstack/console@^10.2.0` — the `/_console/` SPA
  - `@objectstack/cloud-connection@^10.2.0` — marketplace browse/install + cloud-connection + runtime-config
- **`apps/objectos/objectstack.config.ts`** — doc-only note (config stays a bare standalone stack).

### Key finding (why no explicit plugin wiring)
The `objectstack` CLI **already auto-provisions** the full self-host runtime on top of any standalone stack — every entry point (Docker, `dev`, and the ObjectOS One desktop via `one.mjs`) routes through `objectstack serve`, which injects the marketplace + cloud-connection + runtime-config plugins from `@objectstack/cloud-connection` (gated on `resolveCloudUrl()`; `OS_CLOUD_URL=off` → fully offline) and serves the `@objectstack/console` SPA at `/_console/`. Wiring those plugins explicitly in `objectstack.config.ts` would **double-mount**, so it's intentionally omitted (documented in the config; would only be needed if a future framework drops the CLI auto-injection — ADR-0006 Phase 4).

> Note: the original T1 spec said add `@object-ui/console@^7.0.0`; that package is no longer consulted by the CLI (canonical name is `@objectstack/console`, major must match the CLI). Corrected to `@objectstack/console@^10.2.0`.

### Verification
- `type-check` clean.
- **Online** (default cloud URL): `/_console/` SPA renders in a real browser (React mounts, zero console errors) · `/api/v1/marketplace/packages` returns the live catalog · `/api/v1/runtime/config` served.
- **Offline** (`OS_CLOUD_URL=off`): marketplace/cloud-connection/runtime-config unmounted, SPA still served, **zero outbound cloud calls**.
- Desktop (`apps/objectos-one` + `one.mjs`) untouched — kept per ADR-0020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)