### PR TITLE
docs: retire the multi-Environment runtime model from six pages outside Deploy

### DIFF
--- a/content/docs/build/ai-builder.mdx
+++ b/content/docs/build/ai-builder.mdx
@@ -137,8 +137,8 @@ If the AI can't do it, it says so — and points you at the manual path
 ## Live preview
 
 After each approved change, Console re-renders the affected views in
-place. No reload needed. The kernel cache invalidates the touched
-package; subsequent requests use the new metadata.
+place. No reload needed. The runtime hot-loads the touched package's new
+metadata; subsequent requests use it.
 
 ## Roll back
 

--- a/content/docs/operate/observability.mdx
+++ b/content/docs/operate/observability.mdx
@@ -37,7 +37,7 @@ Track at least:
 | Request duration | Detect latency regressions |
 | 5xx errors | Alert on runtime failures |
 | Auth failures | Detect configuration or attack patterns |
-| Artifact/kernel cache misses | Understand cold-start behavior |
+| Readiness transitions | The process reports ready only once its kernel is built, and `/api/v1/ready` answers 503 when a data driver stops |
 
 ### Minimal Prometheus example
 
@@ -72,13 +72,11 @@ groups:
         for: 10m
         annotations:
           summary: "Sustained auth failure rate — check for misconfiguration or attack"
-
-      - alert: ObjectOSKernelColdStartHigh
-        expr: rate(kernel_cache_misses_total[15m]) > 1
-        for: 15m
-        annotations:
-          summary: "Frequent project kernel cold starts — consider raising OS_KERNEL_CACHE_SIZE"
 ```
+
+Cold starts are not on that list. The kernel is built once, at startup, and
+the process reports [ready](/docs/deploy/docker) only afterwards — there is
+no steady-state cache-miss signal to alert on, so alert on readiness instead.
 
 For OpenTelemetry, set `OS_OBS_EXPORTER=otlp` **and** `OS_OTLP_ENDPOINT`
 (e.g. `https://<collector>/otlp`) and ObjectOS will emit traces and metrics

--- a/content/docs/operate/troubleshooting.mdx
+++ b/content/docs/operate/troubleshooting.mdx
@@ -63,14 +63,13 @@ Check:
 - public URL and callback URL match;
 - OIDC discovery URL is reachable from ObjectOS;
 - trusted origins include the public domain;
-- cookies are scoped to the correct project hostname;
-- the project kernel has auth enabled.
+- cookies are scoped to the deployment's public hostname.
 
 ## User cannot see records
 
 Check:
 
-1. Correct project hostname.
+1. Correct deployment hostname.
 2. User belongs to the expected organization.
 3. Object `read` permission.
 4. Row-level security.

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -46,15 +46,23 @@ protocol for an *external* datasource, which is a client of someone
 else's API rather than a surface ObjectOS serves.
 
 **Q: How is multi-tenancy handled?**
