### PR TITLE
docs(cli): remove legacy os publish / os rollback from CLI reference

### DIFF
--- a/content/docs/reference/cli.de.mdx
+++ b/content/docs/reference/cli.de.mdx
@@ -159,8 +159,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## Umgebungs-Befehle

--- a/content/docs/reference/cli.es.mdx
+++ b/content/docs/reference/cli.es.mdx
@@ -160,8 +160,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## Comandos de entorno

--- a/content/docs/reference/cli.fr.mdx
+++ b/content/docs/reference/cli.fr.mdx
@@ -160,8 +160,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## Commandes d'environnement

--- a/content/docs/reference/cli.ja.mdx
+++ b/content/docs/reference/cli.ja.mdx
@@ -160,8 +160,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## 環境コマンド

--- a/content/docs/reference/cli.ko.mdx
+++ b/content/docs/reference/cli.ko.mdx
@@ -159,8 +159,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # publish artifact as a versioned package
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## 환경 명령어

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -164,8 +164,6 @@ os package install <id|file>  # install into a RUNNING runtime: catalog id
                               # (com.acme.crm) or a compiled artifact JSON
                               # (air-gapped, inline). --runtime / --email /
                               # --password identify the runtime to install into
-os publish                    # publish to ObjectStack Cloud
-os rollback <revision>        # activate a previous artifact revision
 ```
 
 ## Environment commands

--- a/content/docs/reference/cli.zh-Hans.mdx
+++ b/content/docs/reference/cli.zh-Hans.mdx
@@ -149,8 +149,6 @@ os cloud login | logout | whoami
 
 ```bash
 os package publish            # 将 artifact 作为版本化包发布
-os publish                    # 发布到 ObjectStack Cloud
-os rollback <revision>        # 激活之前的 artifact 版本
 ```
 
 ## 环境命令


### PR DESCRIPTION
## What

Removes the legacy `os publish` and `os rollback` entries from the CLI reference page across all locales (en, zh-Hans, de, es, fr, ja, ko). Keeps `os package publish`.

## Why

`os publish` / `os rollback` are the **legacy direct-to-environment** publish flow (write/activate `sys_environment_revision`). They are superseded by the **versioned-package** flow `os package publish`. The reference listed both side-by-side without marking the old pair as legacy, which was confusing. The legacy commands are being removed from the CLI itself (see the companion framework PR), so they should no longer appear in the docs.

## Notes

- Powers the live site https://docs.objectos.ai — effective once merged & deployed.
- Other docs already only reference `os package publish`; left untouched.
- Companion CLI change: objectstack-ai/framework removing the actual commands.