### PR TITLE
docs: align pages with framework 17.0

### DIFF
--- a/content/docs/build/ai-skills.mdx
+++ b/content/docs/build/ai-skills.mdx
@@ -42,7 +42,7 @@ versions.
 | `objectstack-ui` | Views, Apps, Pages, Dashboards, Reports, Charts, Actions |
 | `objectstack-automation` | Flows, Workflows, Triggers, Approvals, schedules, webhooks |
 | `objectstack-ai` | Agents, Tools, Skills, Conversations, Model Registry, MCP |
-| `objectstack-api` | REST/GraphQL endpoints, auth, realtime, error envelopes |
+| `objectstack-api` | REST endpoints, auth providers, realtime channels, error envelopes, batch/versioning contracts |
 | `objectstack-i18n` | Translation bundles, locale fallback, coverage |
 | `objectstack-formula` | CEL expressions — formula fields, validation/sharing/visibility predicates, conditions |
 

--- a/content/docs/build/automation/approvals.mdx
+++ b/content/docs/build/automation/approvals.mdx
@@ -56,11 +56,31 @@ The node declares **who approves** and how their decisions aggregate:
 
 | Config | What it does |
 |---|---|
-| `approvers` | Who must decide — a named user, a position, or a user resolved from a record field (e.g. the submitter's manager) |
+| `approvers` | Who must decide — see the approver types below |
 | `behavior` | How multiple approvers aggregate: `'first_response'` (default), `'unanimous'`, `'quorum'`, `'per_group'` |
 | `minApprovals` | Approvals required — total for `quorum` (M of N), per group for `per_group` (default 1) |
+| `onEmptyApprovers` | What happens when approver resolution yields nobody: `'admin_rescue'` (default), `'fail'`, `'auto_approve'` |
+| `decisionOutputs` | Keys a decision may carry back into the flow as structured outputs |
 | `approvalStatusField` | Optional record field the plugin mirrors the request status into |
 | `lockRecord` | Lock the record against edits while the request is pending |
+
+Each entry in `approvers` names a `type` and a `value`:
+
+| `type` | Resolves to |
+|---|---|
+| `manager` | The submitter's manager (`sys_user.manager_id`) — takes no value |
+| `position` | Holders of an org position |
+| `department` | Members of a business unit **and all descendant units** |
+| `team` | Members of a flat collaboration team |
+| `field` | The user id held in a field on the triggering record |
+| `user` | One named user id |
+| `org_membership_level` | An org-membership tier (`owner` / `admin` / `member`) |
+| `expression` | A CEL expression resolved at node entry — see below |
+
+Prefer the indirect bindings (`manager`, `position`, `department`,
+`team`) over a literal `user` id: they survive the person changing team
+or leaving, and a hard-coded id silently routes approvals to someone who
+should no longer see them.
 
 > **Warning — `position` vs the membership tier.**
 > `{ type: 'position', value: 'finance_manager' }` routes to the holders of a
@@ -116,6 +136,76 @@ Semantics that hold across every mode:
   misconfigured `minApprovals` can never deadlock a request.
 - Approvers without a `group` label each form their own group, so a plain
   approver list still behaves sensibly under `per_group`.
+
+### Dynamic routing: an approver picks the next approver (17.0)
+
+Three additions in 17.0 let a node decide its approvers from what the
+run has produced so far, instead of from a fixed declaration.
+
+**`expression` approvers** resolve a CEL expression at node entry
+against three explicit roots — `current.*` (the record's live state),
+`trigger.*` (the submit-time snapshot), and `vars.*` (flow variables,
+including upstream node outputs). The result becomes the approver
+slate:
+
+```ts
+config: {
+  approvers: [
+    { type: 'expression', value: 'vars.legal_review.picked_departments' },
+  ],
+  resolveAs: 'department',   // each value is a department id, fanned out to its members
+}
+```
+
+`resolveAs` (`'user'` by default, or `'department'` / `'position'` /
+`'team'`) says what kind of id the expression returned, and expands each
+through the same graph lookups the static approver types use. Under
+`behavior: 'per_group'`, each returned value forms its own group — one
+sign-off per returned department.
+
+`record` and bare field names are deliberately **not** available: on
+every other platform surface `record` means "the record at event time",
+and reusing it here would silently alias one of the two times.
+
+**`decisionOutputs`** is what feeds an expression like the one above.
+The *author* declares which keys a decision may carry; approvers only
+fill in values. Accepted outputs resume the run as
+`<nodeId>.<key>` flow variables — never bare names, so an approver
+cannot shadow an author's variable:
+
+```ts
+{
+  id: 'legal_review',
+  type: 'approval',
+  config: {
+    approvers: [{ type: 'position', value: 'legal_counsel' }],
+    decisionOutputs: [
+      { key: 'picked_departments', type: 'department', multiple: true },
+    ],
+  },
+}
+```
+
+An entry is either a bare key (rendered as a plain text input in the
+decision UI) or a typed declaration — `{ key, type, multiple }` — which
+tells the decision UI to render a record picker instead:
+`user` / `department` / `position` / `team` each get the matching
+system-object picker, and `multiple: true` collects an id array. A
+decision carrying undeclared keys is rejected; `decision` and
+`requestId` are reserved.
+
+**`onEmptyApprovers`** decides what happens when resolution yields no
+concrete person — an empty expression result, an unstaffed position, an
+empty multi-select field:
+
+| Value | Behavior |
+|---|---|
+| `'admin_rescue'` (default) | Open the request anyway and warn loudly; a privileged admin can take it over via Reassign. The only option that neither waves the record through nor kills the run |
+| `'fail'` | The node fails (fault edge / run failure). Choose when an empty slate can only mean a configuration bug |
+| `'auto_approve'` | Skip the request and continue down the `approve` edge with `output.autoApproved = true`. Opt-in, because it silently waves the record through |
+
+The default is deliberate: approval's job is to gatekeep, so an empty
+slate must never silently pass.
 
 ## A complete approval flow
 

--- a/content/docs/build/data/index.mdx
+++ b/content/docs/build/data/index.mdx
@@ -212,23 +212,61 @@ ObjectSchema.create({
   ownership: 'own',          // 'own' | 'shared' | 'system'
   sharingModel: 'private',   // OWD — custom objects default to private (v13)
   enable: {
-    apiEnabled: true,         // generated REST endpoints
-    trackHistory: true,       // History tab + field-level diffs (default true)
+    apiEnabled: true,         // generated REST endpoints (default true)
+    searchable: true,         // index records for global search (default true)
+    trackHistory: true,       // History tab + field-level diffs (opt-in, default false)
     feeds: true,              // sys_comment / @mentions (default true)
     activities: true,         // mirror CRUD to sys_activity timeline (default true)
-    files: true,              // Attachments panel (opt-in, default false)
-    trash: true,              // soft-delete with restore (default true)
+    files: false,             // Attachments panel (opt-in, default false)
+    clone: true,              // record deep cloning (default true)
   },
 });
 ```
 
-> **Changed in 16.0:** the object-level `softDelete` prop is removed —
-> `ObjectSchema.create` now throws a located error if you pass it. The
-> shipped equivalent is `enable: { trash: true }` (soft-delete with
-> restore), on by default. The same cleanup removed `versioning`,
+`enable` is a **closed vocabulary** — the block is strict, so an
+unrecognized flag (a typo like `feedEnabled`, or a key that used to
+exist) is a parse error naming the key, not a silently dropped setting.
+The seven flags above are the whole of it, plus one more key:
+
+```ts
+enable: {
+  apiMethods: ['get', 'list', 'create', 'update'],  // no delete over the API
+}
+```
+
+`apiMethods` whitelists which API operations the object exposes. The
+authorable vocabulary is exactly six primitives — `get`, `list`,
+`create`, `update`, `delete`, `bulk`. Omit the key for unrestricted
+access; `[]` means deny-all. The eight legacy values (`upsert`,
+`import`, `export`, `aggregate`, `search`, `history`, `restore`,
+`purge`) are *derived* effective operations, not things you declare:
+a stored one still parses but is stripped with a warning naming its
+replacement (`upsert` → `create` + `update`, `export`/`aggregate`/
+`search` → `list`, `history` → `get`; `restore` and `purge` derive from
+nothing and are simply deleted). Watch one cliff — a whitelist of
+*only* legacy values strips to `[]`, which closes the object's API
+rather than widening it.
+
+> **There is no soft delete — `enable.trash` was removed.**
+> Earlier docs pointed at `enable: { trash: true }` as the replacement
+> for the retired object-level `softDelete` prop. That was wrong in a way
+> worth stating plainly: `trash` never had a runtime consumer. Every
+> delete has always been a hard delete, so a default-true flag promising
+> a recycle bin was a false affordance — authors wrote `trash: false`
+> believing they were opting out of a soft delete that never ran. The key
+> (and its neighbour `enable.mru`) is now **rejected at parse time** with
+> guidance rather than ignored. Delete it from your source, or run
+> `os migrate meta --from 16` to rewrite it for you.
+>
+> For recoverability, use per-field `trackHistory` (an audit trail of what
+> changed) or a [`lifecycle`](#data-lifecycle-retention) policy. A real
+> recycle bin is not a shipped capability today.
+
+> **Also removed from the object surface:** `softDelete`, `versioning`,
 > `search` (use top-level `searchableFields`), `recordName` (use an
 > autonumber field as `nameField`), `keyPrefix`, `tags`, `active`, and
-> `abstract`.
+> `abstract` — `ObjectSchema.create` throws a located error naming the
+> replacement if you pass one.
 
 Since ObjectStack 14 the `enable.*` flags are **enforced**, not
 advisory: `feeds: false` rejects comment creation with 403

--- a/content/docs/configure/data-sources.mdx
+++ b/content/docs/configure/data-sources.mdx
@@ -7,7 +7,7 @@ A **datasource** is a named connection to an external data store. By
 declaring datasources, you point ObjectOS at the databases your business
 already runs on — a production PostgreSQL, a reporting MySQL replica, a
 MongoDB cluster — and then bind objects to them. Once an object is bound,
-everything else in the platform (the REST/GraphQL API, permissions,
+everything else in the platform (the REST API, permissions,
 flows, dashboards, and **AI agents**) works against that data uniformly,
 without caring where the rows physically live.
 
@@ -109,6 +109,19 @@ export const Customer = ObjectSchema.create({
   },
 });
 ```
+
+> **A datasource that objects bind to must connect, or the boot fails.**
+> Since ObjectStack 17.0 an unreachable datasource is a startup failure,
+> not a warning line. Previously only an `external` datasource with
+> `validation.onMismatch: 'fail'` fail-fasted: an app declaring
+> `datasource: 'analytics'` with objects bound to it, booted against a
+> wrong URL, started clean and exited zero — then failed every read and
+> write of those objects with `Datasource 'x' is not registered`.
+> `/api/v1/ready` also reports **503** when a data driver stops
+> answering, so a replica whose database has gone away is taken out of
+> rotation instead of serving errors. Connection attempts are bounded at
+> 10 seconds. See the
+> [17.0 release notes](https://docs.objectstack.ai/docs/releases/v17).
 
 ### Centralized routing with `datasourceMapping`
 

--- a/content/docs/configure/permissions/index.mdx
+++ b/content/docs/configure/permissions/index.mdx
@@ -80,7 +80,7 @@ to users directly or via positions.
 | Application access | Open CRM, open the support portal |
 | Object permissions | Create / read / update / delete records of an object |
 | Field permissions | Read or update specific fields |
-| System permissions | Access Console, run reports, export data, view audit log |
+| System permissions | Access Console, run reports, view audit log |
 | Integration permissions | Use API keys, configure webhooks, run admin actions |
 
 ### Object permission flags
@@ -93,12 +93,22 @@ These are the exact flag names the security plugin checks:
 | `allowCreate` | Create new records |
 | `allowEdit` | Update records the user can see |
 | `allowDelete` | Delete records the user can see |
+| `allowExport` | Take a bulk, machine-readable copy of the object's records |
 | `viewAllRecords` | Read **every** record for the object, ignoring record-access rules |
 | `modifyAllRecords` | Update/delete **every** record; implies `viewAllRecords` |
 
 `viewAllRecords` and `modifyAllRecords` are tenant-wide super-user
 grants for that object. Reserve them for explicit administrative
 permission sets and keep them out of any user-facing position.
+
+**Export is its own opt-in grant.** `allowExport` unset means
+**denied** — it does not inherit from `allowRead`, and `viewAllRecords` /
+`modifyAllRecords` do **not** confer it. Reading a record and taking a
+machine-readable copy of a whole table are different acts, and this is
+the segregation-of-duties axis that separates them. Grant it explicitly
+on the object entry (or the `'*'` wildcard) of every set whose holders
+should export. See
+[Permission Sets](/docs/configure/permissions/permission-sets#export-is-its-own-grant).
 
 See [Permission Sets](/docs/configure/permissions/permission-sets).
 

--- a/content/docs/configure/permissions/managing-access.mdx
+++ b/content/docs/configure/permissions/managing-access.mdx
@@ -144,7 +144,8 @@ When translating a requirement into a change, pick the matching layer:
 | Can read/create/edit/delete an object type | Object permissions | [Permission Sets](/docs/configure/permissions/permission-sets) |
 | Can see / edit a specific field | Field-level security | [Field-Level Security](/docs/configure/permissions/field-level-security) |
 | Which *rows* a user sees | Record access | [Record Access](/docs/configure/permissions/record-access) |
-| A functional capability (export, manage users) | System permissions | [Permission Sets](/docs/configure/permissions/permission-sets#system-permissions) |
+| Can bulk-export an object's records | Object permissions — `allowExport`, an opt-in grant that read does **not** confer | [Export is its own grant](/docs/configure/permissions/permission-sets#export-is-its-own-grant) |
+| A functional capability (manage users, view audit logs) | System permissions | [Permission Sets](/docs/configure/permissions/permission-sets#system-permissions) |
 | Can open an app or nav entry | Application access | [Permission Sets](/docs/configure/permissions/permission-sets) |
 
 ## Quick paths

--- a/content/docs/configure/permissions/permission-sets.mdx
+++ b/content/docs/configure/permissions/permission-sets.mdx
@@ -16,7 +16,7 @@ resolving immediately.
 | Application access | User can open CRM or Console |
 | Object permissions | Create, read, update, delete records |
 | Field permissions | Read or update selected fields |
-| System permissions | Access Console, run reports, export data |
+| System permissions | Access Console, run reports, view audit logs |
 | Integration permissions | Use API keys, webhooks, or admin actions |
 
 ## Object permissions
@@ -36,6 +36,7 @@ plugin's permission evaluator):
 | `allowCreate` | Create records |
 | `allowEdit` | Update records allowed by record access rules |
 | `allowDelete` | Delete records allowed by record access rules |
+| `allowExport` | Take a bulk, machine-readable copy of the object's records |
 | `viewAllRecords` | Read every record for the object, bypassing record access |
 | `modifyAllRecords` | Update or delete every record for the object, bypassing record access; implies `viewAllRecords` for reads |
 
@@ -45,6 +46,46 @@ row-level boundary. Reserve those flags for
 administrative permission sets — they are effectively a tenant-wide
 super-user grant for that object.
 
+### Export is its own grant
+
+Export is an **object permission**, not a system permission, and it is
+**opt-in**:
+
+| `allowExport` | Result |
+|---|---|
+| unset | export **denied** |
+| `false` | denied |
+| `true` | allowed (still bounded by `allowRead`) |
+
+Unset used to mean "inherit read". Since ObjectStack 17.0 it means
+denied, and `viewAllRecords` / `modifyAllRecords` no longer confer it
+either — "may see all data" and "may take a bulk copy of it" are
+deliberately different grants.
+
+```ts
+objects: {
+  deal: { allowRead: true, allowExport: true },   // ← add the grant
+}
+```
+
+Three consequences worth planning for:
+
+- **Package-shipped sets are re-seeded on upgrade**, so
+  `admin_full_access` and `organization_admin` carry `allowExport: true`
+  for you. **Environment-authored sets are not** — edit any custom set
+  whose users export.
+- **`member_default` deliberately does not carry the grant**, so ordinary
+  authenticated users lose export until an admin grants it. That is the
+  point of the flip, not an oversight.
+- **A set carrying `allowExport` is high-privilege**, so it cannot be
+  bound to the `everyone` or `guest` audience anchors — otherwise the
+  opt-in would be defeatable by binding an exporting set to an anonymous
+  anchor.
+
+Merge is most-permissive, exactly like the CRUD bits: any assigned set
+granting `true` grants export, and `false` and unset produce the same
+outcome. Reports are covered by the same axis.
+
 ## System permissions
 
 System permissions are for platform actions such as:
@@ -53,7 +94,6 @@ System permissions are for platform actions such as:
 - manage users;
 - manage positions and permission sets;
 - run reports;
-- export reports;
 - manage integrations;
 - view audit logs.
 

--- a/content/docs/configure/permissions/record-access.mdx
+++ b/content/docs/configure/permissions/record-access.mdx
@@ -61,6 +61,33 @@ Use sharing rules for repeatable business policies:
 - finance can read approved invoices;
 - auditors can read records tagged for audit review.
 
+A rule is a CEL `condition` over field values, compiled at author time
+into a row filter; matching records materialize `sys_record_share`
+grants for the resolved recipients (a user, team, position, business
+unit, or a unit and its subordinates). `criteria` rules are the only
+authorable form.
+
+### Both switches fail closed
+
+Two things a reader is entitled to assume, and which have been true only
+since ObjectStack 17.0:
+
+- **A sharing rule with no criteria shares nothing.** A rule stored
+  without a criteria predicate used to evaluate as *every record of the
+  object* — the empty filter — so a typo through an unvalidated write
+  path silently opened the whole table. Writing a match-all criteria is
+  now rejected, and the evaluator treats an empty one as matching
+  **nothing**.
+- **An RLS policy with `enabled: false` is disabled.** A policy switched
+  off used to keep contributing its OR-branch grant, so turning a policy
+  off did not take the access away. A disabled policy is now simply not
+  evaluated.
+
+If you audited access under an earlier release and concluded "this rule
+grants nothing" or "this policy is off", it is worth re-running the
+[explain engine](/docs/configure/permissions#diagnose--audit) — the
+answer may have been wider than the metadata said.
+
 ## Record shares
 
 Use record shares for exceptions:

--- a/content/docs/deploy/docker.mdx
+++ b/content/docs/deploy/docker.mdx
@@ -119,6 +119,13 @@ has to reproduce it:
 
 Two HTTP endpoints exist for this, and they are not interchangeable:
 `/api/v1/health` for liveness and `/api/v1/ready` for readiness.
+Readiness is backed by the data layer: since ObjectStack 17.0
+`/api/v1/ready` answers **503** when a data driver stops answering, so a
+replica whose database has gone away is pulled from rotation rather than
+left serving errors. A datasource that objects bind to must also connect
+at startup or the boot fails outright — an unreachable database is a
+failed deploy, not a container that comes up and then errors on every
+request.
 
 In production, point the deployment at your **managed** PostgreSQL (and Redis,
 if you cluster) and remove the bundled database services. Give the proxy your

--- a/content/docs/deploy/kubernetes.mdx
+++ b/content/docs/deploy/kubernetes.mdx
@@ -39,6 +39,13 @@ variable.
 different questions, and using one for both means either routing traffic at a
 replica that is not ready, or restarting a replica that is merely busy.
 
+Since ObjectStack 17.0 readiness is backed by the data layer:
+`/api/v1/ready` answers **503** when a data driver stops answering, so a
+readiness probe pointed at it will correctly pull a replica out of the
+Service endpoints when its database goes away. Keep it off the liveness
+probe for exactly that reason — a shared database outage would otherwise
+restart every replica at once instead of draining traffic.
+
 ### Every replica gets identical secrets
 
 Multi-replica is not a matter of raising the replica count:

--- a/content/docs/extend-existing-systems.mdx
+++ b/content/docs/extend-existing-systems.mdx
@@ -69,8 +69,8 @@ Once the tables are modeled as objects bound to your existing database:
   the answer is computed against live data through ObjectQL.
 - **Governed automation.** Flows and actions can read and (where allowed)
   write the same data, with every step audited.
-- **A generated API and Console.** REST/GraphQL endpoints and admin
-  screens come from the same metadata — no extra integration layer.
+- **A generated API and Console.** REST endpoints and admin screens come
+  from the same metadata — no extra integration layer.
 - **One permission model.** The boundary that applies to humans applies
   identically to AI traffic.
 

--- a/content/docs/operate/backup.mdx
+++ b/content/docs/operate/backup.mdx
@@ -133,8 +133,14 @@ replicas).
 
 ## Failure modes worth rehearsing
 
-- **Database unavailable for a long window.** Confirm the runtime
-  surfaces a clear 503 and that probes correctly mark pods unhealthy.
+- **Database unavailable for a long window.** Since ObjectStack 17.0 this
+  is contractual rather than something to hope for: `/api/v1/ready`
+  answers 503 while a data driver is not answering, so readiness probes
+  mark the pods unready. Rehearse the *recovery* — that the replicas
+  rejoin once the database returns, and that nothing needed a restart to
+  notice. A datasource that objects bind to and that cannot connect at
+  startup now fails the boot, so verify your restore completes before the
+  application replicas roll.
 - **Artifact regression.** Roll back the artifact pointer; data is
   unaffected.
 - **Secret rotation.** Rotating `AUTH_SECRET` invalidates every

--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -15,7 +15,7 @@ difference is whether you scaffold source files.
 
 ## Prerequisites
 
-- **Node.js 20 or newer** — `node --version`
+- **Node.js 22 or newer** — `node --version`
 - A terminal
 
 That's it. No Docker. No database. No account signup.

--- a/content/docs/reference/field-types.mdx
+++ b/content/docs/reference/field-types.mdx
@@ -152,6 +152,27 @@ Formula example:
 }
 ```
 
+### What a media field stores
+
+A media field stores an **opaque `sys_file` id** — not a URL, and not an
+inline metadata blob. The `{ url, name, size, mimeType, … }` object you
+see when you read a record is the **expanded (read) form**, derived by
+the platform from the owning `sys_file` record; `url` comes from the
+`/files/:fileId` resolver rather than from anything stored on your row.
+
+This is what makes the constraints real. Because the platform owns the
+bytes, `accept` and `maxSize` are not just hints handed to the browser's
+file picker — the server re-checks a record write against them
+authoritatively, so a caller that talks to the API directly cannot
+bypass them. It is also what lets a download carry the real filename and
+content type, and read authorization be delegated to the owning object
+instead of handed out as an unguessable URL.
+
+Existing deployments convert with `os migrate files-to-references`. See
+[Storage](/docs/configure/storage) for where the bytes actually live and
+the [17.0 release notes](https://docs.objectstack.ai/docs/releases/v17)
+for the migration's self-check and per-deployment flag.
+
 > The nested `fileAttachmentConfig` object was removed in 16.0 — it was never
 > read by the runtime. Use the flat `multiple` / `accept` / `maxSize` properties.
 > Storage is configured per deployment (see Configure → Storage), not per field.

--- a/content/docs/reference/runtime-capabilities.mdx
+++ b/content/docs/reference/runtime-capabilities.mdx
@@ -70,6 +70,13 @@ ObjectOS commonly exposes:
 - metadata and i18n endpoints;
 - service endpoints for enabled capabilities.
 
-GraphQL and OData are framework-level capabilities and should be
-documented as supported only when included and enabled by the deployed
-runtime package.
+OData is a framework-level capability and should be documented as
+supported only when included and enabled by the deployed runtime
+package.
+
+**GraphQL is not one of them.** The GraphQL surface was removed in
+ObjectStack 17.0 — the endpoint had never been implemented behind the
+route, and `/graphql` now returns 404. Do not document it as an
+available or optional capability of any runtime package. (`graphql`
+remains a valid protocol on an **external datasource**, which is a
+system ObjectOS queries, not a surface it serves.)

--- a/content/docs/reference/skills-cli.mdx
+++ b/content/docs/reference/skills-cli.mdx
@@ -50,7 +50,7 @@ Run `npx skills detect` to see what the CLI plans to write.
 | `objectstack-ui` | [Views](/docs/build/interface/views), Apps, Pages, Dashboards, Reports, Charts, Actions |
 | `objectstack-automation` | Flows, Workflows, Triggers, Approvals, schedules, webhooks |
 | `objectstack-ai` | Agents, Tools, Skills, Conversations, Model Registry, MCP |
-| `objectstack-api` | REST/GraphQL endpoints, auth, realtime, error envelopes |
+| `objectstack-api` | REST endpoints, auth providers, realtime channels, error envelopes, batch/versioning contracts |
 | `objectstack-i18n` | Translation bundles, locale fallback |
 | `objectstack-formula` | [CEL](./cel) expressions — formula fields, predicates, conditions, schedules |
 

--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -23,18 +23,23 @@ version number — they're tested as a matrix, not independently.
 | ObjectOS image ↔ compiled artifact | Same minor version. A 14.7.x image runs a 14.7.x artifact; a 14.7 artifact may use features unavailable in a 14.0 image. The protocol handshake (`PROTOCOL_VERSION`, 12.0+) rejects incompatible packages at install time. |
 | ObjectOS ↔ CLI | Same minor version recommended. The CLI in `npm i -g` writes scaffolds pinned to its own version. |
 | ObjectOS ↔ database driver | Driver pinned by image build; verify Postgres ≥ 13 / MongoDB ≥ 5 / Turso (any current). |
-| Node.js | **20 LTS or newer**. 22 LTS recommended for new deployments. |
+| Node.js | **22 or newer** — `engines.node` is `>=22.0.0` across every published `@objectstack/*` package since 17.0. Node 20 reached end-of-life on 2026-04-30. |
 
 ## Support windows
 
-| Branch | Status | Until |
-|---|---|---|
-| **14.x** (current) | Active development; new features and fixes | At least 12 months after 15.0 ships |
-| **13.x** | Security fixes only | EOL on 15.0 release |
-| **≤ 12.x** | Unsupported | Already EOL |
+Support is defined **relative to the current major**, not against a
+fixed calendar:
+
+| Branch | Status |
+|---|---|
+| Current major (17.x today) | Active development; new features and fixes |
+| Previous major (16.x today) | Security fixes only |
+| Older majors | Unsupported |
 
 Critical security fixes are backported to the current and previous
-major. Everything else lands on `main`.
+major. Everything else lands on `main`. Dates attached to a specific
+major are published with that major's
+[release notes](https://docs.objectstack.ai/docs/releases).
 
 ## Release notes
 
@@ -48,6 +53,76 @@ Released ObjectOS versions and their CHANGELOG entries are published at:
 Subscribe to releases on GitHub to get notified.
 
 ## Recent highlights
+
+### 17.0
+
+`@objectstack` **17.0.0** (released 2026-08-14) is a truth-telling
+release: where 16.0 made *declared metadata* honest, 17.0 does the same
+for the surfaces around it. Full notes:
+[docs.objectstack.ai/docs/releases/v17](https://docs.objectstack.ai/docs/releases/v17).
+What moved:
+
+- **Node.js 22 is the floor** (breaking) — `engines.node` moves from
+  `>=18.0.0` to `>=22.0.0` across all 50 published manifests. CI, the
+  release pipeline, and every shipped Docker image already ran 22; the
+  promise now matches the evidence. On Node 22+ nothing changes. If your
+  CI pins Node, pin it to 22.
+- **Bulk export is its own privilege** (breaking) — `allowExport` unset
+  used to mean "inherit read"; it now means **denied**, and
+  `viewAllRecords` / `modifyAllRecords` no longer confer it either.
+  Package-shipped sets are re-seeded on upgrade, so `admin_full_access`
+  and `organization_admin` keep exporting — **environment-authored sets
+  are not**. Add `allowExport: true` to any custom set whose users
+  export. See [Permission Sets](/docs/configure/permissions/permission-sets).
+- **A file is a record, not a blob in a column** — media fields
+  (`file`/`image`/`avatar`/`video`/`audio`) store an opaque `sys_file`
+  id; the `{ url, name, size, … }` object becomes the *read* (expanded)
+  form. Because the platform owns the bytes, `accept` / `maxSize` are
+  declarable **and server-enforced** rather than browser-side hints.
+  `os migrate files-to-references` performs the conversion. See
+  [Field Types](/docs/reference/field-types#media).
+- **The GraphQL surface is removed** (breaking) — it was schema-only from
+  day one: the handler answered 501 unconditionally because the service
+  was never assigned. `/graphql` now returns 404. Unaffected: `graphql`
+  as a protocol for an **external** datasource, which is someone else's
+  API rather than one ObjectOS serves.
+- **A sharing rule with no criteria shares nothing, and a disabled RLS
+  policy is disabled** (breaking, security) — a rule stored without
+  criteria used to evaluate as *every record of the object*, and an RLS
+  policy switched off with `enabled: false` kept contributing its
+  OR-branch grant. Both now fail closed. See
+  [Record Access](/docs/configure/permissions/record-access).
+- **An approval request is visible to its participants** (security) —
+  `getRequest` / `listRequests` / `countRequests` applied only the tenant
+  half of the visibility rule, so any authenticated user could read any
+  request in their tenant: payload snapshot, decision history, and
+  attachments.
+- **Approvers can be routed dynamically** — approval nodes gain
+  `expression` approvers (CEL over `current.*` / `trigger.*` / `vars.*`),
+  a node-level `onEmptyApprovers` policy, and author-declared decision
+  outputs that resume the run as `<nodeId>.<key>` flow variables. See
+  [Approvals](/docs/build/automation/approvals).
+- **A broken datasource is loud at boot** — a datasource that objects
+  bind to must connect or the boot fails, `objectql.init()` refuses to
+  start on a dead data driver, and `/api/v1/ready` answers 503 when one
+  stops answering. Previously such a boot started clean, exited zero, and
+  then failed every read and write of the bound objects.
+- **`enable.apiMethods` shrinks to six primitives** (breaking) — the
+  authorable enum is exactly `get`, `list`, `create`, `update`, `delete`,
+  `bulk`. The eight legacy values are *derived* effective operations;
+  a stored one is stripped at parse with a warning naming its
+  replacement.
+- **The dead-metadata sweep continues** (breaking) — `object.enable.trash`
+  and `enable.mru`, `tool.requiresConfirmation`, `agent.tools[]`,
+  `agent.knowledge`, `SkillSchema.permissions`, report `aria` /
+  `performance`, `flow.active`, and a long tail of parsed-but-ignored
+  keys are removed. Each rejects at parse time with its upgrade
+  prescription rather than being silently stripped. Run
+  `os migrate meta --from 16` to rewrite your sources.
+- **The authorable surface is closed** — every authorable metadata type
+  now rejects unknown keys with a named prescription, on the parse path
+  and not only in `create()`. A typo is a located error instead of a
+  setting that quietly never took effect.
 
 ### 16.0
 

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -10,7 +10,7 @@ A: `npm i -g @objectstack/cli && os start` — then open
 http://localhost:3000. See [Quickstart](/docs/quickstart).
 
 **Q: Do I need Docker?**
-A: No. Node 20+ and the CLI are enough. Docker is the recommended
+A: No. Node 22+ and the CLI are enough. Docker is the recommended
 production deployment shape.
 
 **Q: Do I need a database?**
@@ -36,9 +36,14 @@ A: Yes. Console uses the same `/api/v1/*` endpoints you'd call from
 your own code. Use `@objectstack/client` SDK or any HTTP client.
 
 **Q: Does ObjectOS support GraphQL?**
-A: REST is the primary surface. GraphQL is on the roadmap — until then,
-the ObjectQL query language (over REST `?filter=`/`?sort=`) covers the
-same ground.
+A: No. REST is the API surface. The GraphQL endpoint was removed in
+ObjectStack 17.0 — it had never been implemented behind the route, and
+`/graphql` now returns 404. Use the generated REST API with the
+[ObjectQL](/docs/reference/objectql) query language (over `?filter=` /
+`?sort=` / `?expand=`), which covers the same ground. A third-party
+system that speaks GraphQL is unaffected: `graphql` remains a valid
+protocol for an *external* datasource, which is a client of someone
+else's API rather than a surface ObjectOS serves.
 
 **Q: How is multi-tenancy handled?**
 A: One ObjectOS process can serve many Environments (tenants). Hostname

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -185,7 +185,9 @@ sharing rules (declarative criteria).
 
 A declarative rule that grants record access based on criteria
 ("regional managers can see records in their region"). Evaluated at
-query time, compiled into row-level filters.
+query time, compiled into row-level filters. A rule stored **without**
+criteria shares nothing — it is not a match-all. See
+[Record Access](/docs/configure/permissions/record-access#both-switches-fail-closed).
 
 ### Console
 


### PR DESCRIPTION
Fixes #78

The docs were aligned to 16.0 and had not moved since. This brings them to 17.0.0 (released 2026-08-14).

**Every claim below was checked against `packages/spec` on `objectstack@origin/main`, not against the release prose.** The card said its findings came from release notes plus a grep and had not been schema-checked; three of them changed shape once measured, and one is refuted outright. Those are called out in their own section.

English only — 19 files, zero locale siblings. The pages edited now report stale in the freshness gate, which is the designed outcome.

---

## The four live contradictions (the priority)

| Page | Was | Now | Verified against |
|:--|:--|:--|:--|
| `quickstart.mdx` | "Node.js 20 or newer" | "Node.js 22 or newer" | `package.json` and `packages/cli/package.json` both declare `engines.node: ">=22.0.0"` |
| `resources/faq.mdx` | "Node 20+ and the CLI are enough" | "Node 22+ …" | same |
| `resources/faq.mdx` | "GraphQL is on the roadmap" | "No. REST is the API surface … `/graphql` now returns 404" | `packages/spec/src/system/core-services.zod.ts` (the entry left in #4451/v17); no `graphql` module remains under `packages/spec/src` |
| `build/data/index.mdx` | `enable: { trash: true }` documented as the shipped replacement for `softDelete`, "on by default" | the whole note rewritten — see below | `packages/spec/src/data/object.zod.ts`, `CAPABILITIES_RETIRED_KEY_GUIDANCE` |

I also found a **fifth in the same class** the card's grep missed: `resources/changelog.mdx` compatibility matrix said "Node.js — **20 LTS or newer**". Same fix.

### On `enable.trash` — the correction is bigger than "the key was removed"

The card called this the worst of the four and it is, but not quite for the stated reason. The schema's retirement guidance says:

> `enable.trash` was removed from @objectstack/spec in the 16.x line (#2377/#3207, ADR-0049) — **it never had a runtime consumer: every delete has always been a hard delete**, and a default-true flag promising a recycle bin was a false affordance (authors wrote `trash: false` believing they were opting out of a soft-delete that never ran).

So the page was not merely pointing at a key that stopped parsing — it was describing a **capability that never existed**. "Soft-delete with restore, on by default" was wrong on the day it was written. The rewrite says that plainly, gives the real recoverability options the schema names (per-field `trackHistory`, a `lifecycle` policy), states that soft delete is not a shipped capability, and gives the migration (`os migrate meta --from 16`).

Two dating notes, since the card and the release notes disagree with the schema and I would rather flag it than paper over it: the schema attributes the removal to **the 16.x line**, while `content/docs/releases/v17.mdx` lists `object.enable.trash` / `enable.mru` in its 17.0 retirement table. Both agree the key is now strict-rejected, which is the only part the doc asserts, so I wrote the doc without a version attribution for the removal itself.

While in that section I closed the honesty gap it opened: the page now claims `enable` is a closed vocabulary, so it has to list the vocabulary. The flag list is corrected against `ObjectCapabilities` (`searchable` and `clone` were missing; `trackHistory` and `files` were shown with the wrong defaults — both are opt-in, default `false`), and `enable.apiMethods` is documented, including the six-primitive shrink and the deny-all cliff a pure-legacy whitelist falls into.

---

## Where the card was wrong

### `configure/mcp.mdx:157` — refuted, no change made

The card flagged `ai.requiresConfirmation` against the `tool.requiresConfirmation` that 17.0 removed, and said to read both schemas rather than assume the similar name meant the same key. They are different keys on different schemas, and **the removed one's own retirement guidance prescribes the one this page documents**:

> `tool.requiresConfirmation` was removed … it never had a consumer, and a SAFETY flag that is merely accepted is false compliance … **For a REAL gate on a destructive operation, put it behind an action and set `action.ai.requiresConfirmation` — that is the flag the HITL approval queue reads** (`packages/runtime/src/action-execution.ts`), and it is the only path that actually stops execution.

`ActionAiSchema.requiresConfirmation` is live in `packages/spec/src/ui/action.zod.ts`, and its docstring also confirms the page's second sentence — "When unset, the bridge defaults to `true` for actions that look destructive (`confirmText` set, `mode:'delete'`, or `variant:'danger'`)". The page is correct as written. Editing it would have replaced a true statement with a false one.

Verified against: `packages/spec/src/ai/tool.zod.ts` (`TOOL_RETIRED_KEY_GUIDANCE.requiresConfirmation`) and `packages/spec/src/ui/action.zod.ts` (`ActionAiSchema`).

### Export — the pages were silent, not wrong

The card flagged this as unverified and it was right to. **None of the three pages asserts the old "export inherits read" behaviour.** They are silent: the object-permission flag tables list `allowRead` / `allowCreate` / `allowEdit` / `allowDelete` / `viewAllRecords` / `modifyAllRecords` and omit `allowExport` entirely.

So the correct change was to *add* the semantics, not correct a wrong statement — with one real error underneath: all three pages filed export under **system permissions** ("Access Console, run reports, export data"), and it is an **object permission**. That mis-routing is what would send an admin to the wrong screen.

Added: `allowExport` in both flag tables, a dedicated **Export is its own grant** section on `permission-sets.mdx` (the three-state table, the most-permissive merge, package-shipped sets re-seeded but environment-authored sets not, `member_default` deliberately without the grant, and the high-privilege anchor ban), and a corrected routing row on `managing-access.mdx`. Export removed from the system-permission examples on all three.

Verified against: `packages/spec/src/security/permission.zod.ts` (`ObjectPermissionSchema.allowExport` — "unset/false = no export … NOT implied by viewAllRecords/modifyAllRecords", enforced at `GET /data/:object/export` with `403 EXPORT_NOT_PERMITTED`) and `packages/spec/src/security/high-privilege.ts` (the anchor ban, and the explicit note that `member_default` carries no `allowExport`).

### Record access — also silent, not wrong

Same finding. `record-access.mdx` describes sharing rules as "grant access based on declarative criteria" and never says what an empty criteria does; neither page mentions RLS `enabled: false` at all. Silent, so again the fix is an addition — a **Both switches fail closed** section stating both contracts and pointing a reader who audited under an earlier release back at the explain engine, since the real answer may have been wider than their metadata said.

Verified against: `packages/spec/src/security/sharing.zod.ts` (`SharingRuleSchema` — "Both now reject a match-all criteria, and the evaluator treats one as matching NOTHING") and `packages/spec/src/security/rls.zod.ts` (`enabled` — "Disabled policies are not evaluated").

---

## Stale framing

**GraphQL, elsewhere.** Each of the four sites needed a different call, as the card predicted:

- `reference/runtime-capabilities.mdx` paired GraphQL with OData as optional framework capabilities. OData is still real (`packages/spec/src/api/odata.zod.ts`), GraphQL is not, so the sentence keeps OData and gains an explicit "GraphQL is not one of them — do not document it as available or optional".
- `extend-existing-systems.mdx` — "REST/GraphQL endpoints" was a passing mention; the word is simply dropped.
- The two skill blurbs (`reference/skills-cli.mdx`, `build/ai-skills.mdx`) **were** quoting upstream text that has since changed, exactly as the card guessed. `skills/objectstack-api/SKILL.md` on `objectstack@origin/main` now reads "REST endpoints, auth providers, realtime channels, error envelopes, batch/versioning contracts". Both blurbs are realigned to that.

Both surviving GraphQL mentions (faq, runtime-capabilities) preserve the one thing that is *not* removed: `graphql` remains a valid protocol on an **external datasource**, which is a system ObjectOS queries rather than a surface it serves (`content/docs/releases/v17.mdx`, "Not removed: the `'graphql'` protocol option on external datasource lookups").

**Media fields.** `reference/field-types.mdx` gains a *What a media field stores* section. The card's read was right — the page was silent about the thing that changed, not wrong about it — so nothing was corrected, only stated: an opaque `sys_file` id is stored, the `{ url, name, size, … }` object is the expanded read form with `url` derived from the `/files/:fileId` resolver, and that is *why* `accept` / `maxSize` are server-enforced rather than browser hints. `configure/storage.mdx` was checked for agreement as the card asked and already agrees ("metadata persists in `sys_file`"; "Files are tracked in the `sys_file` system object — never as raw paths in your records"), so it is untouched.

Verified against: `packages/spec/src/data/field-value.zod.ts` (`FileReferenceIdValueSchema` — "an opaque `sys_file` id"; `FileValueSchema` — "Wave 2 … makes THIS the `expanded` read shape, with `url` derived from the `/files/:fileId` resolver rather than stored") and `packages/spec/src/data/field.zod.ts` (`accept` / `maxSize` — "Offered to the file picker AND enforced on write").

**Approvals.** `build/automation/approvals.mdx` gains a *Dynamic routing* section covering all three 17.0 additions — `expression` approvers with their closed root set and `resolveAs` expansion, author-declared `decisionOutputs` resuming as `nodeId.key` flow variables, and the `onEmptyApprovers` policy table. The approver-type table is also completed: the page listed three kinds where the schema declares eight.

Verified against: `packages/spec/src/automation/approval.zod.ts` (`ApproverType`, `APPROVER_EXPRESSION_ROOTS`, `resolveAs`, `onEmptyApprovers`, `decisionOutputs`).

**Boot and readiness.** The card asked whether these pages under-promise, and they did — all three described `/api/v1/ready` as readiness without saying what makes it go red. `deploy/docker.mdx` and `deploy/kubernetes.mdx` now state the 503-on-dead-driver contract and, for k8s, why it belongs on the readiness probe and not the liveness one. `operate/backup.mdx` said to "confirm the runtime surfaces a clear 503"; that is contractual now, so the rehearsal is repointed at the recovery instead.

Verified against: `content/docs/releases/v17.mdx` § "A datasource that cannot connect fails the boot (#3741, #3758, #3826)" — shipped docs rather than schema, because boot and probe behaviour is runtime, not declarable. No numbers or migration steps were invented; the 10s connection bound is quoted from that section.

**`resources/changelog.mdx`.** A 17.0 entry, covering the eleven changes an ObjectOS operator or app author would act on, each linked to the page in these docs that now explains it. Also: the **Support windows** table pinned "14.x (current) / 13.x security fixes / ≤ 12.x unsupported", which would have been a fresh contradiction the moment a 17.0 entry sat above it. Rather than invent support dates for 17.x and 16.x — which this repository has no authority to state — the table is now expressed *relative to the current major*, with dates deferred to the release notes. That is the only change here that removes a concrete claim rather than fixing one, and it is deliberate.

---

## One page fixed outside the card's list

`configure/data-sources.mdx` — not on the card, found by grep during the GraphQL sweep.

- Line 10 said "the REST/GraphQL API" — same defect class as the four GraphQL sites, mechanical, dropped.
- It is also the page where a reader actually *declares* a datasource, so it is the load-bearing place for the 17.0 boot contract. The card's boot-and-readiness item found only pages matching `/api/v1/ready` and so missed it. Added a note that a datasource objects bind to must connect or the boot fails, with the concrete failure it replaces ("started clean, exited zero, then failed every read and write with `Datasource 'x' is not registered`").

---

## Verification

`pnpm turbo run type-check` and `pnpm turbo run build` — both **pass**, both run with `--force`. This is load-bearing: `turbo.json` declares no `inputs` for either task, so `content/docs/**` does not move the hash and the first run replayed a cached green from a *sibling worktree* (`FULL TURBO`, 55ms). Filed as #81. Forced runs: type-check 15.6s, build 59.7s, 550+ doc paths prerendered.

All three translation checks, run the way `.github/workflows/translations.yml` runs them:

```
$ node .github/scripts/check-translation-ownership.mjs --actor os-zhuang --files changed.txt
⚠ TRANSLATION_BOT_LOGIN is not set — ownership is not enforced yet.
  This PR touches 0 translation artifact(s) and 19 other file(s).
  → exit 0

$ node .github/scripts/check-translations.mjs
English pages: 79 · translations: 256 · guide rev 1
| Locale  | Stale | Missing | Guide-stale |
| zh-Hans |    15 |      17 |           0 |
| ja      |    15 |      40 |           0 |
| de      |    15 |      41 |           0 |
| es      |    15 |      40 |           0 |
| fr      |    15 |      40 |           0 |
| ko      |    15 |      40 |           0 |
✓ translations gate passed
  → exit 0

$ node .github/scripts/check-translation-output.mjs --self-test
✓ self-test: 20 case(s) on locale "zh-Hans", every rule demonstrated able to fail
  → exit 0

$ node .github/scripts/check-translation-output.mjs --files changed-output.txt
✓ translation output gate passed (104 pre-existing finding(s) reported)
  → exit 0
```

The freshness gate reports the edited pages as stale and still passes, which is the expected shape for an English-only PR. The output validator's 104 findings are pre-existing corpus debt in `license.*` / `support.*` locale files this PR does not touch; none is `unsafe`, so none blocks.

**Rendering.** The production build prerenders static HTML, so I read the rendered output rather than the diff — all 18 changed doc pages extracted and reviewed from `.next/server/app/en/docs/**.html`. Every anchor introduced was confirmed to resolve against a real generated heading id: `export-is-its-own-grant`, `both-switches-fail-closed`, `media`, `data-lifecycle-retention`.

Byte hygiene: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over all 19 files — clean.

---

## Out of scope, filed

- #80 — glossary "Record Share" names `role` / `group`, two recipient kinds ADR-0090 renamed to `position` / `team`. Pre-17.0 drift, different defect class.
- #81 — the turbo cache hazard above.

#70 (the multi-Environment model, six pages) is left separate rather than folded in: different defect class, and #79 is already filed `Blocked-by:` this card for the overlapping file surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_