-A: One ObjectOS process can serve many Environments (tenants). Hostname
-→ Environment resolution caches in an LRU; each Environment has its own
-database, identity, and audit log. Cookies are scoped per hostname so
-sessions can't leak across tenants.
+A: One deployment serves one app, against one database — see
+[Architecture](/docs/architecture). Several organizations can share that
+deployment: a **walled** tenancy posture (`OS_TENANCY_POSTURE`) puts up the
+per-organization isolation wall, and it is a licensed capability the runtime
+refuses to start without. What the wall separates is the organizations' data
+and memberships, not the metadata — schema is scoped to the deployment, not
+to an organization, which is why a walled deployment must also declare which
+AI agents are mounted. Isolation stronger than the wall is deployment
+separation: a customer that must have its own database gets its own
+deployment. See [Multi-organization
+deployments](/docs/reference/environment-variables#multi-organization-deployments).
 
 **Q: Can ObjectOS run in a serverless / Lambda environment?**
 A: The runtime is a long-lived Node process — designed for containers
-or VMs, not stateless functions. The kernel cache and Better Auth
-session model both depend on warm in-process state.
+or VMs, not stateless functions. The kernel is built at startup and the
+process reports ready only afterwards; that warm in-process state, and the
+Better Auth session model, are what a per-invocation function cannot keep.
 
 **Q: Does it scale horizontally?**
 A: Yes. Run multiple instances behind a load balancer. Sessions live in
@@ -146,13 +154,15 @@ for files + your secret manager for `OS_AUTH_SECRET`. See
 [Production Readiness](/docs/operate/production).
 
 **Q: Does ObjectOS have a status page?**
-A: For your self-hosted deployment, status is your concern — wire
-`/health` to your monitor. For hosted services, see
+A: For your self-hosted deployment, status is your concern — point your
+monitor at `/api/v1/health` for liveness and `/api/v1/ready` for readiness,
+the pair [Docker](/docs/deploy/docker) and
+[Kubernetes](/docs/deploy/kubernetes) wire up. For hosted services, see
 [status.objectstack.ai](https://status.objectstack.ai).
 
 **Q: What metrics should I monitor?**
-A: 5xx rate, p95 latency, auth failure rate, kernel cache miss rate,
-queue depth. Minimal Prometheus example in [Observability](/docs/operate/observability).
+A: 5xx rate, p95 latency, auth failure rate, readiness
+(`/api/v1/ready`), queue depth. Minimal Prometheus example in [Observability](/docs/operate/observability).
 
 **Q: How do I take a backup?**
 A: Back up the **database** and the **storage bucket** — those hold

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -77,9 +77,12 @@ See [AI Service](/docs/configure/ai).
 
 ### Environment
 
-A per-tenant runtime instance backed by its own database and identity.
-On v4.x sometimes called *Project* (alias kept). v5.0 standardizes on
-*Environment* across CLI, HTTP, env vars, and schemas.
+A deployment's own identity — the id it reports as `OS_ENVIRONMENT_ID`,
+persisted once a cloud binding completes. A self-hosted ObjectOS is a
+**single-environment** runtime: one process, one environment, one app.
+Holding many environments, and publishing an artifact for each, is what a
+control plane does. See
+[Environment Variables](/docs/reference/environment-variables).
 
 ### Field
 
@@ -108,9 +111,10 @@ hooks are first-class code; flows are metadata.
 ### Kernel
 
 The microkernel inside ObjectOS that loads plugins, holds the DI
-container, dispatches events, and serves a single Environment's
-metadata. One process can hold many cached kernels (one per
-Environment) in an LRU.
+container, dispatches events, and serves the deployment's metadata. One
+process builds one kernel, during startup, and does not report
+[ready](/docs/deploy/docker) until it is built — so nothing per request
+decides which metadata to serve.
 
 ### Manifest
 
@@ -172,8 +176,9 @@ A framework package that extends the runtime with a capability —
 
 ### Project
 
-Old name for **Environment**. Still used in v4.x CLI/env (aliased).
-Removed in v5.0.
+Old name for **Environment**. It survives in inherited configuration and
+in framework-internal identifiers; ObjectOS documentation says
+*Environment*.
 
 ### Record Share
 
@@ -208,9 +213,12 @@ code.
 
 ### Tenant
 
-A logical isolation boundary in multi-tenant deployments. One tenant
-typically maps to one Environment. Cookies and sessions are scoped per
-hostname; data is scoped per Environment.
+An isolation boundary between the organizations sharing one deployment.
+A walled tenancy posture puts the wall up and is a licensed capability.
+Those organizations still share the deployment's app, its database and its
+metadata, so the wall separates their data and memberships rather than
+their schema. See [Multi-organization
+deployments](/docs/reference/environment-variables#multi-organization-deployments).
 
 ### Trigger
 

--- a/content/docs/why.mdx
+++ b/content/docs/why.mdx
@@ -42,7 +42,6 @@ Common scenarios where it's a fit:
 | Building a compliance / risk / vendor management tool for a regulated business | Audit log, RBAC, field security, row-level isolation are first-class — and every AI-driven change is itself an audit entry |
 | Standing up an internal admin for a SaaS product | One Node process, slots in next to your existing services |
 | Air-gapped or on-prem deployment for an enterprise customer | First-class deployment target, no internet egress required (BYO local model) |
-| Multi-tenant internal portal (one runtime, many small apps) | Per-project kernel + LRU cache designed for this |
 | You want your users to "vibe-code" their own extensions safely | The AI Builder + HITL approval queue + audit log are the whole point |
 
 ## Don't use ObjectOS if you …


### PR DESCRIPTION
Fixes #70

Six English pages outside Deploy still taught the hosted many-Environments-per-process
model. Each row got its own decision, verified against `objectstack@origin/main` and
against the pages that shipped today, not a search-and-replace.

## The target state, and where it is pinned

`architecture.mdx` (rewritten by #82, landed today) is the page these six now agree with:
**a deployment serves one app, from one database, and its kernel is built during startup** —
"there is no cache sizing to get right", "nothing per-request resolves which app to serve".
`reference/environment-variables.mdx` carries the tenancy contract: one `OS_DATABASE_URL`,
and a **walled** posture (`OS_TENANCY_POSTURE`) that puts up the per-organization isolation
wall as a licensed capability, on a **shared** database, where "metadata is scoped to the
deployment, not to an organization".

Upstream confirms the split the docs should draw. In
`packages/runtime/src/http-dispatcher.ts` (`resolveRequestScope`), multi-kernel routing runs
only when the host registers a `KernelResolver`, and the comment says where that lives:
"strategy lives in the cloud distribution … **No resolver registered → single-environment:
every request serves from `defaultKernel` with no environment context.**"
`reference/environment-variables.mdx` already calls a self-hosted box "a **single-environment**
runtime" in the `OS_ENVIRONMENT_ID` row. So many-Environments-per-process is the hosted cloud
shape, which `faq.mdx` already says in its "Do I need an account / cloud service?" answer —
that answer was left as it stands.

## Row by row

| Page | Call | Verified against |
|---|---|---|
| `resources/faq.mdx` | Multi-tenancy answer rewritten | `reference/environment-variables.mdx` §Multi-organization deployments; `architecture.mdx` lines 52-57 |
| `resources/glossary.mdx` | Kernel, Environment, Tenant, Project rewritten | `architecture.mdx` lines 86-91, 140; `environment-variables.mdx` `OS_ENVIRONMENT_ID` row |
| `why.mdx` | Fit-scenario row removed; positioning question escalated, **not** decided | see below |
| `operate/observability.mdx` | Kernel cold-start alert deleted, signal row replaced | `packages/observability/src/semconv.ts` on `objectstack@origin/main` |
| `operate/troubleshooting.mdx` | Wording | `architecture.mdx`; the same list's own `OS_AUTH_SECRET` bullet |
| `build/ai-builder.mdx` | Wording | `architecture.mdx` lines 19-21 |

### `faq.mdx` — the card's sharpest claim, confirmed

The FAQ promised "each Environment has its own database, identity, and audit log". The card
asked whether the FAQ might be right and the other pages wrong. It is not: the evidence is
one-sided. A deployment gets one `OS_DATABASE_URL`; the env reference describes several
organizations on "a shared database"; `architecture.mdx` describes a walled deployment where
"several organizations share it" and share its app. The answer now describes the wall, says
what it separates (data and memberships) and what it does not (schema), and names deployment
separation as the stronger isolation.

### `observability.mdx` — the metric does not exist

`kernel_cache_misses_total` is emitted by **nothing**: `git grep kernel_cache` and
`git grep cache_miss` over `objectstack@origin/main` both return zero hits. The canonical
registry, `packages/observability/src/semconv.ts` — which exists, in its own words, "so hosts
can wire alerts/dashboards against a stable namespace" — lists 13 metric names, and no kernel
cache metric is among them. The nearest name is `cache_lookups_total{adapter,result}` from
`@objectstack/service-cache`, which is the optional application cache capability, not a kernel
LRU. Confirming the card: `OS_KERNEL_CACHE_SIZE` has **0** occurrences in
`reference/environment-variables.mdx` against **4** for `OS_ARTIFACT_URL` as a control.

The alert is therefore deleted rather than reworded — there is no metric to point a corrected
alert at, and inventing one is out of bounds. The `Artifact/kernel cache misses` signal row is
replaced with readiness, which is the shipped mechanism for the cold-start question it was
asking (`architecture.mdx` measures startup as "time to a 200 from `/api/v1/ready`").

### `why.mdx` — removed, not re-decided

Triage's clause on the card: do not decide the positioning claim here; flag it if simple
deletion feels lossy. It does feel lossy — a walled multi-organization deployment is a real,
shipped, licensed capability, so the *scenario* survives even though the *mechanism* the row
named ("Per-project kernel + LRU cache designed for this") does not exist. Correcting the row
would have been the deciding action the clause forbids; leaving a nonexistent mechanism on the
pitch page was not an option. So the row is removed — the reversible, non-deciding move — and
the positioning question is filed for the decision inbox. Re-adding a corrected row afterwards
is one line.

## Folded in, and why

- **The `/health` adjacency the card named.** `faq.mdx` told the reader to point a monitor at
  `/health` while `deploy/docker.mdx:121` and `deploy/kubernetes.mdx:38` name `/api/v1/health`
  for liveness and `/api/v1/ready` for readiness. **Folded in**, not split: it is in a file
  already being edited, it is the same defect class (page disagrees with the deploy pages that
  shipped), and the correct shape is pinned by two shipped pages rather than needing a
  decision. Note that `/health` is *not* a dead route — it is registered in
  `packages/runtime/src/http-dispatcher.ts:512` and the route ledger calls it a "liveness probe
  for orchestrators". The defect is that it is liveness-only, so a monitor wired to it alone
  never sees the readiness 503 that a stopped data driver produces.

Three further edits inside the six declared files, same defect class, each mechanically pinned:

- `faq.mdx` "serverless / Lambda" answer said "the kernel cache … depend[s] on warm in-process
  state" — same retired vocabulary, now the kernel built at startup.
- `faq.mdx` "What metrics should I monitor?" listed "kernel cache miss rate", a metric nothing
  emits; replaced with readiness.
- `glossary.mdx` **Environment** and **Tenant** carried the identical load-bearing false claim
  ("its own database" / "data is scoped per Environment"). **Project** changed only because the
  Environment rewrite removed the "v4.x / v5.0" sentence it referred back to; its version claims
  were **removed**, not restated, since `@objectstack/spec` is at 17.0.0 and no `OS_PROJECT*`
  variable exists upstream.

## Observed, deliberately not fixed

- **`auth_failures_total` is also a phantom metric** — the alert directly above the one deleted
  here. Zero hits across `objectstack@origin/main`, and absent from `SEMCONV`. Left alone on
  purpose: unlike the kernel alert, the correct shape is *not* pinned — with no auth metric in
  the registry at all, the fix is either deleting a genuinely useful alert or asking the runtime
  to emit one, which is a product call. Filed separately rather than decided in a docs PR.
- `quickstart.mdx` labels `/health` a "Liveness probe" — the same defect folded in above, but
  outside this card's declared file surface. Filed.
- `glossary.mdx` carries two separate `### Console` entries, each saying "Distinct from Console".
  Pre-existing, unrelated to this card, and adjacent to queued work on Console naming. Filed.
- `operate/troubleshooting.mdx` settings cascade (`Environment -> Tenant -> User -> Default`) was
  **not** touched: its "Environment" means the env-var override, matching
  `configure/system-settings.mdx`, not the retired concept.

## Verification

Both turbo tasks run with `--force`, because `turbo.json` declares no `inputs` covering
`content/docs/**` and the cache is shared across sibling worktrees — a `FULL TURBO` replay
would prove nothing here. Both logged `cache bypass, force executing`, on `acc5b6a`:

- `pnpm turbo run type-check --force` — **1 successful, 0 cached, 9.763s**
- `pnpm turbo run build --force` — **1 successful, 0 cached, 1m7.67s**

All three translation checks, invoked exactly as `translations.yml` invokes them:

- Ownership (`--actor os-zhuang --files changed.txt`) — exit **0**: "touches 0 translation
  artifact(s) and 6 other file(s)". Still inert pending `TRANSLATION_BOT_LOGIN`.
- Freshness — exit **0**, "translations gate passed". The six pages moved to stale in all six
  locales (18 stale per locale); reported, not blocking, per AGENTS.md.
- Output validator self-test — exit **0**, 20 cases, every rule demonstrated able to fail.
- Output validator, PR-scoped — exit **0**: "translation output gate passed (110 pre-existing
  finding(s) reported)". None attributable to this diff, which changes no locale file.

Rendered HTML was read out of `.next/server/app/en/docs/**` for all six pages — not just the
diff — and every changed passage was confirmed in the built output, including that the removed
`why.mdx` row is gone from the fit table and that the alert block dropped only the kernel alert.

English only. No locale sibling is touched; no page is retired or renamed, so no locale sibling
is deleted either.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_