### PR TITLE
docs(configure): state the composed shape's licence constraint on the runtime page

### DIFF
--- a/content/docs/configure/runtime.mdx
+++ b/content/docs/configure/runtime.mdx
@@ -23,7 +23,7 @@ Exactly one source is in effect, and the deployment declares which.
 |---|---|---|
 | **Config-authored** | The shipped shape: one app, evaluation, air-gapped, most production deployments | The runtime serves the metadata authored in the image, plus whatever has been installed into it |
 | **Artifact-pinned** | The app is released on its own cadence, independently of the runtime image | One variable names a published artifact by URL. The image's own configuration is not loaded on this path |
-| **Composed** | Several organizations behind the isolation wall, sharing one database, running a published app | The same artifact reference, consumed from the deployment's own configuration so the enterprise plugins load with it |
+| **Composed** | Several organizations behind the isolation wall, sharing one database, running a published app | The same artifact reference, consumed from the deployment's own configuration so the enterprise plugins load with it. Air-gap licensed only, and [refused at startup](/docs/deploy/air-gapped) otherwise |
 
 Upgrading a published app is a change to the artifact reference plus a restart
 — no image rebuild. Rollback is the same operation with the previous URL, which


### PR DESCRIPTION
Fixes #84

The boot-shape table on `content/docs/configure/runtime.mdx` listed the composed shape without the constraint that four other pages state: it is air-gap licensed only, and the runtime refuses to boot otherwise.

## Why this row and not tidiness

The page is where a reader lands to answer "where does the running app come from". Its own later section, "Startup decisions the runtime will not guess", already explains that licence mode and cloud posture are coupled and that bad pairings are refused — but never ties that back to the composed row. The page held both halves and did not join them. A reader planning a composed deployment from this page alone learned the shape exists, learned that some pairings are refused, and did not learn that this shape has one licit licence mode. The failure lands as a refused boot.

## The wording is not new

`architecture.mdx:121` is the direct twin of this row — same three-row boot-shape table, same "How the app arrives" column, and a cell that already opens with nearly the same sentence ("...so the enterprise plugins load alongside it" vs "load with it"). It carries exactly the clause this row lacked, so that clause is reused verbatim rather than reformulated:

> Air-gap licensed only, and [refused at startup](/docs/deploy/air-gapped) otherwise

The link points at where the refusal is stated, as the sibling pages do. All four sibling statements were read and they agree on the claim:

- `deploy/index.mdx:49` — "it is **air-gap-licensed only**, enforced at startup."
- `architecture.mdx:121` — "Air-gap licensed only, and [refused at startup] otherwise"
- `deploy/air-gapped.mdx:70` — "It requires an air-gap licence and `off`, both enforced at startup."
- `reference/environment-variables.mdx:96` — "is air-gap-licensed only, and requires `OS_CLOUD_URL=off`; both are enforced at startup."

The constraint is stated once, in the row. It is deliberately not restated in the "Startup decisions" bullet list: that section already links the same `/docs/deploy/air-gapped` matrix, so both halves of the page now point at one destination rather than carrying two copies of the claim.

## Scope

`content/docs/configure/runtime.mdx` only, one line. Row one's label was already `Config-authored` and is untouched by the rename that landed in #83 — verified in the worktree, not assumed.

English only. This page turns out to have **no locale siblings at all** (`git ls-files content/docs/configure/runtime*` returns just the English file), so nothing goes stale here — the six locales sit in the translation pass's *missing* bucket, and the worklist picks up all six.

## Verification, at `842dca3`

Both turbo tasks with `--force`, each confirmed `cache bypass, force executing` rather than `FULL TURBO`:

```
@objectos/docs:type-check: cache bypass, force executing cd923271a3fbb98b
@objectos/docs:build:      cache bypass, force executing a7cd347e90916054
 Tasks:    2 successful, 2 total
 Cached:    0 cached, 2 total
```

All three translation checks, run as CI invokes them:

- `check-translation-ownership.mjs --actor os-zhuang --files ...` — exit 0; touches 0 translation artifacts, 1 other file. (`TRANSLATION_BOT_LOGIN` unset, so it reports rather than enforces.)
- `check-translations.mjs` — exit 0, "translations gate passed".
- `check-translation-output.mjs --files changed-output.txt` — exit 0, "translation output gate passed (110 pre-existing finding(s) reported)". Those 110 are corpus fidelity debt, not this PR: a pristine worktree at the branch point `8816154` reports the identical 110, none name `configure/runtime`, and none are `unsafe` (the category that blocks corpus-wide regardless of PR scope).

Rendered HTML read from the production build — `.next/server/app/en/docs/configure/runtime.html` — with row three extracted:

```
| Composed
| Several organizations behind the isolation wall, sharing one database, running a published app
| The same artifact reference, consumed from the deployment's own configuration so the
  enterprise plugins load with it. Air-gap licensed only, and
  [refused at startup -> /docs/deploy/air-gapped] otherwise
```

The link renders as an anchor and its target route prerenders (`.next/server/app/en/docs/deploy/air-gapped.html`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_