### PR TITLE
docs: sync public docs with framework 8.0→10.2 changes

### DIFF
--- a/content/docs/build/views.de.mdx
+++ b/content/docs/build/views.de.mdx
@@ -67,7 +67,8 @@ view: {
 | `timeline` | Chronologischer Feed | `timeline: { startDateField, titleField }` |
 | `gantt` | Projektzeitachse + Abhängigkeiten | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | Geografische Pins | `map: { locationField }` |
-| `chart` | Eingebettetes Diagramm | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | Selbstreferenzierende Hierarchie | `tree: { parentField, labelField }` |
+| `chart` | Eingebettetes Diagramm | `chart: { chartType, dataset }` |
 
 ### Allgemeine List-Optionen
 
@@ -151,24 +152,38 @@ Bearbeitung.
 }
 ```
 
+### Tree
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+Für ein selbstreferenzierendes Objekt (Kategorien, Stücklisten, Organisationseinheiten, verschachtelte Kommentare) verschachtelt das Tree-Grid die Zeilen anhand ihres `parentField`-Zeigers.
+
 ### Chart (inline)
+
+Eine `chart`-Listenansicht bindet ein benanntes **Dataset** — die semantische Analyseschicht (ADR-0021) — und wählt dessen Dimensionen und Kennzahlen **per Name**. Definieren Sie eine Kennzahl einmal, und jedes Diagramm, Dashboard und jeder Report, der dasselbe Dataset bindet, bleibt konsistent:
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-Chart-Views sind für eingebettete Dashboards auf einem einzelnen Objekt
-gedacht — für umfangreichere, objektübergreifende Analysen verwenden Sie
-die dedizierte Reports-Oberfläche.
+Die Inline-Form `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` wurde in 9.0 entfernt — jedes Diagramm, Dashboard-Widget und jeder Report bindet jetzt ein Dataset. Für umfangreichere, objektübergreifende Analysen verwenden Sie die dedizierte Reports-Oberfläche.
 
 ## Form-View-Typen
 

--- a/content/docs/build/views.es.mdx
+++ b/content/docs/build/views.es.mdx
@@ -66,7 +66,8 @@ view: {
 | `timeline` | Feed cronológico | `timeline: { startDateField, titleField }` |
 | `gantt` | Cronograma de proyecto + dependencias | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | Pines geoespaciales | `map: { locationField }` |
-| `chart` | Gráfico incrustado | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | Jerarquía autorreferenciada | `tree: { parentField, labelField }` |
+| `chart` | Gráfico incrustado | `chart: { chartType, dataset }` |
 
 ### Opciones comunes de lista
 
@@ -147,23 +148,38 @@ agrupado — con las mismas reglas de permisos que una edición manual.
 }
 ```
 
+### Tree
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+Para un objeto autorreferenciado (categorías, listas de materiales, unidades organizativas, comentarios anidados) el tree-grid anida las filas según su puntero `parentField`.
+
 ### Chart (en línea)
+
+Una vista de lista `chart` vincula un **dataset** con nombre —la capa analítica semántica (ADR-0021)— y selecciona sus dimensiones y medidas **por nombre**. Define una métrica una vez y cada gráfico, panel e informe vinculado al mismo dataset se mantiene consistente:
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-Las vistas de gráfico son para paneles en línea sobre un único objeto — para
-analíticas más ricas y entre objetos, usa la superficie dedicada de informes.
+La forma en línea `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` se eliminó en 9.0 — cada gráfico, widget de panel e informe ahora vincula un dataset. Para analíticas más ricas y entre objetos, usa la superficie dedicada de informes.
 
 ## Tipos de vista de formulario
 

