### PR TITLE
docs: align public docs with commercial-only positioning and new pricing (ADR-0085)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ repository. There is no open-source edition of ObjectOS.
 
 ## Editions
 
-| Edition | Delivery | For |
-|:---|:---|:---|
-| **ObjectOS Cloud** | Managed service | Organizations that want the platform operated for them — orgs, environments, deploys, billing. |
-| **ObjectOS Enterprise** | Self-managed deployment | Organizations that run the platform on their own infrastructure. |
+One rate card, two deliveries — priced per **AI seat** in every edition:
 
-See [docs.objectos.ai](https://docs.objectos.ai) for capabilities, deployment,
-and operations documentation.
+| Delivery | Plans | For |
+|:---|:---|:---|
+| **ObjectOS Cloud** (managed service) | Free · Team · Business | Organizations that want the platform operated for them — orgs, environments, deploys, billing. |
+| **ObjectOS Self-Managed** (your infrastructure) | Business Self-Managed (single-node license) · Enterprise (full private deployment) | Organizations that run the platform themselves. |
+
+See [License & Pricing](https://docs.objectos.ai/docs/resources/license) for
+plan details, and [docs.objectos.ai](https://docs.objectos.ai) for
+capabilities, deployment, and operations documentation.
 
 ## Building and running your own apps? That's ObjectStack — and it's open source
 

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -90,7 +90,7 @@ you want to know where the artifact comes from:
 | Layer | What it is | Where it runs |
 |---|---|---|
 | **Framework** (`@objectstack/*`) | Open-source kernel, ObjectQL, plugins, drivers | npm — pulled in at build time |
-| **Control plane** (optional) | Publishes compiled `objectstack.json` artifacts; you can use the hosted ObjectStack Cloud, run your own, or skip it entirely | Your CI, our cloud, or your laptop |
+| **Control plane** (optional) | Publishes compiled `objectstack.json` artifacts; you can use the hosted ObjectOS Cloud, run your own, or skip it entirely | Your CI, our cloud, or your laptop |
 | **ObjectOS** | The runtime you operate | **Your infrastructure** |
 
 If you're shipping a single app, you don't need a control plane —

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -40,7 +40,7 @@ Then either:
 
 | You're using | Pain point | What ObjectOS gives you |
 |---|---|---|
-| **Retool / Appsmith** | UI builder is great, but your data sits in their cloud and their pricing scales with users | Your data never leaves your network; Apache-2.0, no seat tax |
+| **Retool / Appsmith** | UI builder is great, but your data sits in their cloud and their pricing scales with users | Your data never leaves your network; open-source foundation (ObjectStack, Apache-2.0), no seat tax |
 | **Supabase / Firebase** | Backend-as-a-service is fast but vendor-locked; multi-tenant SaaS by design | Same DX (auto APIs, auth, storage), but you own the runtime and database |
 | **Salesforce / NetSuite** | Powerful platform, painful customization, eye-watering per-seat cost | Same metadata-driven model (objects, fields, roles, sharing rules), self-hosted, no seat tax |
 | **Rolling your own (Next + Prisma + NextAuth)** | You rebuild RBAC, audit, file uploads, settings, webhooks, jobs every time | Ship the actual business logic; the platform plumbing is already there |
@@ -86,8 +86,10 @@ networks are a first-class deployment target — see
 
 ## License & pricing
 
-ObjectOS runtime is **Apache-2.0** — the most permissive widely-used
-OSS license. Use it in commercial products, embed it, redistribute it,
-keep your modifications private. No per-seat fee, no license server,
-no "starting at $50K/year." Optional commercial support and managed
-hosting are available separately — see [License](/docs/resources/license).
+ObjectOS is a **commercial product** built on the open-source (Apache-2.0)
+**[ObjectStack framework](https://github.com/objectstack-ai/framework)** — the
+framework is free to use in commercial products, embed, and self-host, with
+no per-seat fee and no license server. ObjectOS adds the embedded in-UI AI,
+governance, and official operations, priced **per AI seat only** (viewers and
+non-AI users are free) — no "starting at $50K/year". See
+[License & Pricing](/docs/resources/license).

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -156,7 +156,7 @@ os i18n check                 # find missing keys across configured locales
 
 ## Cloud commands
 
-For users of ObjectStack Cloud (the optional hosted control plane).
+For users of ObjectOS Cloud (the optional hosted control plane).
 
 ```bash
 os login                      # interactive

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -20,7 +20,7 @@ A: No, not to start — ObjectOS uses local SQLite by default. Swap for
 Postgres / MySQL / Turso / Mongo when you go to production.
 
 **Q: Do I need an account / cloud service?**
-A: No. ObjectOS is fully self-contained. ObjectStack Cloud is optional
+A: No. ObjectOS is fully self-contained. ObjectOS Cloud is optional
 for multi-environment / multi-app deployments with a control plane.
 
 ## Architecture
@@ -114,9 +114,9 @@ Native connectors for popular iPaaS tools are on the roadmap.
 **Q: Can AI agents call my ObjectOS?**
 A: Yes, via MCP (`@objectstack/mcp`) — exposes objects (and, increasingly,
 actions) as MCP tools that Claude Desktop, IDEs, Claude Code, or any other MCP
-client can use. This is the **AI path on the free Community Edition** (bring your
-own model); the in-product AI Builder / "ask your data" assistant is a Cloud /
-Enterprise feature. See [AI Service](/docs/configure/ai).
+client can use. This is the **AI path on the free, open-source ObjectStack
+framework** (bring your own model); the in-product AI Builder / "ask your data"
+assistant is what the paid ObjectOS editions add. See [AI Service](/docs/configure/ai).
 
 ## Customization
 
@@ -157,19 +157,25 @@ all customer data. ObjectOS itself is stateless. See [Backup](/docs/operate/back
 
 ## Pricing & legal
 
-**Q: Is ObjectOS really free?**
-A: Yes — the **Community Edition** is free forever (Apache-2.0): no seats, no
-usage tier, no license server. The hosted **in-UI AI** assistant, clustering/HA,
-and enterprise governance are the paid **Cloud / Enterprise** layer — where you
-pay only for **AI seats** (viewers and non-AI users are free). See
-[Editions](/docs/resources/license#editions).
+**Q: Is ObjectOS free?**
+A: ObjectOS is a **commercial product** (there is a free Cloud tier to start
+on). The free, self-hostable platform is the open-source
+**[ObjectStack framework](https://github.com/objectstack-ai/framework)**
+(Apache-2.0): no seats, no usage tier, no license server — with AI over MCP
+(bring your own model). ObjectOS adds the embedded **in-UI AI** + governance
+and official operations, and you pay only for **AI seats** (viewers and
+non-AI users are free). See [Editions](/docs/resources/license#editions).
 
-**Q: Can I use ObjectOS in a commercial product I sell?**
-A: Yes. Apache-2.0 allows commercial use. See [License](/docs/resources/license).
+**Q: Can I use it in a commercial product I sell?**
+A: The **ObjectStack framework** — yes, Apache-2.0 allows commercial use with
+no royalty. Redistributing **ObjectOS** itself requires an OEM agreement. See
+[License & Pricing](/docs/resources/license).
 
 **Q: Do you collect telemetry?**
-A: No. Zero outbound calls unless you configure them (OIDC, email, AI,
-webhooks). See [Security & Compliance](/docs/reference/security#data-residency).
+A: The open-source ObjectStack runtime makes zero outbound calls unless you
+configure them (OIDC, email, AI, webhooks). Self-managed ObjectOS
+additionally validates its license online (air-gapped Enterprise licenses are
+offline-validated). See [Security & Compliance](/docs/reference/security#data-residency).
 
 **Q: Is ObjectOS SOC 2 / ISO 27001 / HIPAA / GDPR compliant?**
 A: ObjectOS provides the **primitives** every framework requires (RBAC,

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -61,7 +61,7 @@ audit log, sessions, API keys, system settings. Distinct from Console
 ### Control Plane
 
 An optional service that publishes versioned artifacts to ObjectOS
-instances. Hosted as ObjectStack Cloud or self-hosted. Most
+instances. Hosted as ObjectOS Cloud or self-hosted. Most
 deployments don't need one — file-backed mode works for single-app
 production.
 

--- a/content/docs/resources/license.mdx
+++ b/content/docs/resources/license.mdx
@@ -1,141 +1,153 @@
 ---
-title: License
-description: ObjectOS licensing — Apache-2.0, commercial options, and FAQ.
+title: License & Pricing
+description: ObjectOS is a commercial product — editions, pricing, and how it relates to the open-source ObjectStack framework.
 ---
 
-# License
+# License & Pricing
 
-## ObjectOS runtime — Apache-2.0
+## ObjectOS is a commercial product
 
-The ObjectOS runtime and all `@objectstack/*` open-source packages are
-licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+ObjectOS is the **official runtime environment for ObjectStack applications**,
+sold in two deliveries: **ObjectOS Cloud** (we operate it) and **ObjectOS
+Self-Managed** (you operate it, under a commercial license). There is **no
+open-source edition of ObjectOS**.
 
-In plain English:
-
-| You can | You must |
-|---|---|
-| Use it in commercial products | Include the LICENSE and NOTICE files when you redistribute |
-| Modify it without sharing changes | Mark modified files as modified |
-| Embed it in proprietary software | Not use ObjectStack trademarks without permission |
-| Run it for any purpose, anywhere | — |
-| Sublicense it as part of a larger work | — |
-
-There is **no copyleft**. Modifications you make for internal use, or
-that you ship in a closed-source product, do **not** have to be
-contributed back. The Apache-2.0 license also includes an **express
-patent grant** from contributors — important for enterprise legal
-review.
-
-Full text: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
-
-## What's included under Apache-2.0
-
-| | License |
-|---|---|
-| ObjectOS runtime image | Apache-2.0 |
-| All `@objectstack/*` npm packages (runtime, plugins, services, drivers, adapters, CLI, client SDKs) | Apache-2.0 |
-| Templates repo (`objectstack-ai/templates`) | Apache-2.0 |
-| Console and Account UIs | Apache-2.0 |
-| Documentation | CC-BY-4.0 |
+The open-source story lives under its own brand: the
+**[ObjectStack framework](https://github.com/objectstack-ai/framework)**
+(Apache-2.0) is everything you need to **build, run, and self-host your own
+applications** — the protocol, kernel, CLI, production runtime, Console, and
+the MCP server — free, with no feature gate between development and
+production. If you want free self-hosting, you want ObjectStack, and it is
+excellent. ObjectOS is what you buy when you want the **embedded AI** and an
+**officially operated / supported** platform on top of that mechanism.
 
 ## Editions
 
-ObjectOS is **open core**. The open-source runtime is the complete *mechanism*
-for building and running business applications; the commercial editions layer on
-hosted *intelligence*, operational scale, and governance.
+One rate card, two deliveries. The **AI seat** is the only unit of pricing in
+every edition.
 
-| | **Community** | **Cloud** | **Enterprise** |
-|---|---|---|---|
-| Delivery | self-host (OSS) | fully hosted | cloud **or private/self-host** |
-| License | Apache-2.0 | — (SaaS) | commercial |
-| Price | **Free, forever** | **per AI seat** ($24 / $54; Free tier available) | Custom (volume) |
-| Build & run apps; real DB tables, RBAC, row/field security, flows, interfaces, REST/ObjectQL | ✓ | ✓ | ✓ |
-| **AI via MCP** — point your own Claude Code / MCP client at your data | ✓ | ✓ | ✓ |
-| **In-UI AI** — hosted AI Builder + "ask your data" assistant | — | ✓ | ✓ |
-| **Private / self-host deployment** (license, BYO model, offline-payable) | — | — | ✓ |
-| Clustering / HA / multi-node, data residency / air-gap | — | managed | ✓ |
-| SSO/SCIM at scale, compliance attestations (SOC 2 report / ISO image), advanced governance | — | by plan | ✓ |
-| Support | community | by plan | SLA + dedicated |
+| | **Free** | **Team** | **Business** | **Enterprise** |
+|---|---|---|---|---|
+| Delivery | cloud | cloud | cloud **or self-managed (single-node)** | cloud **or private deployment** |
+| Price | **Free** | **$24** / AI seat / mo | **$54** / AI seat / mo · self-managed: **$540** / AI seat / yr | Custom (volume) — [contact sales](mailto:sales@objectstack.ai) |
+| In-UI AI (AI Builder + "ask your data") | taste | ✓ | ✓ | ✓ |
+| AI governance (action audit, guardrails, permission scoping) | — | — | ✓ | ✓ |
+| Clustering / HA, multi-org self-host, air-gap, SCIM | — | — | — | ✓ |
+| Support | community | standard | priority (cloud) / standard (self-managed) | SLA + dedicated |
+
+Want to self-host **for free**? That's the open-source
+**ObjectStack framework** (MCP-only AI) — a different brand, not an ObjectOS
+edition. See [the open-source alternative](#the-open-source-alternative) below.
 
 **Open mechanism, closed intelligence.** Everything you need to model data and
-run apps is open-source and free. The *hosted AI* — the in-product AI Builder and
-the "ask your data" assistant — is a Cloud / Enterprise feature. On the free
-Community Edition your AI path is the open **MCP server**: point your own Claude
-Code (or any MCP client) at your deployment and it can query and operate your data
-with your own model — no platform AI bill.
+run apps is open-source (ObjectStack). ObjectOS layers on the *embedded
+intelligence* — the in-product AI Builder and the "ask your data" assistant,
+governed and audited — plus operational scale and official support.
 
-**You pay only for AI seats.** On the paid plans the only billed seat is the
-**AI seat**; viewers and non-AI users are free, with no per-user seat tax (a clean
-contrast to the $150–300/user incumbents).
+**You pay only for AI seats.** The only billed seat is the **AI seat**;
+viewers, non-AI app users, and developers building over MCP are free, with no
+per-user seat tax (a clean contrast to the $150–300/user incumbents).
 
-**Cloud, or private deployment on Enterprise.** The paid cloud plans (Team /
-Business) are **hosted** — per AI seat, AI credits included. **Private / self-host
-deployment is an Enterprise capability**: a license, **bring your own model / key**
-(you pay your own LLM cost), **offline-payable**, plus clustering/HA and
-governance. Want to self-host for free? That's the open-source **Community
-Edition** (MCP-only AI). There is **no per-node charge** — clustering / HA is
-folded into Enterprise.
+## Cloud or self-managed
 
-## When you might want a commercial edition
+- **Cloud (Free / Team / Business)** — fully hosted, self-serve. The price
+  includes hosting and a generous monthly AI allowance (we run the model).
+- **Business Self-Managed** — the Business plan delivered as a **single-node
+  Docker license** for **10–25 AI seats** ($540/AI seat/yr, annual): in-UI AI
+  and AI governance on your own infrastructure, **bring your own model / key**
+  (you pay your own LLM cost — no platform AI bill or metering), card-paid,
+  standard support. If the license lapses, the runtime keeps running and your
+  data stays intact — the paid features simply switch off (it never bricks).
+- **ObjectOS Enterprise** — full private deployment for everything beyond
+  that: clustering / HA / multi-node, multi-organization self-host,
+  data residency and **air-gapped** operation, SCIM and identity lifecycle,
+  compliance attestations, SLA and dedicated support, and offline / invoice
+  payment. Sold as an **annual license** with multi-year price-lock options;
+  on non-renewal your deployment **keeps the last paid version perpetually**
+  (you lose updates and support, never your system or data). Pricing is
+  volume-based — [contact sales](mailto:sales@objectstack.ai).
 
-Apache-2.0 covers most self-host use cases. You may want **Enterprise** (licensed
-self-host) or **ObjectStack Cloud** (hosted) when:
+There is **no per-node charge** — clustering / scale is folded into
+Enterprise.
 
-| Scenario | Edition |
+## When you might want each
+
+| Scenario | Choose |
 |---|---|
-| You want us to **host it for you** (per AI seat, in-UI AI, billing handled) | ObjectStack Cloud |
-| You need **clustering / HA / multi-node** or **air-gapped** scale | Enterprise |
-| You want the **in-product AI assistant** on your own infrastructure | Enterprise |
-| You need **SSO/SCIM at scale** + **compliance attestations** (SOC 2 report, ISO image) | Enterprise |
-| You need **support with SLAs**, **warranty / indemnification**, or **OEM** rights | Enterprise / commercial agreement |
+| You want the platform **hosted and operated for you** | ObjectOS Cloud (Free → Team → Business) |
+| You must run on **your own single node** and want the in-product AI, ≤25 AI seats | **Business Self-Managed** |
+| You need **clustering / HA**, **multi-org**, **air-gap**, **SCIM**, compliance attestations, SLAs, or offline payment | **ObjectOS Enterprise** |
+| You self-host the free ObjectStack runtime but need a **supported distribution with a commercial contract** (SLA, security-patch priority, named escalation) | **ObjectOS Runtime Subscription** — [contact sales](mailto:sales@objectstack.ai) |
+| You want **free self-hosting** and bring your own AI over MCP | **ObjectStack framework** (open source) |
+| You need **OEM / redistribution** rights under the ObjectOS or ObjectStack name | Commercial agreement — [contact sales](mailto:sales@objectstack.ai) |
 
-Contact **sales@objectstack.ai** to discuss.
+## The open-source alternative
 
-## Pricing for the open-source runtime
+The **ObjectStack framework** is licensed under the
+[Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0):
+no copyleft, an express patent grant, free forever — no seats, no usage tier,
+no license server, no key, no telemetry. Run it on your laptop, your servers,
+your customers' servers, or a 1000-pod cluster; the license is the same in
+every case. Your AI path there is the open **MCP server**: point your own
+Claude Code (or any MCP client) at your deployment and it can query and
+operate your data with your own model.
 
-**Free.** Forever. No seats, no usage tier, no license server, no key.
+What's Apache-2.0 (in the framework repository): the runtime image, all
+`@objectstack/*` npm packages (runtime, plugins, services, drivers, adapters,
+CLI, client SDKs), the templates repository, and the Console and Account UIs.
+Documentation is CC-BY-4.0.
 
-Run it on:
-- Your laptop
-- Your servers
-- Your customers' servers
-- A Raspberry Pi
-- A Kubernetes cluster of 1000 pods
+Full text: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
 
-The license is the same in every case. (The hosted **in-UI AI** assistant and the
-Enterprise scale / governance add-ons are the paid layer — the runtime itself is
-free.)
+## Trademarks
+
+"ObjectOS" and the ObjectOS logo are **trademarks** and are not covered by
+any code license. You may truthfully say your product is *built on* or
+*compatible with* ObjectOS / ObjectStack; using the names or logos in your
+own product, company, or domain name requires written permission. See
+[TRADEMARK.md](https://github.com/objectstack-ai/objectos/blob/main/TRADEMARK.md).
 
 ## Third-party components
 
-ObjectOS depends on several upstream open-source projects (Node.js,
-Hono, Zod, Better Auth, AI SDK, …). Each ships with its own license —
-all of which are either Apache-2.0, MIT, or BSD-style permissive
-licenses compatible with commercial use. See the SBOM published with
-each release for the full inventory.
+ObjectOS builds on the ObjectStack framework and several upstream open-source
+projects (Node.js, Hono, Zod, Better Auth, AI SDK, …). Each ships with its
+own license — all Apache-2.0, MIT, or BSD-style permissive licenses compatible
+with commercial use. See the SBOM published with each release for the full
+inventory.
 
 ## FAQ
 
-**Q: Can I use ObjectOS in a closed-source SaaS I sell to my customers?**
-A: Yes. Apache-2.0 has no copyleft. You don't need to share your code.
+**Q: Is ObjectOS open source?**
+A: No. ObjectOS is a commercial product with no open-source edition. The
+open-source platform it runs on is the **ObjectStack framework** (Apache-2.0)
+— build and self-host your own apps with it, free.
 
-**Q: Can I modify ObjectOS and not share my changes?**
-A: Yes. Apache-2.0 doesn't require you to share modifications.
+**Q: Can I use ObjectStack in a closed-source SaaS I sell to my customers?**
+A: Yes. Apache-2.0 has no copyleft and no royalty — you don't need to share
+your code, and you owe nothing if your product makes money.
 
-**Q: Can I rebrand Console as part of my product?**
-A: The UI itself, yes. Using the "ObjectStack" name or logo to promote
-your product requires an OEM agreement — contact sales.
+**Q: Can I self-host ObjectOS without paying?**
+A: No — self-managed ObjectOS (Business Self-Managed or Enterprise) is
+licensed. Free self-hosting is the ObjectStack framework, which is the same
+open mechanism with MCP-only AI.
 
-**Q: Do I owe you anything if my product makes money?**
-A: No. There's no royalty or revenue share.
+**Q: Does the software stop working if I don't renew?**
+A: It never bricks. Business Self-Managed degrades to the free-mechanism
+behavior (paid features switch off; your data and runtime keep working).
+Enterprise keeps the **last paid version perpetually** — you lose updates,
+new AI capabilities, and support, not your system.
 
-**Q: Does ObjectOS phone home with usage data?**
-A: No. There's no telemetry, no license check, no update ping.
-See [Security & Compliance](/docs/reference/security#data-residency).
+**Q: Does ObjectOS phone home?**
+A: ObjectOS Self-Managed validates its license online (Enterprise air-gapped
+licenses are offline-validated). The open-source ObjectStack runtime has no
+telemetry, no license check, and no update ping.
 
-**Q: What if I want a contractual warranty?**
-A: Apache-2.0 disclaims warranty. Buy a commercial agreement and we
-provide one.
+**Q: What if I want a contractual warranty on the free runtime?**
+A: That's the **ObjectOS Runtime Subscription** — a support contract on the
+open-source ObjectStack runtime (official distribution, SLA, security-patch
+priority) with zero feature difference. Contact
+[sales@objectstack.ai](mailto:sales@objectstack.ai).
 
-**Q: Will the open-source version always be free?**
-A: Yes. Apache-2.0 grants are irrevocable.
+**Q: Will the open-source framework always be free?**
+A: Yes. Apache-2.0 grants are irrevocable, and everything already released
+stays licensed as released.

--- a/content/docs/resources/support.mdx
+++ b/content/docs/resources/support.mdx
@@ -52,8 +52,10 @@ formal SLAs.
 
 Available from the ObjectStack team:
 
-- **Commercial support** with response-time SLAs.
-- **Managed hosting** — we run it for you.
+- **ObjectOS Runtime Subscription** — a support contract on the free,
+  self-hosted ObjectStack runtime: response-time SLAs, named escalation,
+  security-patch priority (no feature difference from the open source).
+- **Managed hosting** — ObjectOS Cloud, we run it for you.
 - **Architecture review** — pre-deployment sanity check.
 - **Custom plugins / capabilities** built to your spec.
 - **OEM redistribution** — embed ObjectOS in your product.
@@ -62,7 +64,7 @@ Contact **sales@objectstack.ai**.
 
 ## Contributing back
 
-ObjectOS is Apache-2.0 and accepts contributions:
+The underlying ObjectStack framework is Apache-2.0 and accepts contributions:
 
 - [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
 - [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
@@ -71,7 +73,7 @@ ObjectOS is Apache-2.0 and accepts contributions:
 
 ## Status & incidents
 
-Hosted services (ObjectStack Cloud, package registry):
+Hosted services (ObjectOS Cloud, package registry):
 [status.objectstack.ai](https://status.objectstack.ai).
 
 For your self-hosted ObjectOS deployment, status is your concern —

--- a/content/docs/why.mdx
+++ b/content/docs/why.mdx
@@ -20,9 +20,9 @@ set of audited tools, queues every change for human approval, and the
 result is live — REST endpoints, Console screens, RBAC, audit log,
 everything generated from the same metadata.
 
-The runtime sits in **your** VPC, on **your** database, under
-**your** Apache-2.0 fork. The model talks to a sandboxed metadata API,
-not your data warehouse.
+The runtime sits in **your** VPC, on **your** database — the underlying
+**ObjectStack runtime is Apache-2.0**, yours to fork. The model talks to a
+sandboxed metadata API, not your data warehouse.
 
 That's the whole pitch. The rest of this page is who that fits and
 who it doesn't.
@@ -66,7 +66,7 @@ Common scenarios where it's a fit:
 |---|---|---|
 | Data location | Their cloud (or self-hosted at higher tier) | Your network, always |
 | UI builder | Drag-and-drop, very polished | Metadata-driven, generated; less custom |
-| Pricing | Per-user, scales painfully | Self-hosted, Apache-2.0 |
+| Pricing | Per-user, scales painfully | Self-hostable (open-source ObjectStack); ObjectOS bills AI seats only |
 | Workflow / triggers | Their workflow engine | Declarative flows + plugins |
 | Backend logic | Limited to their query editor | Full TypeScript, full Node ecosystem |
 | Best for | Quick dashboards on top of existing APIs | Apps that *own* their data |
@@ -122,9 +122,10 @@ Common scenarios where it's a fit:
 - **Newer than Salesforce.** Salesforce has 25 years of edge cases
   documented. We have a few hundred. The protocol is stable; the
   ecosystem is growing.
-- **Apache-2.0.** Use it in commercial products, embed it, modify it
-  privately. No copyleft surprises. Optional commercial support
-  available separately.
+- **Open-source foundation.** The underlying ObjectStack framework is
+  Apache-2.0 — use it in commercial products, embed it, modify it
+  privately, no copyleft surprises. ObjectOS (the commercial layer) and
+  support subscriptions are available separately.
 
 ## Reality check
 


### PR DESCRIPTION
## Summary

The July repositioning made ObjectOS a **commercial-only brand** (README: "no open-source edition of ObjectOS") — but the docs body still told the old open-core story ("ObjectOS is open core", a free "Community Edition", "ObjectOS runtime is Apache-2.0"). This PR reconciles the public docs with the new positioning and with the pricing structure decided in cloud ADR-0085 (`objectstack-ai/cloud#846`).

### Changes

- **`content/docs/resources/license.mdx`** — rewritten as **License & Pricing**: ObjectOS is commercial; new editions table — one rate card, two deliveries, priced per AI seat (Cloud Free / Team $24 / Business $54 per AI seat/mo; **Business Self-Managed** $540/AI seat/yr, 10–25 seats, single-node Docker, BYO model; Enterprise custom/contact-sales). Free self-host is presented as the **ObjectStack framework** (a different brand). Honest FAQ answers on license validation, non-renewal behavior (degrade vs Enterprise perpetual version-keep), and trademarks. The `#editions` anchor is preserved.
- **`content/docs/resources/faq.mdx`** — "Is ObjectOS free?" now answers the commercial positioning (free = ObjectStack; Cloud Free tier exists); telemetry answer discloses self-managed license validation; MCP answer points at ObjectStack instead of "free Community Edition".
- **`README.md`** — editions table reframed as one rate card, two deliveries (Cloud: Free/Team/Business · Self-Managed: Business Self-Managed/Enterprise).
- **`content/docs/resources/support.mdx`** — "Commercial support" renamed **ObjectOS Runtime Subscription** (support contract on the free runtime, zero feature difference); contribution links attributed to the framework.
- **Brand artifact cleanup** — the hosted control plane "ObjectStack Cloud" → **ObjectOS Cloud** (architecture, cli, faq, glossary, support); residual "ObjectOS is Apache-2.0" claims reworded to the open-source ObjectStack foundation (index.mdx "License & pricing" section, why.mdx comparison tables and trade-off bullet).

### Deliberately NOT published (internal-only per cloud pricing policy)

Enterprise list prices ($30k floor / seat bands), AI-credit bundle numbers, the Runtime Subscription price, air-gap/channel terms — the public page says "custom / contact sales" and "generous monthly AI allowance".

### Scope notes

English sources only — locale files are derived translations (AGENTS.md) and will follow the normal translation sync; Fumadocs falls back to English in the meantime. Companion internal-strategy PR: objectstack-ai/cloud#846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzpV1ebVbpDn88mMV7caFC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzpV1ebVbpDn88mMV7caFC)_