### PR TITLE
ci: run the build check on merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #76

## Problem

The repo's merge queue is armed with `build` as a required check today. `.github/workflows/ci.yml`'s `on:` block only listened for `push` and `pull_request`, so it never produces a check run on the temporary merge-group ref a queued PR is validated against — every queued PR waits forever for a required check that never starts.

## Fix

Add the `merge_group:` trigger to `ci.yml`'s `on:` block. Minimal diff — one line, nothing else touched:

```diff
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:

 jobs:
   build:
```

`deploy-docs.yml` and `translations.yml` are unchanged (out of scope per the card). The inert `test` turbo task is a separate, already-filed finding (#72) and is untouched here.

## Self-landing property

This PR can land through the merge queue itself: a merge-group run executes the workflow **as defined at the merge-group ref**, which includes this PR's own `merge_group:` addition — so once queued, this change produces the `build` check that then lets it merge.

## Validation

- `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(d[True])"` → `{'push': {'branches': ['main']}, 'pull_request': {'branches': ['main']}, 'merge_group': None}` (PyYAML 1.1 parses the `on:` key as boolean `True`; this is a known quirk, not an error). Parses cleanly, `merge_group` present as a bare trigger alongside the existing two.
- `yamllint` not available in this environment; relied on the YAML parse above plus manual diff review.
- Diff reviewed: exactly the `merge_group:` line added, no other changes.

_Generated by [Claude Code](https://claude.ai/code/session_01WswfK2yNYT9hNnMH6TzAwL)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WswfK2yNYT9hNnMH6TzAwL)_