--- a/content/docs/build/views.fr.mdx
+++ b/content/docs/build/views.fr.mdx
@@ -66,7 +66,8 @@ view: {
 | `timeline` | Flux chronologique | `timeline: { startDateField, titleField }` |
 | `gantt` | Échéancier de projet + dépendances | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | Repères géospatiaux | `map: { locationField }` |
-| `chart` | Graphique intégré | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | Hiérarchie auto-référencée | `tree: { parentField, labelField }` |
+| `chart` | Graphique intégré | `chart: { chartType, dataset }` |
 
 ### Options de liste courantes
 
@@ -147,23 +148,38 @@ champ de regroupement — mêmes règles d'autorisation qu'une modification manu
 }
 ```
 
+### Arbre
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+Pour un objet auto-référencé (catégories, nomenclatures, unités organisationnelles, commentaires imbriqués), la grille arborescente imbrique les lignes selon leur pointeur `parentField`.
+
 ### Graphique (intégré)
+
+Une vue liste `chart` lie un **dataset** nommé — la couche analytique sémantique (ADR-0021) — et sélectionne ses dimensions et mesures **par leur nom**. Définissez une métrique une fois, et chaque graphique, tableau de bord et rapport lié au même dataset reste cohérent :
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-Les vues de graphique servent aux tableaux de bord intégrés sur un seul objet —
-pour des analyses plus riches et inter-objets, utilisez la surface de rapports dédiée.
+La forme en ligne `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` a été supprimée en 9.0 — chaque graphique, widget de tableau de bord et rapport lie désormais un dataset. Pour des analyses plus riches et inter-objets, utilisez la surface de rapports dédiée.
 
 ## Types de vues de formulaire
 

--- a/content/docs/build/views.ja.mdx
+++ b/content/docs/build/views.ja.mdx
@@ -65,7 +65,8 @@ view: {
 | `timeline` | 時系列フィード | `timeline: { startDateField, titleField }` |
 | `gantt` | プロジェクトタイムライン + 依存関係 | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | 地理空間ピン | `map: { locationField }` |
-| `chart` | 埋め込みチャート | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | 自己参照型の階層 | `tree: { parentField, labelField }` |
+| `chart` | 埋め込みチャート | `chart: { chartType, dataset }` |
 
 ### 共通のリストオプション
 
@@ -146,23 +147,38 @@ view: {
 }
 ```
 
+### ツリー
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+自己参照型のオブジェクト（カテゴリ、部品表、組織単位、入れ子のコメント）では、ツリーグリッドが `parentField` ポインタに従って行を入れ子にします。
+
 ### チャート（インライン）
+
+`chart` リストビューは、名前付きの **dataset**（セマンティック分析レイヤー、ADR-0021）をバインドし、そのディメンションとメジャーを**名前で**選択します。メトリックを一度定義すれば、同じ dataset をバインドするすべてのチャート、ダッシュボード、レポートが一貫します。
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-チャートビューは、単一オブジェクト上のインラインダッシュボード向けです。より高度な
-オブジェクト横断分析には、専用のレポート画面を使用してください。
+インラインの `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` の形式は 9.0 で削除されました。すべてのチャート、ダッシュボードウィジェット、レポートは現在 dataset をバインドします。より高度なオブジェクト横断分析には、専用のレポート画面を使用してください。
 
 ## フォームビューの種類
 

