### PR TITLE
docs: update repo references for framework → objectstack rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Read this before opening a PR.
   behavior as an issue instead.
 - **Framework changes** — protocol schemas, kernel internals, drivers, and
   community plugins live in
-  [`objectstack-ai/framework`](https://github.com/objectstack-ai/framework)
+  [`objectstack-ai/objectstack`](https://github.com/objectstack-ai/objectstack)
   (open source, Apache-2.0). Open PRs there.
 
 ## History

--- a/NOTICE
+++ b/NOTICE
@@ -2,6 +2,6 @@ ObjectOS
 Copyright 2026 ObjectOS Authors
 
 This product includes software developed by the ObjectOS Authors and
-the ObjectStack framework contributors (https://github.com/objectstack-ai/framework).
+the ObjectStack framework contributors (https://github.com/objectstack-ai/objectstack).
 
 Licensed under the Apache License, Version 2.0. See LICENSE for the full text.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ capabilities, deployment, and operations documentation.
 ## Building and running your own apps? That's ObjectStack — and it's open source
 
 Everything you need to **build, run, and self-host your own applications** is
-the open-source (Apache-2.0) **[ObjectStack framework](https://github.com/objectstack-ai/framework)**:
+the open-source (Apache-2.0) **[ObjectStack framework](https://github.com/objectstack-ai/objectstack)**:
 
 ```
 ObjectStack  →  for builders  — the open-source protocol, toolkit, and production runtime
@@ -40,7 +40,7 @@ ObjectOS     →  for end users — the commercial runtime environment (Cloud & 
 ```
 
 `os start` — or the official Docker image
-[`ghcr.io/objectstack-ai/objectstack`](https://github.com/objectstack-ai/framework/tree/main/docker) —
+[`ghcr.io/objectstack-ai/objectstack`](https://github.com/objectstack-ai/objectstack/tree/main/docker) —
 serves your compiled app in production with the Console, permissions, and
 audit included. No commercial license required.
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -9,5 +9,5 @@ pnpm --filter @objectos/docs build
 ```
 
 > Protocol references (Object, Field, View, …) belong upstream in
-> `objectstack-ai/framework`. This site is for the **distribution** —
+> `objectstack-ai/objectstack`. This site is for the **distribution** —
 > install, configure, upgrade, operate, and plugin docs.

--- a/content/docs/build/agents.de.mdx
+++ b/content/docs/build/agents.de.mdx
@@ -182,7 +182,7 @@ Sie dieselbe Agent-Definition in einem Marketplace-Paket ausliefern.
 ## Wie es weitergeht
 
 - [AI Builder](/docs/build/ai-builder) — der Assistent zur Build-Zeit
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills`, damit Ihr IDE-Agent Metadaten korrekt erstellt
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills`, damit Ihr IDE-Agent Metadaten korrekt erstellt
 - [Actions](/docs/build/interface/actions) — deklarieren Sie die Tools, die Ihre Agents verwenden werden
 - [AI Service](/docs/configure/ai) — Anbieter-, Embedder- und MCP-Einrichtung
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — vollständige Schemas
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — vollständige Schemas

--- a/content/docs/build/agents.es.mdx
+++ b/content/docs/build/agents.es.mdx
@@ -182,7 +182,7 @@ distribuyes la misma definición de agente en un paquete del marketplace.
 ## A dónde ir después
 
 - [AI Builder](/docs/build/ai-builder) — el asistente de tiempo de build
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills` para que el agente de tu IDE genere los metadatos correctamente
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills` para que el agente de tu IDE genere los metadatos correctamente
 - [Actions](/docs/build/interface/actions) — declara las tools que usarán tus agentes
 - [AI Service](/docs/configure/ai) — configuración de proveedor, embedder y MCP
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — esquemas completos
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — esquemas completos

--- a/content/docs/build/agents.fr.mdx
+++ b/content/docs/build/agents.fr.mdx
@@ -187,7 +187,7 @@ d'agent dans un package du marketplace.
 ## Pour aller plus loin
 
 - [AI Builder](/docs/build/ai-builder) — l'assistant au moment du build
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills` pour que votre agent d'IDE rédige correctement les métadonnées
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills` pour que votre agent d'IDE rédige correctement les métadonnées
 - [Actions](/docs/build/interface/actions) — déclarez les outils que vos agents utiliseront
 - [AI Service](/docs/configure/ai) — configuration du fournisseur, de l'embedder et de MCP
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — schémas complets
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — schémas complets

--- a/content/docs/build/agents.ja.mdx
+++ b/content/docs/build/agents.ja.mdx
@@ -178,7 +178,7 @@ marketplace パッケージで同じエージェント定義を出荷してい�
 ## 次に進む先
 
 - [AI Builder](/docs/build/ai-builder) — ビルド時のアシスタント
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills` で、IDE エージェントがメタデータを正しく作成できるようにします
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills` で、IDE エージェントがメタデータを正しく作成できるようにします
 - [Actions](/docs/build/interface/actions) — エージェントが使用するツールを宣言します
 - [AI Service](/docs/configure/ai) — プロバイダー、エンベッダー、MCP のセットアップ
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — 完全なスキーマ
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — 完全なスキーマ

--- a/content/docs/build/agents.ko.mdx
+++ b/content/docs/build/agents.ko.mdx
@@ -178,7 +178,7 @@ marketplace 패키지로 배포하더라도, 테넌트 A의 `tier1_support` 에�
 ## 다음으로 갈 곳
 
 - [AI Builder](/docs/build/ai-builder) — 빌드 타임 어시스턴트
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills` 로 IDE 에이전트가 메타데이터를 올바르게 작성하도록 합니다
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills` 로 IDE 에이전트가 메타데이터를 올바르게 작성하도록 합니다
 - [Actions](/docs/build/interface/actions) — 에이전트가 사용할 도구를 선언합니다
 - [AI Service](/docs/configure/ai) — 프로바이더, 임베더, MCP 설정
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — 전체 스키마
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — 전체 스키마

--- a/content/docs/build/agents.mdx
+++ b/content/docs/build/agents.mdx
@@ -181,7 +181,7 @@ the same agent definition in a marketplace package.
 ## Where to go next
 
 - [AI Builder](/docs/build/ai-builder) — the build-time assistant
-- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/framework/skills` so your IDE agent authors metadata correctly
+- [IDE Skills](/docs/build/ai-skills) — `npx skills add objectstack-ai/objectstack/skills` so your IDE agent authors metadata correctly
 - [Actions](/docs/build/interface/actions) — declare the tools your agents will use
 - [AI Service](/docs/configure/ai) — provider, embedder, MCP setup
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) — full schemas
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) — full schemas

--- a/content/docs/build/agents.zh-Hans.mdx
+++ b/content/docs/build/agents.zh-Hans.mdx
@@ -150,7 +150,7 @@ Agents 是按 Environment 划分的。租户 A 的 `tier1_support` agent 永远�
 ## 下一步去哪里
 
 - [AI Builder](/docs/build/ai-builder) —— 构建期助手
-- [IDE Skills](/docs/build/ai-skills) —— `npx skills add objectstack-ai/framework/skills`，让你的 IDE agent 正确地编写元数据
+- [IDE Skills](/docs/build/ai-skills) —— `npx skills add objectstack-ai/objectstack/skills`，让你的 IDE agent 正确地编写元数据
 - [Actions](/docs/build/interface/actions) —— 声明你的 agent 将使用的 tool
 - [AI Service](/docs/configure/ai) —— provider、embedder、MCP 设置
-- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/framework/tree/main/packages/spec/src/ai) —— 完整 schema
+- [`@objectstack/spec/ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec/src/ai) —— 完整 schema

--- a/content/docs/build/ai-skills.de.mdx
+++ b/content/docs/build/ai-skills.de.mdx
@@ -20,7 +20,7 @@ opencode** und etwa 50 weiteren Agents.
 In jedem Projekt, das `@objectstack/*`-Pakete verwendet:
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Die CLI erkennt, welche Agents Sie konfiguriert haben (`.claude/`,
@@ -54,7 +54,7 @@ einen CEL-Ausdruck mit dem Data-Skill zu schreiben.
 ## Wie es funktioniert
 
 Jeder Skill ist ein Ordner unter `skills/` im
-[Framework-Repo](https://github.com/objectstack-ai/framework/tree/main/skills):
+[Framework-Repo](https://github.com/objectstack-ai/objectstack/tree/main/skills):
 
 ```
 skills/objectstack-data/
@@ -102,7 +102,7 @@ veröffentlichen wollen** (siehe [Templates](./templates) und [Marketplace](./ma
 ## Aktualisieren
 
 Die Skills folgen den `@objectstack/spec`-Versionen. Führen Sie
-`npx skills add objectstack-ai/framework/skills` nach dem Upgrade des Spec-Pakets
+`npx skills add objectstack-ai/objectstack/skills` nach dem Upgrade des Spec-Pakets
 erneut aus, um Ihren Agent mit den neuesten Zod-Schemas, CEL-Helfern und
 dem Metadaten-Vokabular synchron zu halten.
 

--- a/content/docs/build/ai-skills.es.mdx
+++ b/content/docs/build/ai-skills.es.mdx
@@ -20,7 +20,7 @@ Continue, Roo, Goose, Kiro, opencode** y ~50 agentes más.
 En cualquier proyecto que use paquetes `@objectstack/*`:
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 El CLI detecta qué agentes tienes configurados (`.claude/`,
@@ -54,7 +54,7 @@ skill de datos.
 ## Cómo funciona
 
 Cada skill es una carpeta dentro de `skills/` en el
-[repositorio del framework](https://github.com/objectstack-ai/framework/tree/main/skills):
+[repositorio del framework](https://github.com/objectstack-ai/objectstack/tree/main/skills):
 
 ```
 skills/objectstack-data/
@@ -104,7 +104,7 @@ para la personalización del tenant y las AI Skills para IDE al trabajar en
 ## Actualización
 
 Las skills siguen las versiones de `@objectstack/spec`. Vuelve a ejecutar
-`npx skills add objectstack-ai/framework/skills` tras actualizar el paquete spec
+`npx skills add objectstack-ai/objectstack/skills` tras actualizar el paquete spec
 para mantener tu agente sincronizado con los últimos esquemas Zod,
 helpers de CEL y vocabulario de metadatos.
 

--- a/content/docs/build/ai-skills.fr.mdx
+++ b/content/docs/build/ai-skills.fr.mdx
@@ -22,7 +22,7 @@ cinquantaine d'autres agents.
 Dans n'importe quel projet utilisant les packages `@objectstack/*` :
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 La CLI détecte les agents que vous avez configurés (`.claude/`,
@@ -57,7 +57,7 @@ d'écrire une expression CEL avec le skill data.
 ## Comment ça fonctionne
 
 Chaque skill est un dossier sous `skills/` dans le
-[dépôt framework](https://github.com/objectstack-ai/framework/tree/main/skills) :
+[dépôt framework](https://github.com/objectstack-ai/objectstack/tree/main/skills) :
 
 ```
 skills/objectstack-data/
@@ -107,7 +107,7 @@ travaillent sur des **packages qu'elles comptent publier** (voir
 ## Mise à jour
 
 Les skills suivent les versions de `@objectstack/spec`. Relancez
-`npx skills add objectstack-ai/framework/skills` après avoir mis à niveau le
+`npx skills add objectstack-ai/objectstack/skills` après avoir mis à niveau le
 package spec pour garder votre agent synchronisé avec les derniers
 schémas Zod, helpers CEL et vocabulaire de métadonnées.
 

--- a/content/docs/build/ai-skills.ja.mdx
+++ b/content/docs/build/ai-skills.ja.mdx
@@ -20,7 +20,7 @@ opencode** およびその他約 50 種類のエージェントで動作しま�
 `@objectstack/*` パッケージを使用しているプロジェクトであればどこでも:
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 CLI は構成済みのエージェント (`.claude/`、`.cursor/`、`.github/copilot/`、
@@ -52,7 +52,7 @@ CLI は構成済みのエージェント (`.claude/`、`.cursor/`、`.github/cop
 ## 仕組み
 
 すべてのスキルは
-[framework リポジトリ](https://github.com/objectstack-ai/framework/tree/main/skills)
+[framework リポジトリ](https://github.com/objectstack-ai/objectstack/tree/main/skills)
 の `skills/` 配下にあるフォルダーです:
 
 ```
@@ -101,7 +101,7 @@ AI Builder を使い、**公開を意図したパッケージ** を扱う際に�
 ## 更新
 
 スキルは `@objectstack/spec` のバージョンに追従します。spec パッケージを
-アップグレードした後に `npx skills add objectstack-ai/framework/skills` を再実行して、
+アップグレードした後に `npx skills add objectstack-ai/objectstack/skills` を再実行して、
 エージェントを最新の Zod スキーマ、CEL ヘルパー、メタデータ語彙と
 同期させてください。
 

--- a/content/docs/build/ai-skills.ko.mdx
+++ b/content/docs/build/ai-skills.ko.mdx
@@ -20,7 +20,7 @@ opencode** 및 그 외 약 50개의 에이전트와 함께 작동합니다.
 `@objectstack/*` 패키지를 사용하는 모든 프로젝트에서:
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 CLI는 어떤 에이전트가 구성되어 있는지(`.claude/`,
@@ -54,7 +54,7 @@ skill에게 위임할지 에이전트에게 알려주므로, Claude가 platform 
 ## 작동 방식
 
 모든 skill은
-[framework repo](https://github.com/objectstack-ai/framework/tree/main/skills)의
+[framework repo](https://github.com/objectstack-ai/objectstack/tree/main/skills)의
 `skills/` 아래에 있는 폴더입니다:
 
 ```
@@ -103,7 +103,7 @@ Builder를, 그리고 **게시할 의도가 있는 패키지** 작업에는 IDE 
 ## 업데이트
 
 Skills는 `@objectstack/spec` 버전을 따릅니다. spec 패키지를 업그레이드한
-후 `npx skills add objectstack-ai/framework/skills`를 다시 실행하여 에이전트를
+후 `npx skills add objectstack-ai/objectstack/skills`를 다시 실행하여 에이전트를
 최신 Zod 스키마, CEL 헬퍼, 메타데이터 어휘와 동기화 상태로 유지하세요.
 
 ## 관련 항목

--- a/content/docs/build/ai-skills.mdx
+++ b/content/docs/build/ai-skills.mdx
@@ -20,7 +20,7 @@ opencode** and ~50 other agents.
 In any project that uses `@objectstack/*` packages:
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 The CLI detects which agents you have configured (`.claude/`,
@@ -54,7 +54,7 @@ skill.
 ## How it works
 
 Every skill is a folder under `skills/` in the
-[framework repo](https://github.com/objectstack-ai/framework/tree/main/skills):
+[framework repo](https://github.com/objectstack-ai/objectstack/tree/main/skills):
 
 ```
 skills/objectstack-data/
@@ -102,7 +102,7 @@ publish** (see [Templates](./templates) and [Marketplace](./marketplace)).
 ## Updating
 
 The skills follow `@objectstack/spec` versions. Re-run
-`npx skills add objectstack-ai/framework/skills` after upgrading the spec
+`npx skills add objectstack-ai/objectstack/skills` after upgrading the spec
 package to keep your agent in sync with the latest Zod schemas, CEL
 helpers, and metadata vocabulary.
 

--- a/content/docs/build/ai-skills.zh-Hans.mdx
+++ b/content/docs/build/ai-skills.zh-Hans.mdx
@@ -12,7 +12,7 @@ ObjectOS 提供 **9 个一方 Agent Skill**，教编码助手如何编写各类 
 在任何使用 `@objectstack/*` 包的项目里：
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 CLI 会检测你配置了哪些 Agent（`.claude/`、`.cursor/`、`.github/copilot/`、`AGENTS.md` 等），并把 Skill 写到正确位置。随时重跑可拉取最新版本。
@@ -37,7 +37,7 @@ CLI 会检测你配置了哪些 Agent（`.claude/`、`.cursor/`、`.github/copil
 
 ## 工作原理
 
-每个 Skill 是 [framework 仓库](https://github.com/objectstack-ai/framework/tree/main/skills) `skills/` 下的一个文件夹：
+每个 Skill 是 [framework 仓库](https://github.com/objectstack-ai/objectstack/tree/main/skills) `skills/` 下的一个文件夹：
 
 ```
 skills/objectstack-data/
@@ -77,7 +77,7 @@ metadata:
 
 ## 升级
 
-Skill 跟随 `@objectstack/spec` 版本。升级 spec 包后重跑 `npx skills add objectstack-ai/framework/skills`，可让你的 Agent 与最新的 Zod schema、CEL 辅助函数、元数据词汇保持同步。
+Skill 跟随 `@objectstack/spec` 版本。升级 spec 包后重跑 `npx skills add objectstack-ai/objectstack/skills`，可让你的 Agent 与最新的 Zod schema、CEL 辅助函数、元数据词汇保持同步。
 
 ## 相关
 

--- a/content/docs/build/automation/flows.de.mdx
+++ b/content/docs/build/automation/flows.de.mdx
@@ -231,5 +231,5 @@ os test --scenario "welcome email fires on signup"
 - [AI Service](/docs/configure/ai) — `ai_call`-Aktion für LLM-Steps
 - [API Access](/docs/configure/api-access) — manuelle Flows von
   externen Systemen aufrufen
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — Quellcode der Ausführungs-Engine

--- a/content/docs/build/automation/flows.es.mdx
+++ b/content/docs/build/automation/flows.es.mdx
@@ -231,5 +231,5 @@ os test --scenario "welcome email fires on signup"
 - [AI Service](/docs/configure/ai) — la acción `ai_call` para pasos con LLM
 - [API Access](/docs/configure/api-access) — invocar flujos manuales desde
   sistemas externos
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — código fuente del motor de ejecución

--- a/content/docs/build/automation/flows.fr.mdx
+++ b/content/docs/build/automation/flows.fr.mdx
@@ -231,5 +231,5 @@ os test --scenario "welcome email fires on signup"
 - [AI Service](/docs/configure/ai) — l'action `ai_call` pour les étapes LLM
 - [API Access](/docs/configure/api-access) — invoquer des flux manuels depuis des
   systèmes externes
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — code source du moteur d'exécution

--- a/content/docs/build/automation/flows.ja.mdx
+++ b/content/docs/build/automation/flows.ja.mdx
@@ -207,5 +207,5 @@ os test --scenario "welcome email fires on signup"
 - [Email](/docs/configure/email) — `send_email` アクションのトランスポート
 - [AI Service](/docs/configure/ai) — LLM ステップ用の `ai_call` アクション
 - [API Access](/docs/configure/api-access) — 外部システムから手動フローを呼び出す
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — 実行エンジンのソース

--- a/content/docs/build/automation/flows.ko.mdx
+++ b/content/docs/build/automation/flows.ko.mdx
@@ -227,5 +227,5 @@ os test --scenario "welcome email fires on signup"
 - [AI Service](/docs/configure/ai) — LLM 스텝을 위한 `ai_call` 액션
 - [API Access](/docs/configure/api-access) — 외부 시스템에서 manual
   플로우 호출하기
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — 실행 엔진의 소스

--- a/content/docs/build/automation/flows.mdx
+++ b/content/docs/build/automation/flows.mdx
@@ -306,5 +306,5 @@ os test --scenario "welcome email fires on signup"
 - [AI Service](/docs/configure/ai) — `ai_call` action for LLM steps
 - [API Access](/docs/configure/api-access) — invoke manual flows from
   external systems
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation)
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation)
   — source for the execution engine

--- a/content/docs/build/automation/flows.zh-Hans.mdx
+++ b/content/docs/build/automation/flows.zh-Hans.mdx
@@ -264,4 +264,4 @@ os test --scenario "welcome email fires on signup"
 - [Email](/docs/configure/email) —— `send_email` Action 的传输层
 - [AI Service](/docs/configure/ai) —— 用于 LLM 步骤的 `ai_call` Action
 - [API Access](/docs/configure/api-access) —— 从外部系统调用手动流程
-- [@objectstack/service-automation](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-automation) —— 执行引擎源码
+- [@objectstack/service-automation](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-automation) —— 执行引擎源码

--- a/content/docs/build/data/index.de.mdx
+++ b/content/docs/build/data/index.de.mdx
@@ -257,4 +257,4 @@ Sie verdrahten diese nicht pro Objekt — sie sind auf der Plattform polymorph.
 - [Flows / Automatisierung](/docs/build/automation/flows) — auf Datensatzänderungen reagieren
 - [API-Zugriff](/docs/configure/api-access) — Ihre generierte REST aufrufen
 - [`os explain`](/docs/reference/cli) — das gerenderte Schema ausgeben
-- [`@objectstack/spec`-Quelle](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — das Schema ist der Vertrag; alles hier wird daraus abgeleitet
+- [`@objectstack/spec`-Quelle](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — das Schema ist der Vertrag; alles hier wird daraus abgeleitet

--- a/content/docs/build/data/index.es.mdx
+++ b/content/docs/build/data/index.es.mdx
@@ -256,4 +256,4 @@ No conectas esto por cada objeto — es polimórfico en la plataforma.
 - [Flujos / Automatización](/docs/build/automation/flows) — reacciona a los cambios en los registros
 - [Acceso a la API](/docs/configure/api-access) — llama a tu REST generado
 - [`os explain`](/docs/reference/cli) — imprime el esquema renderizado
-- [Código fuente de `@objectstack/spec`](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — el esquema es el contrato; todo lo aquí descrito se deriva de él
+- [Código fuente de `@objectstack/spec`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — el esquema es el contrato; todo lo aquí descrito se deriva de él

--- a/content/docs/build/data/index.fr.mdx
+++ b/content/docs/build/data/index.fr.mdx
@@ -258,4 +258,4 @@ Vous ne câblez pas cela par objet — c'est polymorphe sur la plateforme.
 - [Flows / Automation](/docs/build/automation/flows) — réagissez aux modifications d'enregistrements
 - [API Access](/docs/configure/api-access) — appelez vos API REST générées
 - [`os explain`](/docs/reference/cli) — affichez le schéma rendu
-- [Source de `@objectstack/spec`](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — le schéma est le contrat ; tout ce qui est ici en est dérivé
+- [Source de `@objectstack/spec`](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — le schéma est le contrat ; tout ce qui est ici en est dérivé

--- a/content/docs/build/data/index.ja.mdx
+++ b/content/docs/build/data/index.ja.mdx
@@ -258,4 +258,4 @@ ObjectSchema.create({
 - [フロー / 自動化](/docs/build/automation/flows) — レコードの変更に反応
 - [API アクセス](/docs/configure/api-access) — 生成された REST を呼び出す
 - [`os explain`](/docs/reference/cli) — レンダリングされたスキーマを出力
-- [`@objectstack/spec` ソース](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — スキーマが契約であり、ここに記載されているものはすべてそこから派生します
+- [`@objectstack/spec` ソース](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — スキーマが契約であり、ここに記載されているものはすべてそこから派生します

--- a/content/docs/build/data/index.ko.mdx
+++ b/content/docs/build/data/index.ko.mdx
@@ -255,4 +255,4 @@ ObjectSchema.create({
 - [플로우 / 자동화](/docs/build/automation/flows) — 레코드 변경에 반응합니다
 - [API 접근](/docs/configure/api-access) — 생성된 REST를 호출합니다
 - [`os explain`](/docs/reference/cli) — 렌더링된 스키마를 출력합니다
-- [`@objectstack/spec` 소스](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — 스키마가 계약이며, 여기의 모든 것은 그로부터 파생됩니다
+- [`@objectstack/spec` 소스](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — 스키마가 계약이며, 여기의 모든 것은 그로부터 파생됩니다

--- a/content/docs/build/data/index.mdx
+++ b/content/docs/build/data/index.mdx
@@ -296,4 +296,4 @@ You don't wire these per object — they're polymorphic on the platform.
 - [Flows / Automation](/docs/build/automation/flows) — react to record changes
 - [API Access](/docs/configure/api-access) — call your generated REST
 - [`os explain`](/docs/reference/cli) — print the rendered schema
-- [`@objectstack/spec` source](https://github.com/objectstack-ai/framework/tree/main/packages/spec) — the schema is the contract; everything here is derived from it
+- [`@objectstack/spec` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) — the schema is the contract; everything here is derived from it

--- a/content/docs/build/data/index.zh-Hans.mdx
+++ b/content/docs/build/data/index.zh-Hans.mdx
@@ -281,4 +281,4 @@ ObjectSchema.create({
 - [Flows / Automation](/docs/build/automation/flows) —— 对记录变更做出反应
 - [API Access](/docs/configure/api-access) —— 调用生成的 REST
 - [`os explain`](/docs/reference/cli) —— 打印渲染后的 Schema
-- [`@objectstack/spec` 源码](https://github.com/objectstack-ai/framework/tree/main/packages/spec) —— Schema 即契约;此处的一切都从它派生
+- [`@objectstack/spec` 源码](https://github.com/objectstack-ai/objectstack/tree/main/packages/spec) —— Schema 即契约;此处的一切都从它派生

--- a/content/docs/build/interface/views.de.mdx
+++ b/content/docs/build/interface/views.de.mdx
@@ -15,7 +15,7 @@ Zwei Arten:
   wizard, …)
 
 Schema-Quelle:
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts).
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts).
 
 ## Die kürzestmögliche Deklaration
 
@@ -256,4 +256,4 @@ und sobald Sie ihn genehmigen, erscheint die View in der Console. Siehe
 - [Actions](./actions) — worauf `rowActions` / `bulkActions` verweisen
 - [ObjectQL](/docs/reference/objectql) — wozu `filter` / `sort` kompiliert werden
 - [CEL](/docs/reference/cel) — `conditionalFormatting`, `visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — Schema
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — Schema

--- a/content/docs/build/interface/views.es.mdx
+++ b/content/docs/build/interface/views.es.mdx
@@ -14,7 +14,7 @@ Dos tipos:
   asistente, …)
 
 Fuente del esquema:
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts).
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts).
 
 ## La declaración más corta posible
 
@@ -249,4 +249,4 @@ lo apruebas, la vista aparece en Console. Consulta [AI Builder](/docs/build/ai-b
 - [Actions](./actions) — a qué referencian `rowActions` / `bulkActions`
 - [ObjectQL](/docs/reference/objectql) — a qué se compilan `filter` / `sort`
 - [CEL](/docs/reference/cel) — `conditionalFormatting`, `visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — esquema
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — esquema

--- a/content/docs/build/interface/views.fr.mdx
+++ b/content/docs/build/interface/views.fr.mdx
@@ -15,7 +15,7 @@ Deux types :
   assistant, …)
 
 Source du schéma :
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts).
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts).
 
 ## La déclaration la plus courte possible
 
@@ -249,4 +249,4 @@ vous l'approuvez, la vue apparaît dans Console. Voir [AI Builder](/docs/build/a
 - [Actions](./actions) — ce que référencent `rowActions` / `bulkActions`
 - [ObjectQL](/docs/reference/objectql) — ce en quoi se compilent `filter` / `sort`
 - [CEL](/docs/reference/cel) — `conditionalFormatting`, `visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — schéma
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — schéma

--- a/content/docs/build/interface/views.ja.mdx
+++ b/content/docs/build/interface/views.ja.mdx
@@ -14,7 +14,7 @@ description: リスト、フォーム、カンバン、カレンダー、ガン�
   ウィザードなど）
 
 スキーマソース:
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts)。
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts)。
 
 ## 最小限の宣言
 
@@ -248,4 +248,4 @@ AI Builder はメタデータツールを呼び出し、差分をキューに入
 - [Actions](./actions) — `rowActions` / `bulkActions` が参照するもの
 - [ObjectQL](/docs/reference/objectql) — `filter` / `sort` のコンパイル先
 - [CEL](/docs/reference/cel) — `conditionalFormatting`、`visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — スキーマ
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — スキーマ

--- a/content/docs/build/interface/views.ko.mdx
+++ b/content/docs/build/interface/views.ko.mdx
@@ -14,7 +14,7 @@ description: List, Form, Kanban, Calendar, Gantt 등 — Console의 모든 오�
   wizard 등)
 
 스키마 소스:
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts).
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts).
 
 ## 가능한 가장 짧은 선언
 
@@ -248,4 +248,4 @@ AI Builder가 메타데이터 도구를 호출하고, diff를 큐에 넣으며, 
 - [Actions](./actions) — `rowActions` / `bulkActions`가 참조하는 것
 - [ObjectQL](/docs/reference/objectql) — `filter` / `sort`가 컴파일되는 대상
 - [CEL](/docs/reference/cel) — `conditionalFormatting`, `visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — 스키마
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — 스키마

--- a/content/docs/build/interface/views.mdx
+++ b/content/docs/build/interface/views.mdx
@@ -14,7 +14,7 @@ Two kinds:
   wizard, …)
 
 Schema source:
-[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts).
+[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts).
 
 ## The shortest possible declaration
 
@@ -254,4 +254,4 @@ view shows up in Console. See [AI Builder](/docs/build/ai-builder).
 - [Actions](./actions) — what `rowActions` / `bulkActions` reference
 - [ObjectQL](/docs/reference/objectql) — what `filter` / `sort` compile to
 - [CEL](/docs/reference/cel) — `conditionalFormatting`, `visibleOn`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) — schema
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) — schema

--- a/content/docs/build/interface/views.zh-Hans.mdx
+++ b/content/docs/build/interface/views.zh-Hans.mdx
@@ -10,7 +10,7 @@ description: List、Form、Kanban、Calendar、Gantt 等等 —— Console 中�
 - **List 视图** —— 可视化多条记录(grid、kanban、calendar……)
 - **Form 视图** —— 查看 / 编辑单条记录(simple、tabbed、wizard……)
 
-Schema 来源：[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts)。
+Schema 来源：[`packages/spec/src/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts)。
 
 ## 最短声明
 
@@ -237,4 +237,4 @@ view: {
 - [Actions](./actions) —— `rowActions` / `bulkActions` 引用的内容
 - [ObjectQL](/docs/reference/objectql) —— `filter` / `sort` 编译到什么
 - [CEL](/docs/reference/cel) —— `conditionalFormatting`、`visibleIf`
-- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/ui/view.zod.ts) —— Schema
+- [`@objectstack/spec/ui/view.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/ui/view.zod.ts) —— Schema

--- a/content/docs/configure/ai.de.mdx
+++ b/content/docs/configure/ai.de.mdx
@@ -198,6 +198,6 @@ Tool-Registry des AI-Service, einschließlich universeller Tools wie
 - [Flows & Automation](/docs/build/automation/flows) — AI aus deklarativer Geschäftslogik aufrufen
 - [Marketplace](/docs/build/marketplace) — AI-gestützte Apps im Standardkatalog
 - [Security & Compliance](/docs/reference/security) — wie AI-Datenflüsse isoliert werden
-- [`@objectstack/service-ai` Quellcode](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [`@objectstack/embedder-openai` Quellcode](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [`@objectstack/service-knowledge` Quellcode](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [`@objectstack/service-ai` Quellcode](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [`@objectstack/embedder-openai` Quellcode](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [`@objectstack/service-knowledge` Quellcode](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.es.mdx
+++ b/content/docs/configure/ai.es.mdx
@@ -200,6 +200,6 @@ universales como `list_objects`, `describe_object`, `query_records`,
 - [Flows & Automation](/docs/build/automation/flows) — invoca la IA desde lógica de negocio declarativa
 - [Marketplace](/docs/build/marketplace) — aplicaciones impulsadas por IA en el catálogo predeterminado
 - [Security & Compliance](/docs/reference/security) — cómo se aíslan los flujos de datos de IA
-- [Código fuente de `@objectstack/service-ai`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [Código fuente de `@objectstack/embedder-openai`](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [Código fuente de `@objectstack/service-knowledge`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [Código fuente de `@objectstack/service-ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [Código fuente de `@objectstack/embedder-openai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [Código fuente de `@objectstack/service-knowledge`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.fr.mdx
+++ b/content/docs/configure/ai.fr.mdx
@@ -203,6 +203,6 @@ et `aggregate_data`.
 - [Flows & Automation](/docs/build/automation/flows) — appeler l'IA depuis une logique métier déclarative
 - [Marketplace](/docs/build/marketplace) — applications propulsées par l'IA dans le catalogue par défaut
 - [Security & Compliance](/docs/reference/security) — comment les flux de données IA sont isolés
-- [Source de `@objectstack/service-ai`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [Source de `@objectstack/embedder-openai`](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [Source de `@objectstack/service-knowledge`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [Source de `@objectstack/service-ai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [Source de `@objectstack/embedder-openai`](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [Source de `@objectstack/service-knowledge`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.ja.mdx
+++ b/content/docs/configure/ai.ja.mdx
@@ -158,6 +158,6 @@ kernel.use(new MCPServerPlugin({
 - [Flows & Automation](/docs/build/automation/flows) — 宣言的なビジネスロジックから AI を呼び出す
 - [Marketplace](/docs/build/marketplace) — デフォルトカタログに含まれる AI 搭載アプリ
 - [Security & Compliance](/docs/reference/security) — AI のデータフローがどのように隔離されるか
-- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.ko.mdx
+++ b/content/docs/configure/ai.ko.mdx
@@ -158,6 +158,6 @@ kernel.use(new MCPServerPlugin({
 - [Flows & Automation](/docs/build/automation/flows) — 선언적 비즈니스 로직에서 AI 호출하기
 - [Marketplace](/docs/build/marketplace) — 기본 카탈로그의 AI 기반 앱
 - [Security & Compliance](/docs/reference/security) — AI 데이터 흐름이 격리되는 방식
-- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.mdx
+++ b/content/docs/configure/ai.mdx
@@ -195,6 +195,6 @@ registry, including universal tools such as `list_objects`,
 - [Flows & Automation](/docs/build/automation/flows) — call AI from declarative business logic
 - [Marketplace](/docs/build/marketplace) — AI-powered apps in the default catalog
 - [Security & Compliance](/docs/reference/security) — how AI data flows are isolated
-- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/framework/tree/main/packages/plugins/embedder-openai)
-- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [`@objectstack/service-ai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [`@objectstack/embedder-openai` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/plugins/embedder-openai)
+- [`@objectstack/service-knowledge` source](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/ai.zh-Hans.mdx
+++ b/content/docs/configure/ai.zh-Hans.mdx
@@ -173,6 +173,6 @@ Agent 通过 MCP 发现并调用 ObjectOS 的 Action——遵循调用用户的�
 - [Flows & Automation](/docs/build/automation/flows) —— 在声明式业务逻辑中调用 AI
 - [Marketplace](/docs/build/marketplace) —— 默认应用市场中的 AI 应用
 - [Security & Compliance](/docs/reference/security) —— AI 数据流是如何隔离的
-- [`@objectstack/service-ai` 源码](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-ai)
-- [`@objectstack/service-embedder` 源码](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-embedder)
-- [`@objectstack/service-knowledge` 源码](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-knowledge)
+- [`@objectstack/service-ai` 源码](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-ai)
+- [`@objectstack/service-embedder` 源码](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-embedder)
+- [`@objectstack/service-knowledge` 源码](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-knowledge)

--- a/content/docs/configure/data-sources.de.mdx
+++ b/content/docs/configure/data-sources.de.mdx
@@ -237,7 +237,7 @@ Der obige Ablauf — eine Datenbank verbinden, Objekte modellieren, sie mit
 einem Coding-Agent generieren — funktioniert heute mit den mitgelieferten
 Bausteinen. Eine reichhaltigere, **schlüsselfertige
 Federation**-Erfahrung befindet sich unter
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 in aktiver Konzeption (Status: *Proposed*). Geplant, **noch nicht
 ausgeliefert**:
 
@@ -261,4 +261,4 @@ geschrieben) und verifizieren Sie zuerst gegen eine Nicht-Produktionskopie.
 - [AI-Service](/docs/configure/ai) — Chat, Embeddings, RAG, MCP
 - [AI Agents](/docs/build/agents) — deklarative Agents über Ihren Objekten
 - [Objects](/docs/build/objects) — die `ObjectSchema.create`-Autorenoberfläche
-- [`examples/app-crm` Datasources](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — ein echtes Beispiel für Datasource + Routing
+- [`examples/app-crm` Datasources](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — ein echtes Beispiel für Datasource + Routing

--- a/content/docs/configure/data-sources.es.mdx
+++ b/content/docs/configure/data-sources.es.mdx
@@ -231,7 +231,7 @@ El flujo anterior — conectar una base de datos, modelar objetos, generarlos
 con un agente de codificación — funciona hoy con los bloques de construcción
 incluidos. Una experiencia de **federación llave en mano** más rica está en
 diseño activo bajo
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (estado: *Propuesto*). Previsto, pero **aún no disponible**:
 
 - Un `schemaMode` (`managed` / `external` / `validate-only`) para que
@@ -254,4 +254,4 @@ copia que no sea de producción.
 - [AI Service](/docs/configure/ai) — chat, embeddings, RAG, MCP
 - [AI Agents](/docs/build/agents) — agents declarativos sobre tus objetos
 - [Objects](/docs/build/objects) — la superficie de autoría `ObjectSchema.create`
-- [datasources de `examples/app-crm`](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — un ejemplo real de datasource + enrutamiento
+- [datasources de `examples/app-crm`](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — un ejemplo real de datasource + enrutamiento

--- a/content/docs/configure/data-sources.fr.mdx
+++ b/content/docs/configure/data-sources.fr.mdx
@@ -242,7 +242,7 @@ Le flux ci-dessus — connecter une base de données, modéliser des objets,
 les générer avec un agent de codage — fonctionne dès aujourd'hui avec les
 briques livrées. Une expérience de **fédération clé en main** plus riche
 est en cours de conception active sous
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (statut : *Proposed*). Prévu, **pas encore livré** :
 
 - Un `schemaMode` (`managed` / `external` / `validate-only`) afin
@@ -266,4 +266,4 @@ vérifiez d'abord sur une copie hors production.
 - [Service IA](/docs/configure/ai) — chat, embeddings, RAG, MCP
 - [AI Agents](/docs/build/agents) — agents déclaratifs sur vos objets
 - [Objects](/docs/build/objects) — la surface d'écriture `ObjectSchema.create`
-- [Sources de données de `examples/app-crm`](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — un exemple réel de datasource + routage
+- [Sources de données de `examples/app-crm`](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — un exemple réel de datasource + routage

--- a/content/docs/configure/data-sources.ja.mdx
+++ b/content/docs/configure/data-sources.ja.mdx
@@ -158,7 +158,7 @@ export default defineStack({
 
 ## ロードマップ: 製品内の外部データソースフェデレーション
 
-上記のフロー — データベースを接続し、オブジェクトをモデル化し、コーディングエージェントで生成する — は、同梱のビルディングブロックで今日機能します。よりリッチな**ターンキー型フェデレーション**体験が [ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)（ステータス: *Proposed*）の下で活発に設計中です。計画されている、**まだ出荷されていない**もの:
+上記のフロー — データベースを接続し、オブジェクトをモデル化し、コーディングエージェントで生成する — は、同梱のビルディングブロックで今日機能します。よりリッチな**ターンキー型フェデレーション**体験が [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)（ステータス: *Proposed*）の下で活発に設計中です。計画されている、**まだ出荷されていない**もの:
 
 - ObjectOS が、所有して**いない**テーブルを移行しようとせずにバインドできるようにする `schemaMode`（`managed` / `external` / `validate-only`）。
 - オブジェクトのフィールドを既存のカラムにマッピングする、オブジェクト上の `external` バインディングサブレコード。
@@ -173,4 +173,4 @@ export default defineStack({
 - [AI サービス](/docs/configure/ai) — チャット、埋め込み、RAG、MCP
 - [AI Agents](/docs/build/agents) — オブジェクトに対する宣言的なエージェント
 - [Objects](/docs/build/objects) — `ObjectSchema.create` の作成サーフェス
-- [`examples/app-crm` datasources](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — 実際のデータソース + ルーティングの例
+- [`examples/app-crm` datasources](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — 実際のデータソース + ルーティングの例

--- a/content/docs/configure/data-sources.ko.mdx
+++ b/content/docs/configure/data-sources.ko.mdx
@@ -158,7 +158,7 @@ export default defineStack({
 
 ## 로드맵: 제품 내 외부 데이터 소스 페더레이션
 
-위의 흐름 — 데이터베이스 연결, 객체 모델링, 코딩 에이전트로 생성 — 은 기본 제공 빌딩 블록으로 오늘날 동작합니다. 더 풍부한 **턴키(turn-key) 페더레이션** 경험이 [ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)(상태: *Proposed*) 아래에서 활발히 설계되고 있습니다. 계획되어 있지만 **아직 출시되지 않은** 것들:
+위의 흐름 — 데이터베이스 연결, 객체 모델링, 코딩 에이전트로 생성 — 은 기본 제공 빌딩 블록으로 오늘날 동작합니다. 더 풍부한 **턴키(turn-key) 페더레이션** 경험이 [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)(상태: *Proposed*) 아래에서 활발히 설계되고 있습니다. 계획되어 있지만 **아직 출시되지 않은** 것들:
 
 - ObjectOS가 소유하지 **않은** 테이블을 마이그레이션하려 시도하지 않고 바인딩할 수 있도록 하는 `schemaMode`(`managed` / `external` / `validate-only`).
 - 객체 필드를 기존 컬럼에 매핑하는 객체의 `external` 바인딩 하위 레코드.
@@ -173,4 +173,4 @@ export default defineStack({
 - [AI 서비스](/docs/configure/ai) — 채팅, 임베딩, RAG, MCP
 - [AI Agents](/docs/build/agents) — 객체에 대한 선언적 에이전트
 - [Objects](/docs/build/objects) — `ObjectSchema.create` 작성 인터페이스
-- [`examples/app-crm` 데이터 소스](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — 실제 데이터 소스 + 라우팅 예제
+- [`examples/app-crm` 데이터 소스](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — 실제 데이터 소스 + 라우팅 예제

--- a/content/docs/configure/data-sources.mdx
+++ b/content/docs/configure/data-sources.mdx
@@ -221,7 +221,7 @@ configuration that backs the `default` datasource.
 The flow above — connect a database, model objects, generate them with a
 coding agent — works today with shipped building blocks. A richer,
 **turn-key federation** experience is in active design under
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (status: *Proposed*). Planned, **not yet shipped**:
 
 - A `schemaMode` (`managed` / `external` / `validate-only`) so ObjectOS
@@ -243,4 +243,4 @@ non-production copy first.
 - [AI Service](/docs/configure/ai) — chat, embeddings, RAG, MCP
 - [AI Agents](/docs/build/agents) — declarative agents over your objects
 - [Objects](/docs/build/objects) — the `ObjectSchema.create` authoring surface
-- [`examples/app-crm` datasources](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) — a real datasource + routing example
+- [`examples/app-crm` datasources](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — a real datasource + routing example

--- a/content/docs/configure/data-sources.zh-Hans.mdx
+++ b/content/docs/configure/data-sources.zh-Hans.mdx
@@ -190,7 +190,7 @@ data-chat agent —— 都经由 ObjectQL,后者会把每个对象路由到它�
 
 上面的流程 —— 连接数据库、建模对象、用编码 Agent 生成 —— 借助已发布的能力今天就
 能用。更完善的**一键式联邦**体验正在
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 下积极设计中(状态:*Proposed*)。计划中、**尚未发布**的内容:
 
 - `schemaMode`(`managed` / `external` / `validate-only`),让 ObjectOS 能绑定到它
@@ -208,4 +208,4 @@ data-chat agent —— 都经由 ObjectQL,后者会把每个对象路由到它�
 - [AI 服务](/docs/configure/ai) —— 对话、嵌入、RAG、MCP
 - [AI Agent](/docs/build/agents) —— 作用于你对象之上的声明式 Agent
 - [对象](/docs/build/objects) —— `ObjectSchema.create` 的编写界面
-- [`examples/app-crm` 数据源](https://github.com/objectstack-ai/framework/tree/main/examples/app-crm/src/datasources) —— 一个真实的数据源 + 路由示例
+- [`examples/app-crm` 数据源](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) —— 一个真实的数据源 + 路由示例

--- a/content/docs/configure/storage.de.mdx
+++ b/content/docs/configure/storage.de.mdx
@@ -186,4 +186,4 @@ Die Änderung gilt ab der nächsten Anfrage — kein Neustart erforderlich.
   und der Settings-Dienst, der bei Speicher-Wechseln verwendet wird
 - [Production Readiness](/docs/operate/production) — Checkliste, die die
   Beständigkeit von Objektspeicher und Backups umfasst
-- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — Quellcode und vollständige Optionsreferenz
+- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — Quellcode und vollständige Optionsreferenz

--- a/content/docs/configure/storage.es.mdx
+++ b/content/docs/configure/storage.es.mdx
@@ -187,4 +187,4 @@ El cambio se aplica en la siguiente petición — sin necesidad de reiniciar.
   en vivo y el servicio de settings que utilizan los cambios de almacenamiento
 - [Preparación para producción](/docs/operate/production) — lista de verificación que
   incluye la durabilidad y la copia de seguridad del almacenamiento de objetos
-- [`@objectstack/service-storage` en GitHub](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — código fuente y referencia completa de opciones
+- [`@objectstack/service-storage` en GitHub](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — código fuente y referencia completa de opciones

--- a/content/docs/configure/storage.fr.mdx
+++ b/content/docs/configure/storage.fr.mdx
@@ -193,4 +193,4 @@ Le changement s'applique à la requête suivante — aucun redémarrage requis.
   direct et service de paramètres utilisé par les changements de stockage
 - [Préparation à la production](/docs/operate/production) — liste de
   contrôle incluant la durabilité et la sauvegarde du stockage d'objets
-- [`@objectstack/service-storage` sur GitHub](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — source et référence complète des options
+- [`@objectstack/service-storage` sur GitHub](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — source et référence complète des options

--- a/content/docs/configure/storage.ja.mdx
+++ b/content/docs/configure/storage.ja.mdx
@@ -187,4 +187,4 @@ new StorageServicePlugin({
   ストレージの切り替えで使用される設定サービス
 - [本番環境への準備](/docs/operate/production) — オブジェクトストレージの
   耐久性とバックアップを含むチェックリスト
-- [GitHub 上の `@objectstack/service-storage`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — ソースとすべてのオプションのリファレンス
+- [GitHub 上の `@objectstack/service-storage`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — ソースとすべてのオプションのリファレンス

--- a/content/docs/configure/storage.ko.mdx
+++ b/content/docs/configure/storage.ko.mdx
@@ -184,4 +184,4 @@ new StorageServicePlugin({
   구성 및 스토리지 교체에 사용되는 설정 서비스
 - [Production Readiness](/docs/operate/production) — 객체 스토리지
   내구성 및 백업을 포함하는 체크리스트
-- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — 소스 및 전체 옵션 참조
+- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — 소스 및 전체 옵션 참조

--- a/content/docs/configure/storage.mdx
+++ b/content/docs/configure/storage.mdx
@@ -187,4 +187,4 @@ The change applies to the next request — no restart needed.
   configuration and the settings service used by storage swaps
 - [Production Readiness](/docs/operate/production) — checklist that
   includes object storage durability and backup
-- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) — source and full option reference
+- [`@objectstack/service-storage` on GitHub](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) — source and full option reference

--- a/content/docs/configure/storage.zh-Hans.mdx
+++ b/content/docs/configure/storage.zh-Hans.mdx
@@ -170,4 +170,4 @@ new StorageServicePlugin({
 
 - [系统设置](/docs/configure/system-settings) —— 实时配置以及存储切换所使用的设置服务
 - [Production Readiness](/docs/operate/production) —— 包含对象存储持久化与备份的清单
-- [GitHub 上的 `@objectstack/service-storage`](https://github.com/objectstack-ai/framework/tree/main/packages/services/service-storage) —— 源码与完整选项参考
+- [GitHub 上的 `@objectstack/service-storage`](https://github.com/objectstack-ai/objectstack/tree/main/packages/services/service-storage) —— 源码与完整选项参考

--- a/content/docs/extend-existing-systems.de.mdx
+++ b/content/docs/extend-existing-systems.de.mdx
@@ -92,7 +92,7 @@ Der obige Ablauf funktioniert heute mit ausgelieferten Bausteinen. Ein
 reichhaltigeres, **schlüsselfertiges Federations**-Erlebnis —
 einstufiger Schema-Import, Bindung extern verwalteter Schemas und
 eingebaute Sicherheits-Gates — ist in aktiver Konzeption unter
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (Status: *Proposed*). Bis es soweit ist, ist der dokumentierte Weg —
 verbinden, modellieren, binden, abfragen — die unterstützte Art, ein
 bestehendes System zu erweitern.

--- a/content/docs/extend-existing-systems.es.mdx
+++ b/content/docs/extend-existing-systems.es.mdx
@@ -91,7 +91,7 @@ El flujo anterior funciona hoy con bloques de construcción ya
 disponibles. Una experiencia de **federación llave en mano** más rica —
 importación de esquemas en un solo paso, vinculación de esquemas de
 propiedad externa, y barreras de seguridad integradas — está en diseño
-activo bajo [ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+activo bajo [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (estado: *Propuesto*). Hasta que llegue, el camino documentado —
 conectar, modelar, vincular, consultar — es la forma soportada de
 extender un sistema existente.

--- a/content/docs/extend-existing-systems.fr.mdx
+++ b/content/docs/extend-existing-systems.fr.mdx
@@ -92,7 +92,7 @@ Le parcours ci-dessus fonctionne aujourd'hui avec les briques déjà
 livrées. Une expérience de **fédération clé en main** plus riche —
 import de schéma en une étape, liaison de schéma détenu en externe et
 garde-fous de sécurité intégrés — est en cours de conception active sous
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (statut : *Proposed*). En attendant son arrivée, le parcours documenté —
 connecter, modéliser, lier, interroger — est la manière prise en charge
 d'étendre un système existant.

--- a/content/docs/extend-existing-systems.ja.mdx
+++ b/content/docs/extend-existing-systems.ja.mdx
@@ -84,7 +84,7 @@ AI エージェントにそのデータをクエリ・分析・操作させる**
 上記のフローは、すでに出荷されているビルディングブロックで今日機能します。
 より豊かな **ターンキーのフェデレーション** 体験 — ワンステップの
 スキーマインポート、外部所有スキーマのバインディング、組み込みの安全ゲート —
-は [ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+は [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 （ステータス: *Proposed*）のもとで活発に設計が進められています。それが
 実現するまでは、文書化された道筋 — 接続、モデル化、バインド、クエリ —
 が既存システムを拡張するサポート済みの方法です。

--- a/content/docs/extend-existing-systems.ko.mdx
+++ b/content/docs/extend-existing-systems.ko.mdx
@@ -82,7 +82,7 @@ ERP, 티켓팅 도구, 프로덕션 SQL 또는 MongoDB 데이터베이스 위에
 위의 흐름은 이미 출시된 빌딩 블록으로 오늘날 작동합니다. 더 풍부한
 **턴키 페더레이션** 경험 — 한 단계 스키마 가져오기, 외부 소유 스키마
 바인딩, 내장 안전 게이트 — 는
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 아래에서 활발히 설계 중입니다(상태: *Proposed*). 그것이 도착하기 전까지,
 문서화된 경로 — 연결, 모델링, 바인딩, 쿼리 — 가 기존 시스템을 확장하는
 지원되는 방식입니다.

--- a/content/docs/extend-existing-systems.mdx
+++ b/content/docs/extend-existing-systems.mdx
@@ -79,7 +79,7 @@ Once the tables are modeled as objects bound to your existing database:
 The flow above works today with shipped building blocks. A richer,
 **turn-key federation** experience — one-step schema import, externally
 owned schema binding, and built-in safety gates — is in active design
-under [ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+under [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 (status: *Proposed*). Until it lands, the documented path — connect,
 model, bind, query — is the supported way to extend an existing system.
 

--- a/content/docs/extend-existing-systems.zh-Hans.mdx
+++ b/content/docs/extend-existing-systems.zh-Hans.mdx
@@ -77,7 +77,7 @@ ObjectOS 成为其上层那个 AI 原生、感知权限的界面。
 上述流程在今天就能通过已发布的构建块运转。一种更丰富的、
 **开箱即用的联邦**体验 —— 一步式 schema 导入、外部
 拥有的 schema 绑定，以及内建的安全闸门 —— 正在
-[ADR-0015](https://github.com/objectstack-ai/framework/blob/main/docs/adr/0015-external-datasource-federation.md)
+[ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
 下积极设计中（状态：*Proposed*）。在它落地之前，这条已记录的
 路径 —— 连接、建模、绑定、查询 —— 就是扩展现有系统的受支持方式。
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -96,7 +96,7 @@ matches how you use ObjectOS:
 ## License & pricing
 
 ObjectOS is a **commercial product** built on the open-source (Apache-2.0)
-**[ObjectStack framework](https://github.com/objectstack-ai/framework)** — the
+**[ObjectStack framework](https://github.com/objectstack-ai/objectstack)** — the
 framework is free to use in commercial products, embed, and self-host, with
 no per-seat fee and no license server. ObjectOS adds the embedded in-UI AI,
 governance, and official operations, priced **per AI seat only** (viewers and

--- a/content/docs/index.zh-Hans.mdx
+++ b/content/docs/index.zh-Hans.mdx
@@ -80,4 +80,4 @@ ObjectOS 从不回传数据。无遥测。无授权服务器。气隙网络是�
 
 ## 许可与定价
 
-ObjectOS 是构建在开源（Apache-2.0）**[ObjectStack 框架](https://github.com/objectstack-ai/framework)** 之上的**商业产品** —— 框架可免费用于商业产品、可嵌入、可自托管，没有按席位收费，也没有许可证服务器。ObjectOS 在其上增加内嵌的界面内 AI、治理与官方运维，**仅按 AI 席位**计价（只读用户与不使用 AI 的用户免费）—— 没有 "起价 5 万美元/年"。参见 [许可与定价](/docs/resources/license)。
+ObjectOS 是构建在开源（Apache-2.0）**[ObjectStack 框架](https://github.com/objectstack-ai/objectstack)** 之上的**商业产品** —— 框架可免费用于商业产品、可嵌入、可自托管，没有按席位收费，也没有许可证服务器。ObjectOS 在其上增加内嵌的界面内 AI、治理与官方运维，**仅按 AI 席位**计价（只读用户与不使用 AI 的用户免费）—— 没有 "起价 5 万美元/年"。参见 [许可与定价](/docs/resources/license)。

--- a/content/docs/quickstart.de.mdx
+++ b/content/docs/quickstart.de.mdx
@@ -79,7 +79,7 @@ REST-Endpunkte, Console-Ansichten, Audit-Log-Einträge, Berechtigungsschranken.
 Keine Datei bearbeitet, kein Neustart. Siehe [Build → AI Builder](/docs/build/ai-builder)
 für das vollständige Vokabular.
 
-> **Handcodierung in Ihrer IDE?** Führen Sie `npx skills add objectstack-ai/framework/skills` aus,
+> **Handcodierung in Ihrer IDE?** Führen Sie `npx skills add objectstack-ai/objectstack/skills` aus,
 > um Claude Code / Cursor / Copilot / Codex beizubringen, wie man
 > ObjectOS-Metadaten gegen die echten Zod-Schemas verfasst. Siehe
 > [Build → IDE Skills](/docs/build/ai-skills).

--- a/content/docs/quickstart.es.mdx
+++ b/content/docs/quickstart.es.mdx
@@ -79,7 +79,7 @@ endpoints REST, vistas de Console, entradas de registro de auditoría, controles
 Sin editar archivos, sin reiniciar. Consulta [Build → AI Builder](/docs/build/ai-builder)
 para conocer todo el vocabulario.
 
-> **¿Programando a mano en tu IDE?** Ejecuta `npx skills add objectstack-ai/framework/skills`
+> **¿Programando a mano en tu IDE?** Ejecuta `npx skills add objectstack-ai/objectstack/skills`
 > para enseñar a Claude Code / Cursor / Copilot / Codex a crear
 > metadatos de ObjectOS con los esquemas reales de Zod. Consulta
 > [Build → IDE Skills](/docs/build/ai-skills).

--- a/content/docs/quickstart.fr.mdx
+++ b/content/docs/quickstart.fr.mdx
@@ -79,7 +79,7 @@ points de terminaison REST, vues Console, entrées du journal d'audit, contrôle
 de permissions. Aucun fichier modifié, aucun redémarrage. Consultez
 [Build → AI Builder](/docs/build/ai-builder) pour le vocabulaire complet.
 
-> **Vous codez à la main dans votre IDE ?** Exécutez `npx skills add objectstack-ai/framework/skills`
+> **Vous codez à la main dans votre IDE ?** Exécutez `npx skills add objectstack-ai/objectstack/skills`
 > pour apprendre à Claude Code / Cursor / Copilot / Codex comment rédiger
 > des métadonnées ObjectOS conformes aux véritables schémas Zod. Consultez
 > [Build → IDE Skills](/docs/build/ai-skills).

--- a/content/docs/quickstart.ja.mdx
+++ b/content/docs/quickstart.ja.mdx
@@ -70,7 +70,7 @@ os start
 
 AI がプランを提案し、あなたが承認すると、メタデータが即座に有効になります — REST エンドポイント、Console ビュー、監査ログのエントリ、権限ゲート。ファイルの編集も再起動も不要です。完全な語彙については [Build → AI Builder](/docs/build/ai-builder) を参照してください。
 
-> **IDE で手書きコーディングしますか？** `npx skills add objectstack-ai/framework/skills` を実行すると、Claude Code / Cursor / Copilot / Codex に、本物の Zod スキーマに対して ObjectOS メタデータを記述する方法を教えられます。[Build → IDE Skills](/docs/build/ai-skills) を参照してください。
+> **IDE で手書きコーディングしますか？** `npx skills add objectstack-ai/objectstack/skills` を実行すると、Claude Code / Cursor / Copilot / Codex に、本物の Zod スキーマに対して ObjectOS メタデータを記述する方法を教えられます。[Build → IDE Skills](/docs/build/ai-skills) を参照してください。
 
 ### marketplace からアプリをインストールする
 

--- a/content/docs/quickstart.ko.mdx
+++ b/content/docs/quickstart.ko.mdx
@@ -78,7 +78,7 @@ REST 엔드포인트, Console 뷰, 감사 로그 항목, 권한 게이트까지.
 파일 편집도, 재시작도 필요 없습니다. 전체 어휘는 [Build → AI Builder](/docs/build/ai-builder)를
 참고하세요.
 
-> **IDE에서 직접 코딩하시나요?** `npx skills add objectstack-ai/framework/skills`를
+> **IDE에서 직접 코딩하시나요?** `npx skills add objectstack-ai/objectstack/skills`를
 > 실행하여 Claude Code / Cursor / Copilot / Codex가 실제 Zod 스키마에 맞춰
 > ObjectOS 메타데이터를 작성하는 방법을 익히도록 하세요.
 > [Build → IDE Skills](/docs/build/ai-skills)를 참고하세요.

--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -79,7 +79,7 @@ REST endpoints, Console views, audit log entries, permission gates.
 No file edited, no restart. See [Build → AI Builder](/docs/build/ai-builder)
 for the full vocabulary.
 
-> **Hand-coding in your IDE?** Run `npx skills add objectstack-ai/framework/skills`
+> **Hand-coding in your IDE?** Run `npx skills add objectstack-ai/objectstack/skills`
 > to teach Claude Code / Cursor / Copilot / Codex how to author
 > ObjectOS metadata against the real Zod schemas. See
 > [Build → IDE Skills](/docs/build/ai-skills).

--- a/content/docs/quickstart.zh-Hans.mdx
+++ b/content/docs/quickstart.zh-Hans.mdx
@@ -70,7 +70,7 @@ os start
 
 AI 提出一份计划，你批准，元数据就立刻生效 —— REST 端点、Console 视图、审计日志、权限闸门。无需编辑文件，无需重启。完整词汇请见 [Build → AI Builder](/docs/build/ai-builder)。
 
-> **在 IDE 中手写代码？** 运行 `npx skills add objectstack-ai/framework/skills`，让 Claude Code / Cursor / Copilot / Codex 学会根据真实的 Zod schema 编写 ObjectOS 元数据。参见 [Build → IDE Skills](/docs/build/ai-skills)。
+> **在 IDE 中手写代码？** 运行 `npx skills add objectstack-ai/objectstack/skills`，让 Claude Code / Cursor / Copilot / Codex 学会根据真实的 Zod schema 编写 ObjectOS 元数据。参见 [Build → IDE Skills](/docs/build/ai-skills)。
 
 ### 从市场安装应用
 

--- a/content/docs/reference/cel.de.mdx
+++ b/content/docs/reference/cel.de.mdx
@@ -18,7 +18,7 @@ JSON-Objekt, das die Laufzeit parst:
 ```
 
 Schema-Quelle:
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts).
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts).
 
 ## Die fünf getaggten Templates
 
@@ -77,7 +77,7 @@ ausgewertet:
 ## Standardbibliothek
 
 Registriert in
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts).
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts).
 Die am häufigsten verwendeten Built-ins:
 
 ### Zeit
@@ -166,5 +166,5 @@ oder eine Guard-Entscheidung unbemerkt zu beschädigen.
 - [Feldtypen](./field-types) — Formel- und bedingt erforderliche Felder
 - [Build → Datenmodell](/docs/build/data) — Validierungen und Prädikate
 - [Build → Flows](/docs/build/automation/flows) — Guards und Zeitpläne
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — Schema
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — Built-ins
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — Schema
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — Built-ins

--- a/content/docs/reference/cel.es.mdx
+++ b/content/docs/reference/cel.es.mdx
@@ -18,7 +18,7 @@ que el runtime analiza:
 ```
 
 Fuente del esquema:
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts).
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts).
 
 ## Las cinco plantillas etiquetadas
 
@@ -76,7 +76,7 @@ Las expresiones CEL se evalúan en un contexto con estas variables de nivel supe
 ## Biblioteca estándar
 
 Registrada en
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts).
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts).
 Las funciones integradas más usadas:
 
 ### Tiempo
@@ -165,5 +165,5 @@ guarda.
 - [Tipos de campo](./field-types) — campos de fórmula y de obligatoriedad condicional
 - [Build → Modelo de datos](/docs/build/data) — validaciones y predicados
 - [Build → Flujos](/docs/build/automation/flows) — guardas y programaciones
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — esquema
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — funciones integradas
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — esquema
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — funciones integradas

--- a/content/docs/reference/cel.fr.mdx
+++ b/content/docs/reference/cel.fr.mdx
@@ -18,7 +18,7 @@ runtime analyse :
 ```
 
 Source du schéma :
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts).
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts).
 
 ## Les cinq tagged templates
 
@@ -78,7 +78,7 @@ variables de premier niveau :
 ## Bibliothèque standard
 
 Enregistrée dans
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts).
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts).
 Les fonctions intégrées les plus utilisées :
 
 ### Temps
@@ -168,5 +168,5 @@ d'un formule ou la décision d'une garde.
 - [Types de champs](./field-types) — champs de formule et à exigence conditionnelle
 - [Build → Modèle de données](/docs/build/data) — validations et prédicats
 - [Build → Flux](/docs/build/automation/flows) — gardes et planifications
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — schéma
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — fonctions intégrées
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — schéma
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — fonctions intégrées

--- a/content/docs/reference/cel.ja.mdx
+++ b/content/docs/reference/cel.ja.mdx
@@ -14,7 +14,7 @@ Expression Language）を使用します。対象は、数式フィールド、�
 ```
 
 スキーマソース:
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts)。
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts)。
 
 ## 5 つのタグ付きテンプレート
 
@@ -67,7 +67,7 @@ CEL 式は、次のトップレベル変数を持つコンテキスト内で評�
 
 ## 標準ライブラリ
 
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts)
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts)
 に登録されています。
 最もよく使われる組み込み関数:
 
@@ -154,5 +154,5 @@ CEL にはネイティブの `timestamp(...)`、`duration(...)`、
 - [Field types](./field-types) — 数式フィールドと条件付き必須フィールド
 - [Build → Data model](/docs/build/data) — 検証と述語
 - [Build → Flows](/docs/build/automation/flows) — ガードとスケジュール
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — スキーマ
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — 組み込み関数
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — スキーマ
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — 組み込み関数

--- a/content/docs/reference/cel.ko.mdx
+++ b/content/docs/reference/cel.ko.mdx
@@ -16,7 +16,7 @@ ObjectOS는 작고 안전하며 샌드박스화된 표현식이 필요한 모든
 ```
 
 스키마 소스:
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts).
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts).
 
 ## 다섯 가지 태그드 템플릿
 
@@ -72,7 +72,7 @@ CEL 표현식은 다음과 같은 최상위 변수를 가진 컨텍스트에서 
 
 ## 표준 라이브러리
 
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts)에
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts)에
 등록되어 있습니다. 가장 많이 사용되는 빌트인:
 
 ### 시간
@@ -160,5 +160,5 @@ did-you-mean 힌트 포함)와 함께 `os compile`에서 실패합니다. 런타
 - [필드 타입](./field-types) — 수식 및 조건부 필수 필드
 - [Build → 데이터 모델](/docs/build/data) — 검증 및 술어
 - [Build → 플로우](/docs/build/automation/flows) — 가드 및 스케줄
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — 스키마
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — 빌트인
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — 스키마
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — 빌트인

--- a/content/docs/reference/cel.mdx
+++ b/content/docs/reference/cel.mdx
@@ -18,7 +18,7 @@ parses:
 ```
 
 Schema source:
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts).
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts).
 
 ## The five tagged templates
 
@@ -76,7 +76,7 @@ CEL expressions evaluate in a context with these top-level variables:
 ## Standard library
 
 Registered in
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts).
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts).
 The most-used built-ins:
 
 ### Time
@@ -163,5 +163,5 @@ quietly corrupting a formula value or a guard decision.
 - [Field types](./field-types) — formula and conditional-required fields
 - [Build → Data model](/docs/build/data) — validations and predicates
 - [Build → Flows](/docs/build/automation/flows) — guards and schedules
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) — schema
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) — built-ins
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) — schema
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) — built-ins

--- a/content/docs/reference/cel.zh-Hans.mdx
+++ b/content/docs/reference/cel.zh-Hans.mdx
@@ -12,7 +12,7 @@ ObjectOS 在所有需要小型、安全、沙箱化表达式的地方使用 [CEL
 ```
 
 Schema 源码：
-[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts)。
+[`packages/spec/src/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts)。
 
 ## 五个标签模板
 
@@ -65,7 +65,7 @@ CEL 表达式在带有以下顶级变量的上下文中求值：
 ## 标准库
 
 注册位置：
-[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts)。
+[`packages/formula/src/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts)。
 最常用的内置函数：
 
 ### 时间
@@ -144,5 +144,5 @@ CEL 还包含原生 `timestamp(...)`、`duration(...)`、`date.getDayOfWeek()` �
 - [字段类型](./field-types) —— 公式和条件必填字段
 - [Build → 数据模型](/docs/build/data) —— 校验和谓词
 - [Build → 流程](/docs/build/automation/flows) —— 守卫和调度
-- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/shared/expression.zod.ts) —— schema
-- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/formula/src/stdlib.ts) —— 内置函数
+- [`@objectstack/spec/shared/expression.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/shared/expression.zod.ts) —— schema
+- [`@objectstack/formula/stdlib.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/formula/src/stdlib.ts) —— 内置函数

--- a/content/docs/reference/field-types.de.mdx
+++ b/content/docs/reference/field-types.de.mdx
@@ -4,7 +4,7 @@ description: Jeder Feldtyp, den du auf einem Objekt deklarieren kannst — was e
 ---
 
 48 integrierte Feldtypen, gruppiert nach Familie. Das vollständige Zod-Schema befindet sich in
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — diese Seite ist eine praktische Zusammenfassung.
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — diese Seite ist eine praktische Zusammenfassung.
 
 ## Kerneigenschaften (jedes Feld)
 
@@ -200,4 +200,4 @@ Diese deklarierst du nicht — deaktiviere sie pro Objekt mit
 - [CEL](./cel) — `expression`, `conditionalRequired`, Validierungen
 - [ObjectQL](./objectql) — diese Felder abfragen
 - [REST API](./rest-api) — Endpunkte, die sie erzeugen / konsumieren
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — maßgebliches Schema
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — maßgebliches Schema

--- a/content/docs/reference/field-types.es.mdx
+++ b/content/docs/reference/field-types.es.mdx
@@ -4,7 +4,7 @@ description: Cada tipo de campo que puedes declarar en un objeto — qué almace
 ---
 
 48 tipos de campo integrados, agrupados por familia. El esquema Zod completo está en
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — esta página es un resumen práctico.
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — esta página es un resumen práctico.
 
 ## Propiedades fundamentales (cada campo)
 
@@ -200,4 +200,4 @@ No declaras estos campos — desactívalos por objeto con
 - [CEL](./cel) — `expression`, `conditionalRequired`, validaciones
 - [ObjectQL](./objectql) — consulta de estos campos
 - [REST API](./rest-api) — endpoints que los producen / consumen
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — esquema autoritativo
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — esquema autoritativo

--- a/content/docs/reference/field-types.fr.mdx
+++ b/content/docs/reference/field-types.fr.mdx
@@ -4,7 +4,7 @@ description: Chaque type de champ que vous pouvez déclarer sur un objet — ce 
 ---
 
 48 types de champ intégrés, regroupés par famille. Le schéma Zod complet se trouve dans
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — cette page en est un résumé pratique.
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — cette page en est un résumé pratique.
 
 ## Propriétés fondamentales (chaque champ)
 
@@ -200,4 +200,4 @@ Vous ne déclarez pas ces champs — désactivez-les par objet avec
 - [CEL](./cel) — `expression`, `conditionalRequired`, validations
 - [ObjectQL](./objectql) — interroger ces champs
 - [API REST](./rest-api) — points d'accès qui les produisent / consomment
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — schéma de référence
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — schéma de référence

--- a/content/docs/reference/field-types.ja.mdx
+++ b/content/docs/reference/field-types.ja.mdx
@@ -4,7 +4,7 @@ description: オブジェクトに宣言できるすべてのフィールドタ�
 ---
 
 48 個の組み込みフィールドタイプを、ファミリーごとに分類しています。完全な Zod スキーマは
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) にあります — このページは実用的なサマリーです。
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) にあります — このページは実用的なサマリーです。
 
 ## コアプロパティ（すべてのフィールド）
 
@@ -200,4 +200,4 @@ Formula の例:
 - [CEL](./cel) — `expression`、`conditionalRequired`、検証
 - [ObjectQL](./objectql) — これらのフィールドへのクエリ
 - [REST API](./rest-api) — それらを生成 / 消費するエンドポイント
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — 正式なスキーマ
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — 正式なスキーマ

--- a/content/docs/reference/field-types.ko.mdx
+++ b/content/docs/reference/field-types.ko.mdx
@@ -4,7 +4,7 @@ description: 객체에 선언할 수 있는 모든 필드 타입 — 저장하�
 ---
 
 패밀리별로 분류된 48가지 기본 제공 필드 타입. 전체 Zod 스키마는
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts)에 있으며, 이 페이지는 실용적인 요약입니다.
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts)에 있으며, 이 페이지는 실용적인 요약입니다.
 
 ## 핵심 속성 (모든 필드)
 
@@ -200,4 +200,4 @@ options: [
 - [CEL](./cel) — `expression`, `conditionalRequired`, 검증
 - [ObjectQL](./objectql) — 이 필드들을 쿼리하기
 - [REST API](./rest-api) — 이를 생성/소비하는 엔드포인트
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — 권위 있는 스키마
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — 권위 있는 스키마

--- a/content/docs/reference/field-types.mdx
+++ b/content/docs/reference/field-types.mdx
@@ -4,7 +4,7 @@ description: Every field type you can declare on an object — what it stores, w
 ---
 
 48 built-in field types, grouped by family. The full Zod schema is in
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — this page is a working summary.
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — this page is a working summary.
 
 ## Core properties (every field)
 
@@ -212,4 +212,4 @@ You don't declare these — opt out per object with
 - [CEL](./cel) — `expression`, `conditionalRequired`, validations
 - [ObjectQL](./objectql) — querying these fields
 - [REST API](./rest-api) — endpoints that produce / consume them
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) — authoritative schema
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) — authoritative schema

--- a/content/docs/reference/field-types.zh-Hans.mdx
+++ b/content/docs/reference/field-types.zh-Hans.mdx
@@ -4,7 +4,7 @@ description: 你可以在对象上声明的所有字段类型 —— 存储什�
 ---
 
 48 个内置字段类型,按家族分组。完整的 Zod schema 在
-[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) —— 本页为工作摘要。
+[`packages/spec/src/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) —— 本页为工作摘要。
 
 ## 核心属性（每个字段都有）
 
@@ -210,4 +210,4 @@ options: [
 - [CEL](./cel) —— `expression`、`conditionalRequired`、校验
 - [ObjectQL](./objectql) —— 查询这些字段
 - [REST API](./rest-api) —— 生产/消费它们的端点
-- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/field.zod.ts) —— 权威 schema
+- [`@objectstack/spec/data/field.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/field.zod.ts) —— 权威 schema

--- a/content/docs/reference/objectql.de.mdx
+++ b/content/docs/reference/objectql.de.mdx
@@ -35,7 +35,7 @@ Zwei Formen:
 }
 ```
 
-Schema-Quelle: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts).
+Schema-Quelle: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts).
 
 ## Filter
 
@@ -211,4 +211,4 @@ werden in der Objekt-Spezifikation konfiguriert.
 - [REST API](./rest-api) — Endpunkte, die ObjectQL verarbeiten
 - [Field types](./field-types) — was abfragbar ist
 - [CEL](./cel) — Ausdruckssprache, die in `$cel`-Filtern verwendet wird
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — maßgebliches Schema
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — maßgebliches Schema

--- a/content/docs/reference/objectql.es.mdx
+++ b/content/docs/reference/objectql.es.mdx
@@ -35,7 +35,7 @@ Dos formas:
 }
 ```
 
-Origen del esquema: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts).
+Origen del esquema: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts).
 
 ## Filtros
 
@@ -210,4 +210,4 @@ configuran en la especificación del objeto.
 - [REST API](./rest-api) — endpoints que consumen ObjectQL
 - [Field types](./field-types) — qué es consultable
 - [CEL](./cel) — lenguaje de expresiones usado dentro de los filtros `$cel`
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — esquema autoritativo
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — esquema autoritativo

--- a/content/docs/reference/objectql.fr.mdx
+++ b/content/docs/reference/objectql.fr.mdx
@@ -35,7 +35,7 @@ Deux formes :
 }
 ```
 
-Source du schéma : [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts).
+Source du schéma : [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts).
 
 ## Filtres
 
@@ -210,4 +210,4 @@ sont configurées sur le spec de l'objet.
 - [REST API](./rest-api) — points de terminaison qui consomment ObjectQL
 - [Field types](./field-types) — ce qui est interrogeable
 - [CEL](./cel) — langage d'expression utilisé dans les filtres `$cel`
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — schéma faisant autorité
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — schéma faisant autorité

--- a/content/docs/reference/objectql.ja.mdx
+++ b/content/docs/reference/objectql.ja.mdx
@@ -35,7 +35,7 @@ ObjectQL は、データエンジンが消費する JSON クエリ形式です�
 }
 ```
 
-スキーマのソース: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts)。
+スキーマのソース: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts)。
 
 ## フィルター
 
@@ -210,4 +210,4 @@ GET /api/v1/data/ticket?limit=50&offset=200
 - [REST API](./rest-api) — ObjectQL を消費するエンドポイント
 - [Field types](./field-types) — クエリ可能なもの
 - [CEL](./cel) — `$cel` フィルター内で使用される式言語
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — 正式なスキーマ
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — 正式なスキーマ

--- a/content/docs/reference/objectql.ko.mdx
+++ b/content/docs/reference/objectql.ko.mdx
@@ -35,7 +35,7 @@ ObjectQL은 데이터 엔진이 사용하는 JSON 쿼리 형식입니다.
 }
 ```
 
-스키마 소스: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts).
+스키마 소스: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts).
 
 ## 필터(Filters)
 
@@ -209,4 +209,4 @@ GET /api/v1/data/ticket?limit=50&offset=200
 - [REST API](./rest-api) — ObjectQL을 사용하는 엔드포인트
 - [필드 타입](./field-types) — 쿼리 가능한 항목
 - [CEL](./cel) — `$cel` 필터 내부에서 사용하는 표현식 언어
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — 공식 스키마
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — 공식 스키마

--- a/content/docs/reference/objectql.mdx
+++ b/content/docs/reference/objectql.mdx
@@ -35,7 +35,7 @@ Two shapes:
 }
 ```
 
-Schema source: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts).
+Schema source: [`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts).
 
 ## Filters
 
@@ -211,4 +211,4 @@ configured on the object spec.
 - [REST API](./rest-api) — endpoints that consume ObjectQL
 - [Field types](./field-types) — what's queryable
 - [CEL](./cel) — expression language used inside `$cel` filters
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) — authoritative schema
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) — authoritative schema

--- a/content/docs/reference/objectql.zh-Hans.mdx
+++ b/content/docs/reference/objectql.zh-Hans.mdx
@@ -30,7 +30,7 @@ ObjectQL 是数据引擎消费的 JSON 查询格式。它是 `/api/v1/data/:obje
 }
 ```
 
-Schema 源码：[`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts)。
+Schema 源码：[`packages/spec/src/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts)。
 
 ## 过滤器
 
@@ -194,4 +194,4 @@ GET /api/v1/data/ticket?limit=50&offset=200
 - [REST API](./rest-api) —— 消费 ObjectQL 的端点
 - [字段类型](./field-types) —— 可查询的内容
 - [CEL](./cel) —— `$cel` 过滤器内使用的表达式语言
-- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/framework/blob/main/packages/spec/src/data/query.zod.ts) —— 权威 schema
+- [`@objectstack/spec/data/query.zod.ts`](https://github.com/objectstack-ai/objectstack/blob/main/packages/spec/src/data/query.zod.ts) —— 权威 schema

--- a/content/docs/reference/skills-cli.de.mdx
+++ b/content/docs/reference/skills-cli.de.mdx
@@ -14,13 +14,13 @@ findest du unter [Build → IDE Skills](/docs/build/ai-skills).
 ## Installation
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Beim ersten Ausführen wird das
 [`skills`](https://www.npmjs.com/package/skills)-Paket über `npx` von npm
 heruntergeladen, anschließend wird das Skill-Bundle von
-[github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+[github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 (`skills/<name>/`-Ordner) abgerufen und in die Agenten-Konfiguration
 deines Projekts geschrieben.
 
@@ -72,7 +72,7 @@ npx skills --help                  # full options
 Pinne eine Version für reproduzierbare CI:
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## Wo die Ausgabe committet werden sollte
@@ -85,7 +85,7 @@ die du ohnehin normalerweise einchecken würdest.
 ## Aktualisieren
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Führe den Befehl nach dem Upgrade von `@objectstack/spec` erneut aus,
@@ -97,4 +97,4 @@ Metadaten-Vokabular synchron bleibt.
 - [Build → IDE Skills](/docs/build/ai-skills) — konzeptionelle Übersicht, AI Builder vs. Skills
 - [Build → AI Builder](/docs/build/ai-builder) — das Gegenstück in der Console
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — Upstream-CLI
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — Source of Truth für jeden Skill
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — Source of Truth für jeden Skill

--- a/content/docs/reference/skills-cli.es.mdx
+++ b/content/docs/reference/skills-cli.es.mdx
@@ -15,12 +15,12 @@ consulta [Build → IDE Skills](/docs/build/ai-skills).
 ## Instalación
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 La primera ejecución descarga el paquete [`skills`](https://www.npmjs.com/package/skills)
 desde npm mediante `npx`, luego obtiene el paquete de skills desde
-[github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+[github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 (carpetas `skills/<name>/`) y los escribe en la configuración del
 agente de tu proyecto.
 
@@ -72,7 +72,7 @@ npx skills --help                  # full options
 Fija una versión para una CI reproducible:
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## Dónde confirmar la salida
@@ -85,7 +85,7 @@ incluirías en el control de versiones de todos modos.
 ## Actualización
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Vuelve a ejecutarlo después de actualizar `@objectstack/spec` para que
@@ -97,4 +97,4 @@ helpers de CEL y vocabulario de metadatos.
 - [Build → IDE Skills](/docs/build/ai-skills) — visión conceptual, AI Builder frente a skills
 - [Build → AI Builder](/docs/build/ai-builder) — la contraparte dentro de Console
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — CLI original
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — fuente de verdad para cada skill
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — fuente de verdad para cada skill

--- a/content/docs/reference/skills-cli.fr.mdx
+++ b/content/docs/reference/skills-cli.fr.mdx
@@ -15,13 +15,13 @@ conceptuelle, voir [Build → IDE Skills](/docs/build/ai-skills).
 ## Installation
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Lors de la première exécution, le paquet
 [`skills`](https://www.npmjs.com/package/skills) est téléchargé depuis
 npm via `npx`, puis le bundle de skills est récupéré depuis
-[github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+[github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 (dossiers `skills/<name>/`) et écrit dans la configuration de l'agent de
 votre projet.
 
@@ -73,7 +73,7 @@ npx skills --help                  # full options
 Épinglez une version pour une CI reproductible :
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## Où committer la sortie
@@ -86,7 +86,7 @@ vous versionneriez normalement de toute façon.
 ## Mise à jour
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Réexécutez après avoir mis à niveau `@objectstack/spec` afin que l'agent
@@ -98,4 +98,4 @@ vocabulaire de métadonnées.
 - [Build → IDE Skills](/docs/build/ai-skills) — vue d'ensemble conceptuelle, AI Builder vs skills
 - [Build → AI Builder](/docs/build/ai-builder) — l'équivalent dans la Console
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — CLI en amont
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — source de vérité pour chaque skill
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — source de vérité pour chaque skill

--- a/content/docs/reference/skills-cli.ja.mdx
+++ b/content/docs/reference/skills-cli.ja.mdx
@@ -14,12 +14,12 @@ description: ObjectOS のスキルバンドルをコーディングエージェ�
 ## インストール
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 初回実行時には、`npx` 経由で npm から
 [`skills`](https://www.npmjs.com/package/skills) パッケージをダウンロードし、
-続いて [github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+続いて [github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 （`skills/<name>/` フォルダ）からスキルバンドルを取得して、プロジェクトの
 エージェント設定に書き込みます。
 
@@ -71,7 +71,7 @@ npx skills --help                  # full options
 再現可能な CI のためにバージョンを固定する場合：
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## 出力をどこにコミットするか
@@ -83,7 +83,7 @@ npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/ski
 ## 更新
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 `@objectstack/spec` をアップグレードした後に再実行すると、エージェントが
@@ -94,4 +94,4 @@ npx skills add objectstack-ai/framework/skills
 - [Build → IDE Skills](/docs/build/ai-skills) — 概念的な概要、AI Builder とスキルの比較
 - [Build → AI Builder](/docs/build/ai-builder) — Console 内の対応機能
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — 上流の CLI
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — すべてのスキルのソースオブトゥルース
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — すべてのスキルのソースオブトゥルース

--- a/content/docs/reference/skills-cli.ko.mdx
+++ b/content/docs/reference/skills-cli.ko.mdx
@@ -13,12 +13,12 @@ description: ObjectOS 스킬 번들을 코딩 에이전트에 설치하는 npx �
 ## 설치
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 처음 실행하면 `npx`를 통해 npm에서 [`skills`](https://www.npmjs.com/package/skills)
 패키지를 다운로드한 다음
-[github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+[github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 (`skills/<name>/` 폴더)에서 스킬 번들을 가져와 프로젝트의 에이전트
 설정에 기록합니다.
 
@@ -70,7 +70,7 @@ npx skills --help                  # full options
 재현 가능한 CI를 위해 버전을 고정하세요.
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## 출력을 어디에 커밋해야 하나요
@@ -82,7 +82,7 @@ npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/ski
 ## 업데이트
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 `@objectstack/spec`를 업그레이드한 후 다시 실행하면 에이전트가 최신
@@ -93,4 +93,4 @@ Zod 스키마, CEL 헬퍼, 메타데이터 어휘와 동기화된 상태를 유�
 - [Build → IDE Skills](/docs/build/ai-skills) — 개념적 개요, AI Builder 대 skills
 - [Build → AI Builder](/docs/build/ai-builder) — Console 내 대응 기능
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — 업스트림 CLI
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — 모든 스킬의 소스 오브 트루스
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — 모든 스킬의 소스 오브 트루스

--- a/content/docs/reference/skills-cli.mdx
+++ b/content/docs/reference/skills-cli.mdx
@@ -14,12 +14,12 @@ This page is a reference card. For the conceptual overview see
 ## Install
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 The first run downloads the [`skills`](https://www.npmjs.com/package/skills)
 package from npm via `npx`, then fetches the skill bundle from
-[github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework)
+[github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)
 (`skills/<name>/` folders) and writes them into your project's agent
 config.
 
@@ -71,7 +71,7 @@ npx skills --help                  # full options
 Pin a version for reproducible CI:
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## Where to commit the output
@@ -84,7 +84,7 @@ anyway.
 ## Updating
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 Re-run after upgrading `@objectstack/spec` so the agent stays in sync
@@ -95,4 +95,4 @@ with the latest Zod schemas, CEL helpers, and metadata vocabulary.
 - [Build → IDE Skills](/docs/build/ai-skills) — conceptual overview, AI Builder vs skills
 - [Build → AI Builder](/docs/build/ai-builder) — the in-Console counterpart
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — upstream CLI
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) — source of truth for every skill
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — source of truth for every skill

--- a/content/docs/reference/skills-cli.zh-Hans.mdx
+++ b/content/docs/reference/skills-cli.zh-Hans.mdx
@@ -10,10 +10,10 @@ description: 将 ObjectOS skill 包安装到编码 Agent 的 npx 命令。
 ## 安装
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
-首次运行通过 `npx` 从 npm 下载 [`skills`](https://www.npmjs.com/package/skills) 包,然后从 [github.com/objectstack-ai/framework](https://github.com/objectstack-ai/framework) 拉取 skill 包(`skills/<name>/` 目录)并写入你的项目 Agent 配置。
+首次运行通过 `npx` 从 npm 下载 [`skills`](https://www.npmjs.com/package/skills) 包,然后从 [github.com/objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack) 拉取 skill 包(`skills/<name>/` 目录)并写入你的项目 Agent 配置。
 
 任何时候重新运行以拉取最新版本。
 
@@ -62,7 +62,7 @@ npx skills --help                  # 完整选项
 为可复现 CI 钉定版本：
 
 ```bash
-npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/skills
+npx skills add https://github.com/objectstack-ai/objectstack/tree/<commit-sha>/skills
 ```
 
 ## 输出应提交在哪
@@ -72,7 +72,7 @@ npx skills add https://github.com/objectstack-ai/framework/tree/<commit-sha>/ski
 ## 更新
 
 ```bash
-npx skills add objectstack-ai/framework/skills
+npx skills add objectstack-ai/objectstack/skills
 ```
 
 升级 `@objectstack/spec` 后重新运行,使 Agent 与最新 Zod schema、CEL 辅助函数和元数据词汇保持同步。
@@ -82,4 +82,4 @@ npx skills add objectstack-ai/framework/skills
 - [Build → IDE Skills](/docs/build/ai-skills) —— 概念性概览、AI Builder 与 skills 对比
 - [Build → AI Builder](/docs/build/ai-builder) —— Console 内的对应物
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) —— 上游 CLI
-- [objectstack-ai/framework/skills](https://github.com/objectstack-ai/framework/tree/main/skills) —— 每个 skill 的事实源
+- [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) —— 每个 skill 的事实源

--- a/content/docs/resources/changelog.de.mdx
+++ b/content/docs/resources/changelog.de.mdx
@@ -42,8 +42,8 @@ Veröffentlichte ObjectOS-Versionen und ihre CHANGELOG-Einträge werden hier pub
 
 - **npm**: [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**: [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **Quell-CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **Ausführliche Release Notes**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **Quell-CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **Ausführliche Release Notes**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 Abonnieren Sie Releases auf GitHub, um benachrichtigt zu werden.
 

--- a/content/docs/resources/changelog.es.mdx
+++ b/content/docs/resources/changelog.es.mdx
@@ -42,8 +42,8 @@ Las versiones publicadas de ObjectOS y sus entradas de CHANGELOG se publican en:
 
 - **npm**: [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**: [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **CHANGELOG de origen**: [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **Notas de versión extensas**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **CHANGELOG de origen**: [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **Notas de versión extensas**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 Suscríbete a las versiones en GitHub para recibir notificaciones.
 

--- a/content/docs/resources/changelog.fr.mdx
+++ b/content/docs/resources/changelog.fr.mdx
@@ -43,8 +43,8 @@ Les versions publiées d'ObjectOS et leurs entrées de CHANGELOG sont publiées 
 
 - **npm** : [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub** : [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **CHANGELOG source** : [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **Notes de version détaillées** : [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **CHANGELOG source** : [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **Notes de version détaillées** : [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 Abonnez-vous aux versions sur GitHub pour être notifié.
 

--- a/content/docs/resources/changelog.ja.mdx
+++ b/content/docs/resources/changelog.ja.mdx
@@ -40,8 +40,8 @@ ObjectOS は **[セマンティックバージョニング](https://semver.org/)
 
 - **npm**: [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**: [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **ソース CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **詳細リリースノート**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **ソース CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **詳細リリースノート**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 GitHub でリリースを購読すると、通知を受け取れます。
 

--- a/content/docs/resources/changelog.ko.mdx
+++ b/content/docs/resources/changelog.ko.mdx
@@ -42,8 +42,8 @@ ObjectOS는 **[유의적 버전(Semantic Versioning)](https://semver.org/)**을 
 
 - **npm**: [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**: [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **소스 CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **상세 릴리스 노트**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **소스 CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **상세 릴리스 노트**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 알림을 받으려면 GitHub에서 릴리스를 구독하세요.
 

--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -42,8 +42,8 @@ Released ObjectOS versions and their CHANGELOG entries are published at:
 
 - **npm**: [`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**: [github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **Source CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **Long-form release notes**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **Source CHANGELOG**: [`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **Long-form release notes**: [`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 Subscribe to releases on GitHub to get notified.
 

--- a/content/docs/resources/changelog.zh-Hans.mdx
+++ b/content/docs/resources/changelog.zh-Hans.mdx
@@ -42,8 +42,8 @@ ObjectOS 遵循 **[语义化版本](https://semver.org/)**：`MAJOR.MINOR.PATCH`
 
 - **npm**：[`@objectstack/runtime`](https://www.npmjs.com/package/@objectstack/runtime)
 - **GitHub**：[github.com/objectstack-ai/objectos/releases](https://github.com/objectstack-ai/objectos/releases)
-- **源码 CHANGELOG**：[`CHANGELOG.md`](https://github.com/objectstack-ai/framework/blob/main/CHANGELOG.md)
-- **长文版发版说明**：[`RELEASE_NOTES.md`](https://github.com/objectstack-ai/framework/blob/main/RELEASE_NOTES.md)
+- **源码 CHANGELOG**：[`CHANGELOG.md`](https://github.com/objectstack-ai/objectstack/blob/main/CHANGELOG.md)
+- **长文版发版说明**：[`RELEASE_NOTES.md`](https://github.com/objectstack-ai/objectstack/blob/main/RELEASE_NOTES.md)
 
 在 GitHub 上订阅 Releases 即可收到通知。
 

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -158,7 +158,7 @@ all customer data. ObjectOS itself is stateless. See [Backup](/docs/operate/back
 **Q: Is ObjectOS free?**
 A: ObjectOS is a **commercial product** (there is a free Cloud tier to start
 on). The free, self-hostable platform is the open-source
-**[ObjectStack framework](https://github.com/objectstack-ai/framework)**
+**[ObjectStack framework](https://github.com/objectstack-ai/objectstack)**
 (Apache-2.0): no seats, no usage tier, no license server — with AI over MCP
 (bring your own model). ObjectOS adds the embedded **in-UI AI** + governance
 and official operations, and you pay only for **AI seats** (viewers and

--- a/content/docs/resources/license.de.mdx
+++ b/content/docs/resources/license.de.mdx
@@ -24,7 +24,7 @@ vornehmen oder die Sie in einem Closed-Source-Produkt ausliefern, müssen
 eine **ausdrückliche Patentlizenz** von den Mitwirkenden — wichtig für
 die rechtliche Prüfung in Unternehmen.
 
-Volltext: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+Volltext: [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Was unter Apache-2.0 enthalten ist
 

--- a/content/docs/resources/license.es.mdx
+++ b/content/docs/resources/license.es.mdx
@@ -24,7 +24,7 @@ aportadas de vuelta. La licencia Apache-2.0 también incluye una **concesión
 expresa de patentes** por parte de los contribuyentes — algo importante para la
 revisión legal empresarial.
 
-Texto completo: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+Texto completo: [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Qué está incluido bajo Apache-2.0
 

--- a/content/docs/resources/license.fr.mdx
+++ b/content/docs/resources/license.fr.mdx
@@ -24,7 +24,7 @@ n'ont **pas** à être reversées. La licence Apache-2.0 inclut également une
 **concession expresse de brevet** de la part des contributeurs — un point
 important pour les revues juridiques en entreprise.
 
-Texte intégral : [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+Texte intégral : [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Ce qui est couvert par Apache-2.0
 

--- a/content/docs/resources/license.ja.mdx
+++ b/content/docs/resources/license.ja.mdx
@@ -23,7 +23,7 @@ ObjectOS ランタイムおよびすべての `@objectstack/*` オープンソ�
 ライセンスには、コントリビューターからの **明示的な特許許諾** も含まれており、
 これはエンタープライズの法務レビューにおいて重要です。
 
-全文: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+全文: [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Apache-2.0 に含まれるもの
 

--- a/content/docs/resources/license.ko.mdx
+++ b/content/docs/resources/license.ko.mdx
@@ -24,7 +24,7 @@ ObjectOS 런타임과 모든 `@objectstack/*` 오픈소스 패키지는
 **명시적 특허 권리 부여**도 포함되어 있어 엔터프라이즈 법무 검토에
 중요합니다.
 
-전문: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+전문: [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Apache-2.0에 포함되는 항목
 

--- a/content/docs/resources/license.mdx
+++ b/content/docs/resources/license.mdx
@@ -11,7 +11,7 @@ Self-Managed** (you operate it, under a commercial license). There is **no
 open-source edition of ObjectOS**.
 
 The open-source story lives under its own brand: the
-**[ObjectStack framework](https://github.com/objectstack-ai/framework)**
+**[ObjectStack framework](https://github.com/objectstack-ai/objectstack)**
 (Apache-2.0) is everything you need to **build, run, and self-host your own
 applications** — the protocol, kernel, CLI, production runtime, Console, and
 the MCP server — free, with no feature gate between development and
@@ -95,7 +95,7 @@ What's Apache-2.0 (in the framework repository): the runtime image, all
 CLI, client SDKs), the templates repository, and the Console and Account UIs.
 Documentation is CC-BY-4.0.
 
-Full text: [LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+Full text: [LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## Trademarks
 

--- a/content/docs/resources/license.zh-Hans.mdx
+++ b/content/docs/resources/license.zh-Hans.mdx
@@ -10,7 +10,7 @@ ObjectOS 是 **ObjectStack 应用的官方运行环境**，以两种交付形式
 采用商业许可）。**不存在开源版的 ObjectOS**。
 
 开源的故事在它自己的品牌之下：
-**[ObjectStack 框架](https://github.com/objectstack-ai/framework)**
+**[ObjectStack 框架](https://github.com/objectstack-ai/objectstack)**
 （Apache-2.0）包含你**构建、运行、自托管自有应用**所需的一切 ——
 协议、内核、CLI、生产运行时、Console 和 MCP 服务器 —— 免费，且开发与
 生产之间没有任何功能门槛。如果你想要免费自托管，你要的就是 ObjectStack，
@@ -86,7 +86,7 @@ Apache-2.0 涵盖的内容（位于框架仓库）：运行时镜像、所有
 `@objectstack/*` npm 包（运行时、插件、服务、驱动、adapter、CLI、
 客户端 SDK）、模板仓库，以及 Console 与 Account UI。文档采用 CC-BY-4.0。
 
-完整文本：[LICENSE](https://github.com/objectstack-ai/framework/blob/main/LICENSE)
+完整文本：[LICENSE](https://github.com/objectstack-ai/objectstack/blob/main/LICENSE)
 
 ## 商标
 

--- a/content/docs/resources/support.de.mdx
+++ b/content/docs/resources/support.de.mdx
@@ -62,8 +62,8 @@ Kontakt: **sales@objectstack.ai**.
 
 ObjectOS steht unter Apache-2.0 und nimmt Beiträge an:
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - Eröffnen Sie früh einen Draft-PR — wir prüfen lieber einen Entwurf, als dass
   doppelte Arbeit entsteht.
 

--- a/content/docs/resources/support.es.mdx
+++ b/content/docs/resources/support.es.mdx
@@ -62,8 +62,8 @@ Contacta a **sales@objectstack.ai**.
 
 ObjectOS usa la licencia Apache-2.0 y acepta contribuciones:
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - Abre un borrador de PR pronto — preferimos revisar un esbozo a que haya
   esfuerzo duplicado.
 

--- a/content/docs/resources/support.fr.mdx
+++ b/content/docs/resources/support.fr.mdx
@@ -62,8 +62,8 @@ Contactez **sales@objectstack.ai**.
 
 ObjectOS est sous licence Apache-2.0 et accepte les contributions :
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - Ouvrez une PR en brouillon tôt — nous préférons relire une ébauche plutôt
   que de voir des efforts dupliqués.
 

--- a/content/docs/resources/support.ja.mdx
+++ b/content/docs/resources/support.ja.mdx
@@ -62,8 +62,8 @@ ObjectStack チームが提供します:
 
 ObjectOS は Apache-2.0 ライセンスであり、コントリビューションを受け付けています:
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - 早めにドラフト PR を作成してください。重複した作業をするよりも、
   下書きをレビューするほうが望ましいです。
 

--- a/content/docs/resources/support.ko.mdx
+++ b/content/docs/resources/support.ko.mdx
@@ -62,8 +62,8 @@ ObjectStack 팀에서 제공:
 
 ObjectOS는 Apache-2.0이며 기여를 받습니다:
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - 초안 PR을 일찍 여세요 — 중복 작업이 발생하는 것보다 스케치를
   검토하는 편이 낫습니다.
 

--- a/content/docs/resources/support.mdx
+++ b/content/docs/resources/support.mdx
@@ -64,8 +64,8 @@ Contact **sales@objectstack.ai**.
 
 The underlying ObjectStack framework is Apache-2.0 and accepts contributions:
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - Open a draft PR early — we'd rather review a sketch than have
   duplicate effort.
 

--- a/content/docs/resources/support.zh-Hans.mdx
+++ b/content/docs/resources/support.zh-Hans.mdx
@@ -61,8 +61,8 @@ ObjectStack 团队可提供：
 
 ObjectOS 是 Apache-2.0，接受贡献：
 
-- [CONTRIBUTING.md](https://github.com/objectstack-ai/framework/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/objectstack-ai/framework/blob/main/CODE_OF_CONDUCT.md)
+- [CONTRIBUTING.md](https://github.com/objectstack-ai/objectstack/blob/main/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/objectstack-ai/objectstack/blob/main/CODE_OF_CONDUCT.md)
 - 尽早开 draft PR —— 我们更愿意评审一份草图，而不是出现重复劳动。
 
 ## 状态与事件


### PR DESCRIPTION
## Summary

Follow-up to the GitHub repository rename **`objectstack-ai/framework` → `objectstack-ai/objectstack`**. Updates all 270 documentation links (blob / tree / skills references) that pointed at the old repo path, across 126 files.

GitHub redirects old repo URLs to the new name, so nothing breaks during the transition; this makes the references canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kPznpkdptgo2hvW7wMDNw

---
_Generated by [Claude Code](https://claude.ai/code/session_011kPznpkdptgo2hvW7wMDNw)_