### PR TITLE
docs: use one canonical name for the config-authored boot shape

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -118,7 +118,7 @@ carries the exact contract for each.
 |---|---|---|
 | **Config-authored** | The shipped shape. Single app, evaluation, air-gapped, most production deployments | The runtime boots the metadata authored in the image, plus anything installed into it |
 | **Artifact-pinned** | The app is released on its own cadence, separately from the runtime image | One variable names a published artifact by URL, with an optional integrity pin. Upgrading the app is a change to that variable plus a restart |
-| **Composed** | Several organizations behind the isolation wall, sharing one database, running a published app | The same artifact reference, consumed from the deployment's own configuration so the enterprise plugins load alongside it. Air-gap licensed only |
+| **Composed** | Several organizations behind the isolation wall, sharing one database, running a published app — the hosted single-app SaaS shape | The same artifact reference, consumed from the deployment's own configuration so the enterprise plugins load alongside it. Air-gap licensed only, and [refused at startup](/docs/deploy/air-gapped) otherwise |
 
 Whether the deployment also talks to a **control plane** is a separate
 decision, made by the cloud-posture variable — a connected deployment can be

--- a/content/docs/deploy/index.mdx
+++ b/content/docs/deploy/index.mdx
@@ -44,7 +44,7 @@ available to you — it is not just a matter of packaging.
 
 | Shape | The app comes from | Use it when |
 |---|---|---|
-| **Shipped runtime** | The image's own bundled application | A single-organization deployment; the default the Compose stack configures. |
+| **Config-authored** | The image's own bundled application — the metadata authored in the image, plus anything installed into it | A single-organization deployment; the default the Compose stack configures, and the shape that needs no configuration. |
 | **Artifact-pinned** | A published app artifact named by URL, resolved before any deployment config runs | You run one published app and want app upgrades to be an environment change and a restart, with no image rebuild. Note that the deployment's enterprise plugins do **not** load on this path. |
 | **Composed** | A published app artifact composed *with* this deployment's enterprise plugins | Several organizations share one database. This is the hosted single-app SaaS shape — and it is **air-gap-licensed only**, enforced at startup. |
 


### PR DESCRIPTION
Fixes #71

Two current pages named the same boot shape differently: `architecture.mdx` called row one **Config-authored**, `deploy/index.mdx` called it **Shipped runtime**. Rows two and three agreed, which is what made the third name costly — the deploy bundle ships one environment template per shape, `deploy/index.mdx` warns against adapting one template into another, and these pages are how a reader picks. A reader who had seen both could not tell whether the two names were one shape or two.

## What decided it: not the card's guess

The card proposed `deploy/index.mdx`'s "Shipped runtime" **because it is the newer page**, and labelled that a guess. It is not the newer page, and five independent lines of evidence point the other way.

**1. Three pages carry this table, not two.** `content/docs/configure/runtime.mdx:24` also names row one `Config-authored`. The corpus stands 2-1, and "Shipped runtime" is a hapax — it appears exactly once in the whole corpus as a shape name.

**2. The commit order inverts the guess.**