--- a/content/docs/build/views.ko.mdx
+++ b/content/docs/build/views.ko.mdx
@@ -65,7 +65,8 @@ view: {
 | `timeline` | 시간순 피드 | `timeline: { startDateField, titleField }` |
 | `gantt` | 프로젝트 타임라인 + 의존성 | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | 지리공간 핀 | `map: { locationField }` |
-| `chart` | 임베드 차트 | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | 자기 참조 계층 | `tree: { parentField, labelField }` |
+| `chart` | 임베드 차트 | `chart: { chartType, dataset }` |
 
 ### 공통 list 옵션
 
@@ -146,23 +147,38 @@ view: {
 }
 ```
 
+### Tree
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+자기 참조 오브젝트(카테고리, BOM, 조직 단위, 중첩 댓글)의 경우 tree-grid는 `parentField` 포인터에 따라 행을 중첩합니다.
+
 ### Chart (인라인)
+
+`chart` 리스트 뷰는 이름이 지정된 **dataset**(시맨틱 분석 레이어, ADR-0021)을 바인딩하고 그 디멘션과 측정값을 **이름으로** 선택합니다. 메트릭을 한 번 정의하면 동일한 dataset을 바인딩하는 모든 차트, 대시보드, 리포트가 일관되게 유지됩니다:
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-Chart 뷰는 단일 오브젝트의 인라인 대시보드를 위한 것입니다 — 더 풍부한
-오브젝트 간 분석을 위해서는 전용 reports 표면을 사용하세요.
+인라인 `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` 형식은 9.0에서 제거되었습니다 — 모든 차트, 대시보드 위젯, 리포트는 이제 dataset을 바인딩합니다. 더 풍부한 오브젝트 간 분석을 위해서는 전용 reports 표면을 사용하세요.
 
 ## Form 뷰 타입
 

--- a/content/docs/build/views.mdx
+++ b/content/docs/build/views.mdx
@@ -65,7 +65,8 @@ view: {
 | `timeline` | Chronological feed | `timeline: { startDateField, titleField }` |
 | `gantt` | Project timeline + dependencies | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | Geospatial pins | `map: { locationField }` |
-| `chart` | Embedded chart | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | Self-referencing hierarchy | `tree: { parentField, labelField }` |
+| `chart` | Embedded chart | `chart: { chartType, dataset }` |
 
 ### Common list options
 
@@ -146,23 +147,44 @@ field — same permission rules as a manual edit.
 }
 ```
 
+### Tree
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+For a self-referencing object (categories, BOMs, org units, nested
+comments) the tree-grid nests rows by their `parentField` pointer.
+
 ### Chart (inline)
+
+A `chart` list view binds a named **dataset** — the semantic analytics layer
+(ADR-0021) — and selects its dimensions and measures **by name**. Define a
+metric once and every chart, dashboard, and report bound to the same dataset
+stays consistent:
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-Chart views are for inline dashboards on a single object — for richer,
-cross-object analytics use the dedicated reports surface.
+The inline `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` shape
+was removed in 9.0 — every chart, dashboard widget, and report now binds a
+dataset. For richer, cross-object analytics use the dedicated reports surface.
 
 ## Form view types
 

--- a/content/docs/build/views.zh-Hans.mdx
+++ b/content/docs/build/views.zh-Hans.mdx
@@ -59,7 +59,8 @@ view: {
 | `timeline` | 按时间顺序的 feed | `timeline: { dateField, titleField }` |
 | `gantt` | 项目时间线 + 依赖 | `gantt: { startDateField, endDateField, titleField }` |
 | `map` | 地理 pin | `map: { locationField }` |
-| `chart` | 嵌入式图表 | `chart: { chartType, xAxisField, yAxisFields }` |
+| `tree` | 自引用层级 | `tree: { parentField, labelField }` |
+| `chart` | 嵌入式图表 | `chart: { chartType, dataset }` |
 
 ### 通用 list 选项
 
@@ -141,22 +142,38 @@ view: {
 }
 ```
 
+### Tree
+
+```ts
+{
+  type: 'tree',
+  tree: {
+    parentField: 'parent_id',                // self-lookup that builds the hierarchy
+    labelField:  'name',                     // shown indented in the first column
+    defaultExpandedDepth: 1                   // optional — 0 = roots only, omit = expand all
+  }
+}
+```
+
+对于自引用对象(分类、BOM、组织单元、嵌套评论),树形表格会按 `parentField` 指针把行嵌套展示。
+
 ### Chart(内联)
+
+`chart` 列表视图绑定一个具名 **dataset**(语义分析层,ADR-0021),并**按名称**选择它的维度和度量。度量只定义一次,绑定同一个 dataset 的每个图表、仪表板和报表都保持一致:
 
 ```ts
 {
   type: 'chart',
   chart: {
-    chartType: 'bar',                        // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
-    xAxisField:  'created_at',
-    yAxisFields: ['amount'],
-    aggregation: 'sum',
-    groupByField: 'status'
+    chartType:  'bar',                       // 'bar' | 'line' | 'pie' | 'area' | 'scatter'
+    dataset:    'tickets_by_status',         // a dataset declared with defineDataset(...)
+    dimensions: ['status'],                  // dataset dimension name(s) — X / group / split
+    values:     ['ticket_count']             // dataset measure name(s) — the value axis
   }
 }
 ```
 
-完整的报表请用 [Reports](/docs/build/reports) 表面 —— chart 视图用于对象的内联仪表板。
+内联的 `xAxisField` / `yAxisFields` / `aggregation` / `groupByField` 形式已在 9.0 中移除 —— 现在每个图表、仪表板小组件和报表都绑定 dataset。完整的跨对象分析请使用专用的 reports 表面。
 
 ## Form 视图类型
 

--- a/content/docs/configure/ai.de.mdx
+++ b/content/docs/configure/ai.de.mdx
@@ -166,7 +166,7 @@ IDEs, eigene Agents) über das offene [Model Context
 Protocol](https://modelcontextprotocol.io) bereitstellen.
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.es.mdx
+++ b/content/docs/configure/ai.es.mdx
@@ -167,7 +167,7 @@ agentes de IA (Claude Desktop, IDEs, agentes personalizados) a través del
 [Model Context Protocol](https://modelcontextprotocol.io) abierto.
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.fr.mdx
+++ b/content/docs/configure/ai.fr.mdx
@@ -168,7 +168,7 @@ Desktop, IDE, agents personnalisés) via le [Model Context
 Protocol](https://modelcontextprotocol.io) ouvert.
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.ja.mdx
+++ b/content/docs/configure/ai.ja.mdx
@@ -136,7 +136,7 @@ kernel.use(new KnowledgeRagflowPlugin({
 ObjectOS は、オープンな [Model Context Protocol](https://modelcontextprotocol.io) を介して、AI エージェント（Claude Desktop、IDE、カスタムエージェント）に対してツールサーバーとして自身を公開できます。
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.ko.mdx
+++ b/content/docs/configure/ai.ko.mdx
@@ -136,7 +136,7 @@ kernel.use(new KnowledgeRagflowPlugin({
 ObjectOS는 개방형 [Model Context Protocol](https://modelcontextprotocol.io)을 통해 자신을 AI 에이전트(Claude Desktop, IDE, 사용자 정의 에이전트)에 대한 도구 서버로 노출할 수 있습니다.
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.mdx
+++ b/content/docs/configure/ai.mdx
@@ -165,7 +165,7 @@ Desktop, IDEs, custom agents) via the open [Model Context
 Protocol](https://modelcontextprotocol.io).
 
 ```ts
-import { MCPServerPlugin } from '@objectstack/plugin-mcp-server';
+import { MCPServerPlugin } from '@objectstack/mcp';
 
 kernel.use(new MCPServerPlugin({
   transport: 'stdio', // or 'http'

--- a/content/docs/configure/ai.zh-Hans.mdx
+++ b/content/docs/configure/ai.zh-Hans.mdx
@@ -152,7 +152,7 @@ new TursoKnowledgePlugin({
 ObjectOS 可以通过开放的 [Model Context Protocol](https://modelcontextprotocol.io) 把自己作为工具服务器暴露给 AI Agent（Claude Desktop、IDE、自定义 Agent）。
 
 ```ts
-import { McpServerPlugin } from '@objectstack/plugin-mcp-server';
+import { McpServerPlugin } from '@objectstack/mcp';
 
 new McpServerPlugin({
   // expose specific objects + actions as MCP tools

--- a/content/docs/configure/permissions/index.de.mdx
+++ b/content/docs/configure/permissions/index.de.mdx
@@ -43,7 +43,7 @@ wichtigsten davon:
 | `sys_user` | Eine Person oder ein Dienstkonto, das sich authentifizieren kann |
 | `sys_organization` | Mandanten-/Workspace-Grenze (mandantenfähige Apps) |
 | `sys_member` | Die Mitgliedschaft eines Benutzers in einer Organisation (Rolle pro Mitgliedschaft zugewiesen) |
-| `sys_department`, `sys_team` | Optionale Organisationsstruktur für Freigaberegeln |
+| `sys_business_unit`, `sys_team` | Optionale Organisationsstruktur für Freigaberegeln |
 | `sys_invitation` | Ausstehende Einladung, die auf Annahme wartet |
 | `sys_session` | Aktive authentifizierte Sitzung |
 | `sys_api_key` | Langlebige programmatische Anmeldeinformationen, die an einen Benutzer gebunden sind |

--- a/content/docs/configure/permissions/index.es.mdx
+++ b/content/docs/configure/permissions/index.es.mdx
@@ -39,7 +39,7 @@ Los objetos de identidad residen en la base de datos de tu proyecto. Los más im
 | `sys_user` | Una persona o cuenta de servicio que puede autenticarse |
 | `sys_organization` | Límite de inquilino / espacio de trabajo (aplicaciones multiinquilino) |
 | `sys_member` | La pertenencia de un usuario a una organización (rol asignado por pertenencia) |
-| `sys_department`, `sys_team` | Estructura organizativa opcional para las reglas de uso compartido |
+| `sys_business_unit`, `sys_team` | Estructura organizativa opcional para las reglas de uso compartido |
 | `sys_invitation` | Invitación pendiente a la espera de ser aceptada |
 | `sys_session` | Sesión autenticada activa |
 | `sys_api_key` | Credencial programática de larga duración vinculada a un usuario |

--- a/content/docs/configure/permissions/index.fr.mdx
+++ b/content/docs/configure/permissions/index.fr.mdx
@@ -43,7 +43,7 @@ Les plus importants :
 | `sys_user` | Une personne ou un compte de service pouvant s'authentifier |
 | `sys_organization` | Limite de locataire / espace de travail (applications multi-locataires) |
 | `sys_member` | L'appartenance d'un utilisateur à une organisation (rôle attribué par appartenance) |
-| `sys_department`, `sys_team` | Structure organisationnelle facultative pour les règles de partage |
+| `sys_business_unit`, `sys_team` | Structure organisationnelle facultative pour les règles de partage |
 | `sys_invitation` | Invitation en attente d'acceptation |
 | `sys_session` | Session authentifiée active |
 | `sys_api_key` | Identifiant programmatique de longue durée lié à un utilisateur |

--- a/content/docs/configure/permissions/index.ja.mdx
+++ b/content/docs/configure/permissions/index.ja.mdx
@@ -34,7 +34,7 @@ Field security       For those records, which FIELDS are readable / writable?
 | `sys_user` | 認証可能な個人またはサービスアカウント |
 | `sys_organization` | テナント / ワークスペースの境界（マルチテナントアプリ向け） |
 | `sys_member` | 組織におけるユーザーのメンバーシップ（ロールはメンバーシップごとに割り当てられる） |
-| `sys_department`、`sys_team` | シェアルール向けの任意の組織構造 |
+| `sys_business_unit`、`sys_team` | シェアルール向けの任意の組織構造 |
 | `sys_invitation` | 承諾待ちの保留中の招待 |
 | `sys_session` | アクティブな認証済みセッション |
 | `sys_api_key` | ユーザーに紐づく長期間有効なプログラム用の認証情報 |

--- a/content/docs/configure/permissions/index.ko.mdx
+++ b/content/docs/configure/permissions/index.ko.mdx
@@ -34,7 +34,7 @@ Field security       For those records, which FIELDS are readable / writable?
 | `sys_user` | 인증할 수 있는 사람 또는 서비스 계정 |
 | `sys_organization` | 테넌트 / 워크스페이스 경계(멀티테넌트 앱) |
 | `sys_member` | 조직 내 사용자의 멤버십(역할은 멤버십 단위로 할당됨) |
-| `sys_department`, `sys_team` | 공유 규칙을 위한 선택적 조직 구조 |
+| `sys_business_unit`, `sys_team` | 공유 규칙을 위한 선택적 조직 구조 |
 | `sys_invitation` | 수락을 기다리는 대기 중인 초대 |
 | `sys_session` | 활성 인증 세션 |
 | `sys_api_key` | 사용자에 바인딩된 장기 프로그래밍 자격 증명 |

--- a/content/docs/configure/permissions/index.mdx
+++ b/content/docs/configure/permissions/index.mdx
@@ -39,7 +39,7 @@ Identity objects live in your project database. The most important ones:
 | `sys_user` | A person or service account that can authenticate |
 | `sys_organization` | Tenant / workspace boundary (multi-tenant apps) |
 | `sys_member` | A user's membership in an organization (role assigned per membership) |
-| `sys_department`, `sys_team` | Optional org structure for sharing rules |
+| `sys_business_unit`, `sys_team` | Optional org structure for sharing rules |
 | `sys_invitation` | Pending invite waiting to be accepted |
 | `sys_session` | Active authenticated session |
 | `sys_api_key` | Long-lived programmatic credential bound to a user |

--- a/content/docs/configure/permissions/index.zh-Hans.mdx
+++ b/content/docs/configure/permissions/index.zh-Hans.mdx
@@ -34,7 +34,7 @@ Field security       For those records, which FIELDS are readable / writable?
 | `sys_user` | 一个能认证的人或服务账号 |
 | `sys_org` | 租户/工作空间边界（多租户应用） |
 | `sys_member` | 用户在某组织内的成员资格（按成员资格分配角色） |
-| `sys_department`、`sys_team` | 可选的组织结构，用于共享规则 |
+| `sys_business_unit`、`sys_team` | 可选的组织结构，用于共享规则 |
 | `sys_invitation` | 待接受的邀请 |
 | `sys_session` | 已认证的活动会话 |
 | `sys_api_key` | 绑定到用户的长期编程凭据 |

--- a/content/docs/resources/faq.de.mdx
+++ b/content/docs/resources/faq.de.mdx
@@ -125,7 +125,7 @@ eingehende Kommunikation. Native Konnektoren für gängige iPaaS-Tools
 sind auf der Roadmap.
 
 **F: Können KI-Agenten mein ObjectOS aufrufen?**
-A: Ja, über MCP (`@objectstack/plugin-mcp-server`) — stellt Objekte
+A: Ja, über MCP (`@objectstack/mcp`) — stellt Objekte
 und Aktionen als MCP-Tools bereit, die Claude Desktop, IDEs oder andere
 MCP-Clients verwenden können. Siehe [AI Service](/docs/configure/ai).
 

--- a/content/docs/resources/faq.es.mdx
+++ b/content/docs/resources/faq.es.mdx
@@ -120,7 +120,7 @@ entrada. Los conectores nativos para herramientas iPaaS populares están
 en la hoja de ruta.
 
 **P: ¿Pueden los agentes de IA llamar a mi ObjectOS?**
-R: Sí, mediante MCP (`@objectstack/plugin-mcp-server`) — expone objetos
+R: Sí, mediante MCP (`@objectstack/mcp`) — expone objetos
 y acciones como herramientas MCP que Claude Desktop, los IDE u otros
 clientes MCP pueden usar. Consulta [AI Service](/docs/configure/ai).
 

--- a/content/docs/resources/faq.fr.mdx
+++ b/content/docs/resources/faq.fr.mdx
@@ -126,7 +126,7 @@ l'entrant. Des connecteurs natifs pour les outils iPaaS populaires sont
 dans la feuille de route.
 
 **Q : Les agents IA peuvent-ils appeler mon ObjectOS ?**
-R : Oui, via MCP (`@objectstack/plugin-mcp-server`) — il expose les objets
+R : Oui, via MCP (`@objectstack/mcp`) — il expose les objets
 et les actions comme des outils MCP que Claude Desktop, les IDE ou d'autres
 clients MCP peuvent utiliser. Voir [Service IA](/docs/configure/ai).
 

--- a/content/docs/resources/faq.ja.mdx
+++ b/content/docs/resources/faq.ja.mdx
@@ -120,7 +120,7 @@ A: はい。アウトバウンドには Webhook、インバウンドには REST 
 あります。
 
 **Q: AI エージェントは私の ObjectOS を呼び出せますか?**
-A: はい、MCP(`@objectstack/plugin-mcp-server`)経由で可能です。オブジェクトや
+A: はい、MCP(`@objectstack/mcp`)経由で可能です。オブジェクトや
 アクションを MCP ツールとして公開し、Claude Desktop、IDE、その他の MCP
 クライアントが利用できます。[AI Service](/docs/configure/ai)を参照してください。
 

--- a/content/docs/resources/faq.ko.mdx
+++ b/content/docs/resources/faq.ko.mdx
@@ -112,7 +112,7 @@ A: 예 — 아웃바운드는 웹훅으로, 인바운드는 REST API + API 키�
 인기 있는 iPaaS 도구를 위한 네이티브 커넥터는 로드맵에 있습니다.
 
 **Q: AI 에이전트가 제 ObjectOS를 호출할 수 있나요?**
-A: 예, MCP(`@objectstack/plugin-mcp-server`)를 통해 가능합니다 — 객체와
+A: 예, MCP(`@objectstack/mcp`)를 통해 가능합니다 — 객체와
 액션을 Claude Desktop, IDE 또는 기타 MCP
 클라이언트가 사용할 수 있는 MCP 도구로 노출합니다. [AI Service](/docs/configure/ai)를 참고하세요.
 

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -112,7 +112,7 @@ A: Yes — webhooks for outbound and the REST API + API keys for inbound.
 Native connectors for popular iPaaS tools are on the roadmap.
 
 **Q: Can AI agents call my ObjectOS?**
-A: Yes, via MCP (`@objectstack/plugin-mcp-server`) — exposes objects
+A: Yes, via MCP (`@objectstack/mcp`) — exposes objects
 and actions as MCP tools that Claude Desktop, IDEs, or other MCP
 clients can use. See [AI Service](/docs/configure/ai).
 

--- a/content/docs/resources/faq.zh-Hans.mdx
+++ b/content/docs/resources/faq.zh-Hans.mdx
@@ -105,7 +105,7 @@ A：可以 —— 出站走 webhook，入站走 REST API + API key。主流 iPaa
 的原生连接器在路线图中。
 
 **Q：AI 智能体能调用我的 ObjectOS 吗？**
-A：可以，通过 MCP（`@objectstack/plugin-mcp-server`） —— 把对象与
+A：可以，通过 MCP（`@objectstack/mcp`） —— 把对象与
 action 暴露为 MCP 工具，供 Claude Desktop、IDE 或其他 MCP 客户端
 使用。见 [AI 服务](/docs/configure/ai)。
 

--- a/content/docs/resources/glossary.de.mdx
+++ b/content/docs/resources/glossary.de.mdx
@@ -129,7 +129,7 @@ Paket-Registry. Siehe [Marketplace](/docs/build/marketplace).
 
 Ein offenes Protokoll, mit dem KI-Agenten Werkzeuge entdecken und aufrufen können.
 ObjectOS kann seine Objekte + Actions über
-`@objectstack/plugin-mcp-server` als MCP bereitstellen.
+`@objectstack/mcp` als MCP bereitstellen.
 
 ### Object
 
@@ -169,7 +169,7 @@ Autorisierungseinheit. Siehe [Permissions](/docs/configure/permissions).
 
 Ein Framework-Paket, das die Laufzeitumgebung um eine Capability erweitert —
 `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-webhooks`,
-`plugin-mcp-server` usw. Wird über DI + Lifecycle-Hooks aktiviert
+`mcp` usw. Wird über DI + Lifecycle-Hooks aktiviert
 (`init → start → destroy`).
 
 ### Project

--- a/content/docs/resources/glossary.es.mdx
+++ b/content/docs/resources/glossary.es.mdx
@@ -130,7 +130,7 @@ de paquetes configurable. Consulta [Marketplace](/docs/build/marketplace).
 
 Un protocolo abierto para que los agentes de IA descubran e invoquen
 herramientas. ObjectOS puede exponer sus objetos + acciones como MCP mediante
-`@objectstack/plugin-mcp-server`.
+`@objectstack/mcp`.
 
 ### Object
 
@@ -170,7 +170,7 @@ unidad principal de autorización. Consulta [Permissions](/docs/configure/permis
 
 Un paquete del framework que extiende el runtime con una capability —
 `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-webhooks`,
-`plugin-mcp-server`, etc. Activado mediante DI + hooks de ciclo de vida
+`mcp`, etc. Activado mediante DI + hooks de ciclo de vida
 (`init → start → destroy`).
 
 ### Project

--- a/content/docs/resources/glossary.fr.mdx
+++ b/content/docs/resources/glossary.fr.mdx
@@ -129,7 +129,7 @@ packages configurable. Voir [Marketplace](/docs/build/marketplace).
 
 Un protocole ouvert permettant aux agents IA de découvrir et d'appeler des outils.
 ObjectOS peut exposer ses objets + actions en tant que MCP via
-`@objectstack/plugin-mcp-server`.
+`@objectstack/mcp`.
 
 ### Object
 
@@ -169,7 +169,7 @@ principale. Voir [Permissions](/docs/configure/permissions).
 
 Un package du framework qui étend le runtime avec une capability —
 `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-webhooks`,
-`plugin-mcp-server`, etc. Activé via DI + hooks de cycle de vie
+`mcp`, etc. Activé via DI + hooks de cycle de vie
 (`init → start → destroy`).
 
 ### Project

--- a/content/docs/resources/glossary.ja.mdx
+++ b/content/docs/resources/glossary.ja.mdx
@@ -85,7 +85,7 @@ Artifact の先頭にあるトップレベルのメタデータ: `id`、`namespa
 
 ### MCP (Model Context Protocol)
 
-AI エージェントがツールを検出して呼び出すためのオープンプロトコル。ObjectOS は `@objectstack/plugin-mcp-server` を介して、オブジェクト + アクションを MCP として公開できます。
+AI エージェントがツールを検出して呼び出すためのオープンプロトコル。ObjectOS は `@objectstack/mcp` を介して、オブジェクト + アクションを MCP として公開できます。
 
 ### Object
 
@@ -113,7 +113,7 @@ AI エージェントがツールを検出して呼び出すためのオープ�
 
 ### Plugin
 
-ランタイムをある機能で拡張するフレームワークパッケージ — `plugin-auth`、`plugin-security`、`plugin-audit`、`plugin-webhooks`、`plugin-mcp-server` など。DI + ライフサイクルフック（`init → start → destroy`）を介して有効化されます。
+ランタイムをある機能で拡張するフレームワークパッケージ — `plugin-auth`、`plugin-security`、`plugin-audit`、`plugin-webhooks`、`mcp` など。DI + ライフサイクルフック（`init → start → destroy`）を介して有効化されます。
 
 ### Project
 

--- a/content/docs/resources/glossary.ko.mdx
+++ b/content/docs/resources/glossary.ko.mdx
@@ -127,7 +127,7 @@ Object의 형식 지정 속성입니다. 약 48개의 기본 제공 타입: `tex
 ### MCP (Model Context Protocol)
 
 AI 에이전트가 도구를 검색하고 호출하기 위한 개방형 프로토콜입니다.
-ObjectOS는 `@objectstack/plugin-mcp-server`를 통해 자신의 객체 + 액션을
+ObjectOS는 `@objectstack/mcp`를 통해 자신의 객체 + 액션을
 MCP로 노출할 수 있습니다.
 
 ### Object
@@ -168,7 +168,7 @@ marketplace. 때때로 "플랫폼"이라고 불립니다.
 
 런타임을 하나의 기능으로 확장하는 프레임워크 패키지입니다 —
 `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-webhooks`,
-`plugin-mcp-server` 등. DI + 수명 주기 훅
+`mcp` 등. DI + 수명 주기 훅
 (`init → start → destroy`)을 통해 활성화됩니다.
 
 ### Project

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -129,7 +129,7 @@ package registry. See [Marketplace](/docs/build/marketplace).
 
 An open protocol for AI agents to discover and call tools.
 ObjectOS can expose its objects + actions as MCP via
-`@objectstack/plugin-mcp-server`.
+`@objectstack/mcp`.
 
 ### Object
 
@@ -169,7 +169,7 @@ authorization unit. See [Permissions](/docs/configure/permissions).
 
 A framework package that extends the runtime with a capability —
 `plugin-auth`, `plugin-security`, `plugin-audit`, `plugin-webhooks`,
-`plugin-mcp-server`, etc. Activated via DI + lifecycle hooks
+`mcp`, etc. Activated via DI + lifecycle hooks
 (`init → start → destroy`).
 
 ### Project

--- a/content/docs/resources/glossary.zh-Hans.mdx
+++ b/content/docs/resources/glossary.zh-Hans.mdx
@@ -116,7 +116,7 @@ Console 内可安装应用的目录。背后由可配置的包注册中心支持
 ### MCP（Model Context Protocol）
 
 一个开放协议，让 AI 智能体发现并调用工具。ObjectOS 可以通过
-`@objectstack/plugin-mcp-server` 把对象 + action 暴露为 MCP。
+`@objectstack/mcp` 把对象 + action 暴露为 MCP。
 
 ### Object（对象）
 
@@ -153,7 +153,7 @@ Console 渲染 ObjectUI 声明。
 ### Plugin（插件）
 
 为运行时扩展能力的框架包 —— `plugin-auth`、`plugin-security`、
-`plugin-audit`、`plugin-webhooks`、`plugin-mcp-server` 等。通过
+`plugin-audit`、`plugin-webhooks`、`mcp` 等。通过
 DI + 生命周期 Hook（`init → start → destroy`）激活。
 
 ### Project

--- a/content/docs/resources/support.de.mdx
+++ b/content/docs/resources/support.de.mdx
@@ -22,7 +22,7 @@ description: Wo Sie Hilfe erhalten, wie Sie Fehler melden, welche Reaktionszeite
 Die 30-Sekunden-Variante:
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.es.mdx
+++ b/content/docs/resources/support.es.mdx
@@ -22,7 +22,7 @@ description: Dónde obtener ayuda, cómo reportar errores y qué esperar en cuan
 La versión de 30 segundos:
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.fr.mdx
+++ b/content/docs/resources/support.fr.mdx
@@ -22,7 +22,7 @@ description: O√π obtenir de l'aide, comment signaler des bugs, attentes en mati√
 La version en 30 secondes :
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.ja.mdx
+++ b/content/docs/resources/support.ja.mdx
@@ -22,7 +22,7 @@ description: ヘルプの入手先、バグの報告方法、応答時間の目�
 30 秒で済むテンプレート:
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.ko.mdx
+++ b/content/docs/resources/support.ko.mdx
@@ -22,7 +22,7 @@ description: 도움을 받을 수 있는 곳, 버그 신고 방법, 응답 기�
 30초 버전:
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.mdx
+++ b/content/docs/resources/support.mdx
@@ -22,7 +22,7 @@ description: Where to get help, how to report bugs, response expectations.
 The 30-second version:
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo

--- a/content/docs/resources/support.zh-Hans.mdx
+++ b/content/docs/resources/support.zh-Hans.mdx
@@ -22,7 +22,7 @@ description: 到哪里寻求帮助、如何上报 bug、响应预期。
 30 秒版本：
 
 ```text
-ObjectOS version:           4.0.4 (or sha-abc123)
+ObjectOS version:           10.2.0 (or sha-abc123)
 Node version:               22.4.0
 Install method:             docker / npm -g / source
 Database:                   postgres 16 / sqlite / turso / mongo


### PR DESCRIPTION
## What

Brings the ObjectOS public docs in line with upstream `@objectstack` changes from **8.0 → 10.2.0**. This is a targeted staleness fix (not a wholesale sync) — every item was verified against the framework source.

| Fix | Source version | Pages (EN + 6 locales) |
|---|---|---|
| Inline chart example → **dataset-bound model** (`xAxisField`/`yAxisFields`/`aggregation`/`groupByField` removed from `ListChart` in 9.0) | 9.0 (ADR-0021) | `build/views` |
| Add the new **`tree`** list view type | 9.9/10.0 | `build/views` |
| MCP package **`@objectstack/plugin-mcp-server` → `@objectstack/mcp`** (export `MCPServerPlugin` unchanged) | 8.0 | `configure/ai`, `resources/faq`, `resources/glossary` |
| System object **`sys_department` → `sys_business_unit`** (renamed, no alias) | 10.0 (ADR-0057) | `configure/permissions/index` |
| Version example **`4.0.4` → `10.2.0`** | — | `resources/support` |

## Scope

- **42 files** = 6 pages × (English source + 6 locales: de/es/fr/ja/ko/zh-Hans).
- Code fences are byte-identical across locales; prose deltas were translated per locale.
- Verified: no stale chart code remains in any `views.*.mdx`; `xAxisField` now appears only in the explanatory "removed in 9.0" note.

## Deliberately left alone

`resources/changelog.mdx`'s `/f/:slug` public-form route — it documents the Console front-end FormPage route (distinct from the REST `/api/v1/forms/:slug/submit` endpoint); the objectui front-end isn't in this repo to disprove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)