### PR TITLE
docs(readme): 以 "build & ask online vs with Claude Code" 表达与 objectstack 的核心区别

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # ObjectOS
 
-> ## Describe the app you need. Keep the data you own.
+> ## Build & ask online. Keep the data you own.
 >
 > ObjectOS is the **commercial runtime environment for
-> [ObjectStack](https://github.com/objectstack-ai/objectstack) apps**: tell the
-> built-in AI Builder what your business needs — a helpdesk, an approval flow,
-> a CRM — and get a working app with a generated admin Console, REST APIs,
-> SSO, RBAC, and audit logs. Run it as **ObjectOS Cloud** (we operate it) or
-> **ObjectOS Enterprise** (self-managed: your servers, your database, your
-> data — never ours).
+> [ObjectStack](https://github.com/objectstack-ai/objectstack) apps — built
+> and operated entirely in the browser**: tell the built-in AI Builder what
+> your business needs — a helpdesk, an approval flow, a CRM — and it's running
+> immediately, with a generated admin Console, REST APIs, SSO, RBAC, and audit
+> logs. No local toolchain, nothing to deploy. Run it as **ObjectOS Cloud**
+> (we operate it) or **ObjectOS Enterprise** (self-managed: your servers, your
+> database, your data — never ours).
 
 [Website](https://www.objectos.ai) ·
 [Documentation](https://docs.objectos.ai) ·
@@ -46,8 +47,8 @@ Everything you need to **build, run, and self-host your own applications** is
 the open-source (Apache-2.0) **[ObjectStack framework](https://github.com/objectstack-ai/objectstack)**:
 
 ```
-ObjectStack  →  for builders  — the open-source protocol, toolkit, and production runtime
-ObjectOS     →  for end users — the commercial runtime environment (Cloud & Enterprise)
+ObjectStack  →  build & ask with Claude Code — in your repo, with your coding agent (Apache-2.0)
+ObjectOS     →  build & ask online — in the browser, on a governed platform (Cloud & Enterprise)
 ```
 
 `os start` — or the official Docker image


### PR DESCRIPTION
## 背景

维护者明确了两个仓库的核心区别口径:objectstack = **build & ask with Claude Code**(在自己的仓库里用编码智能体开发),objectos = **build & ask online**(在浏览器里在线开发)。本 PR 把这一口径落进 README。

## 改动

- 首屏标题改为 **Build &amp; ask online. Keep the data you own.**,正文点明"完全在浏览器中构建与运营"、"No local toolchain, nothing to deploy"。
- "Building and running your own apps? That's ObjectStack" 一节的对照块改为:
  - `ObjectStack → build &amp; ask with Claude Code — in your repo, with your coding agent (Apache-2.0)`
  - `ObjectOS → build &amp; ask online — in the browser, on a governed platform (Cloud &amp; Enterprise)`

objectstack 侧的对应改动在 objectstack#3390(定位段落同口径)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk

---
_Generated by [Claude Code](https://claude.ai/code/session_0145qhfty9sRLm3HUvNBFxpk)_