| Write | Commit | When | Row-1 name |
|---|---|---|---|
| `deploy/index.mdx` table | `093e848` (#62) | 2026-08-18 13:14:58 +0800 | Shipped runtime |
| `configure/runtime.mdx` + `architecture.mdx` tables | `7eaf3a9` (#63) | 2026-08-18 14:49:48 +0800 | Config-authored |
| `architecture.mdx` rewrite | `6711c94` (#69) | 2026-08-18 17:40:44 +0800 | Config-authored (kept) |

"Shipped runtime" is the **oldest** of the three writes. #63 landed after the Deploy rewrite, its scope was explicitly "outside Deploy", and its own message says it was reconciling a contradiction *with* the page #62 had just shipped.

**3. The template-mapping authority sits with `Config-authored`, not against it.** Triage favoured `deploy/index.mdx` as "the page that maps shapes to the shipped environment templates". But #63's commit message states its rows were checked "against the deployment bundle that ships with the release, and against the runtime and CLI source that reads it", and that "rows that could not be confirmed against any shipped artifact are not carried forward on a guess". That verification produced `Config-authored`.

**4. The naming paradigm is inherited from the framework, and "Shipped runtime" breaks it.** `Artifact-pinned` is the upstream product's own term — `packages/runtime/src/artifact-reference.ts`, `packages/cli/src/commands/serve.ts`, `packages/cli/test/artifact-pinned-boot.e2e.test.ts`, and the framework docs all say "Artifact-pinned boot". The paradigm is a past-participle naming **where the app came from**: Config-authored / Artifact-pinned / Composed. "Shipped runtime" is a noun phrase naming the *runtime*, under a column headed "The app comes from" — the odd one out even inside its own table. `Config-authored` is also live upstream vocabulary for this shape ("Config-authored stacks are unaffected", contrasted with `sys_metadata` overlay writes).

**5. "The shipped runtime" is already a generic phrase, and the collision lands on the worst page.** It is used three times upstream to mean the product runtime as shipped ("not part of the shipped runtime", "the cheap, shipped runtime guard", "ENFORCED in the shipped runtime") — and once right here, at `reference/environment-variables.mdx:158`: "Nothing in **the shipped runtime** reads `OS_ARTIFACT_FILE`". Promoting it to a proper noun would make the boot-contract reference page use the phrase in two senses at once. `Config-authored` has no such collision.

Choosing `Config-authored` also happens to need the fewest edits: `configure/runtime.mdx` is already correct, so only `deploy/index.mdx` changes.

## Row three: the evidence settles it, it does not contradict

The card flagged row three as differing in substance — `architecture.mdx` said "Air-gap licensed only" while `deploy/index.mdx` framed it as "the hosted single-app SaaS shape". These are not competing claims; they are the shape's **purpose** and its **requirement**, and two independent pages state them jointly:

- `deploy/air-gapped.mdx`, under the heading "The hosted multi-organization shape is air-gap-licensed too": the composed shape "requires an air-gap licence and `off`, both enforced at startup, and it has its own environment template in the deploy bundle."
- `reference/environment-variables.mdx`, on `OS_COMPOSED_ARTIFACT_URL`: "several organizations sharing one database. That shape has its own template in the deploy bundle, is air-gap-licensed only, and requires `OS_CLOUD_URL=off`; both are enforced at startup."

`deploy/index.mdx` already carried both halves. `architecture.mdx` carried the licence half and the multi-org description but not the purpose framing or the enforcement point, so it gains both — worded from the pages above rather than invented.

## Changes

- `content/docs/deploy/index.mdx:47` — row one renamed `Shipped runtime` to `Config-authored`, with the provenance gloss that makes the name self-explanatory on that page.
- `content/docs/architecture.mdx:121` — row three gains "the hosted single-app SaaS shape" and a link to where the startup refusal is stated.

No headings renamed, so no anchors move: `/docs/architecture#boot-modes` (linked from `operate/troubleshooting.mdx:34`) still resolves, confirmed against `id="boot-modes"` in the built HTML. Nothing in the corpus anchors to a shape name.

## Verification

Gate union re-run at the final commit `7d4ca79`:

```
@objectos/docs:type-check: cache bypass, force executing 6eb08f6bec2cc211
@objectos/docs:build:      cache bypass, force executing 8e2864cf2b9427a5
@objectos/docs:build:      ✓ Compiled successfully in 59s
 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    1m26.958s
```

`--force` throughout, per #81 — `cache bypass` on both tasks confirms real execution, not a replayed green. Separate runs: `type-check --force` 9.311s, `build --force` 1m33.178s.

All four `translations.yml` steps run locally:

| Step | Result |
|---|---|
| Ownership | pass — 0 translation artifacts touched, 2 other files |
| Freshness | `✓ translations gate passed` |
| Output validator self-test | `✓ 20 case(s) ... every rule demonstrated able to fail` |
| Output (PR-scoped) | `✓ translation output gate passed (104 pre-existing finding(s) reported)` |

Neither edited page has locale siblings — #63 and #69 deleted them when they rewrote the pages — so this PR adds **zero** translation debt and the freshness table is unchanged by it.

Rendered HTML read out of the build for both pages:

```
en/docs/deploy.html        Config-authored | The image's own bundled application — the metadata
                           authored in the image, plus anything installed into it | ...
en/docs/architecture.html  Config-authored | The shipped shape. Single app, evaluation,
                           air-gapped, most production deployments | ...
en/docs/architecture.html  Composed | ... — the hosted single-app SaaS shape | ... Air-gap
                           licensed only, and [refused at startup](/docs/deploy/air-gapped) otherwise
```

## For the router, not this PR

`content/docs/configure/runtime.mdx:24` already uses `Config-authored` — consistent, no change needed. That is the complete list of other pages carrying the canonical name; it is out of this card's declared file surface and needed no edit either way.

⚠️ This inverts the triage ruling on the issue, which picked `deploy/index.mdx`'s name on the stated grounds that "it is the newer page". That premise is false — see the commit table above. Flagging rather than quietly diverging; a docs rename is cheap to reverse if triage still prefers the other name on grounds other than recency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_