### PR TITLE
docs: editions table -> deployment-agnostic per-AI-seat

### DIFF
--- a/content/docs/resources/license.mdx
+++ b/content/docs/resources/license.mdx
@@ -44,17 +44,17 @@ ObjectOS is **open core**. The open-source runtime is the complete *mechanism*
 for building and running business applications; the commercial editions layer on
 hosted *intelligence*, operational scale, and governance.
 
-| | **Community** | **Enterprise** | **Cloud** |
+| | **Community** | **Self-host (licensed)** | **Cloud** |
 |---|---|---|---|
-| Delivery | self-host | self-host (licensed) | fully hosted |
+| Delivery | self-host, free | self-host, paid | fully hosted |
 | License | Apache-2.0 | commercial | — (SaaS) |
-| Price | **Free, forever** | per-seat + per-node | **per AI seat** ($24 / $54) |
+| Price | **Free, forever** | **per AI seat** (BYO model) | **per AI seat** ($24 / $54, credits included) |
 | Build & run apps; real DB tables, RBAC, row/field security, flows, interfaces, REST/ObjectQL | ✓ | ✓ | ✓ |
 | **AI via MCP** — point your own Claude Code / MCP client at your data | ✓ | ✓ | ✓ |
 | **In-UI AI** — hosted AI Builder + "ask your data" assistant | — | ✓ | ✓ |
-| Clustering / HA / multi-node, data residency / air-gap | — | ✓ | managed |
-| SSO/SCIM at scale, compliance attestations (SOC 2 report / ISO image), advanced governance | — | ✓ | by plan |
-| Support | community | SLA + dedicated | by plan |
+| Clustering / HA / multi-node, data residency / air-gap | — | ✓ (Enterprise) | managed |
+| SSO/SCIM at scale, compliance attestations (SOC 2 report / ISO image), advanced governance | — | ✓ (Enterprise) | by plan |
+| Support | community | by plan / SLA | by plan |
 
 **Open mechanism, closed intelligence.** Everything you need to model data and
 run apps is open-source and free. The *hosted AI* — the in-product AI Builder and
@@ -63,9 +63,16 @@ Community Edition your AI path is the open **MCP server**: point your own Claude
 Code (or any MCP client) at your deployment and it can query and operate your data
 with your own model — no platform AI bill.
 
-**You pay only for AI seats.** On the paid Cloud plans the only billed seat is the
-**AI seat** — viewers and non-AI users are free, with no per-user seat tax (a clean
-contrast to the $150–300/user incumbents).
+**You pay only for AI seats.** On the paid plans — **cloud or self-hosted** — the
+only billed seat is the **AI seat**; viewers and non-AI users are free, with no
+per-user seat tax (a clean contrast to the $150–300/user incumbents).
+
+**Same price, your choice of deployment.** The paid plans (Team / Business /
+Enterprise) run **either** in our cloud **or** self-hosted on your own
+infrastructure, at the **same per-AI-seat price**. The only difference is who runs
+the model: in the cloud we bundle AI credits; self-hosted, you **bring your own
+model / key** (and pay your own LLM cost) as a **license — offline-payable**.
+There is **no per-node charge** — clustering / HA is an Enterprise-tier feature.
 
 ## When you might want a commercial edition
 


### PR DESCRIPTION
Same per-AI-seat price whether self-hosted (license + BYO model, offline-payable) or cloud (credits included); relabel 'Enterprise' column -> 'Self-host (licensed)', drop the per-node charge (clustering = Enterprise-tier feature), note paid plans (cloud or self-host) bill only AI seats. Aligns with ADR-0023 / cloud#490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)