### PR TITLE
docs(readme): 简介区新增官网/文档/定价/开源框架快捷链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 > for end-user organizations as **ObjectOS Cloud** (managed) and
 > **ObjectOS Enterprise** (self-managed).
 
+[Website](https://www.objectos.ai) ·
+[Documentation](https://docs.objectos.ai) ·
+[License & Pricing](https://docs.objectos.ai/docs/resources/license) ·
+[ObjectStack — the open-source framework](https://github.com/objectstack-ai/objectstack)
+
 ObjectOS is a **commercial product**. This repository is its public home:
 
 - 📚 **Documentation** — source for [docs.objectos.ai](https://docs.objectos.ai)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # ObjectOS
 
-> **The official runtime environment for ObjectStack applications** — operated
-> for end-user organizations as **ObjectOS Cloud** (managed) and
-> **ObjectOS Enterprise** (self-managed).
+> ## Describe the app you need. Keep the data you own.
+>
+> ObjectOS is the **commercial runtime environment for
+> [ObjectStack](https://github.com/objectstack-ai/objectstack) apps**: tell the
+> built-in AI Builder what your business needs — a helpdesk, an approval flow,
+> a CRM — and get a working app with a generated admin Console, REST APIs,
+> SSO, RBAC, and audit logs. Run it as **ObjectOS Cloud** (we operate it) or
+> **ObjectOS Enterprise** (self-managed: your servers, your database, your
+> data — never ours).
 
 [Website](https://www.objectos.ai) ·
 [Documentation](https://docs.objectos.ai) ·


### PR DESCRIPTION
## 背景

objectos / objectstack 已完成拆分,本仓库现在是 ObjectOS 商业产品的公开门户(文档站、issue 跟踪、商标政策)。原 README 开头是一句偏公文式的定义,不够吸引人。

## 改动

- 重写 README 开头简介,采用 benefit-led 钩子(文案卖点取自 docs 首页,未发明新能力):
  - 标题句:**Describe the app you need. Keep the data you own.**
  - 正文:内置 AI Builder 把业务需求变成可运行的应用(生成 Console 管理界面、REST API、SSO、RBAC、审计日志);ObjectOS Cloud 托管运营,或 Enterprise 自管("your data — never ours")。
- 引言块下新增快捷链接行:官网 · 文档(docs.objectos.ai) · License & Pricing · 开源框架仓库 [objectstack-ai/objectstack](https://github.com/objectstack-ai/objectstack)。

## 建议同步更新仓库 About 简介(需管理员在仓库设置中修改)

当前 About 还是拆分前的旧文案(仍在描述框架能力,那已是 objectstack 仓库的角色)。建议改为:

> Describe the app. Keep the data. ObjectOS turns plain language into governed business apps — AI Builder, admin Console, SSO, RBAC, audit — in our cloud or yours. Docs &amp; issues for the commercial runtime built on ObjectStack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk