### PR TITLE
docs: retire "Console" as the end-user surface name; keep Setup for administration

### DIFF
--- a/content/docs/build/agents.mdx
+++ b/content/docs/build/agents.mdx
@@ -47,7 +47,7 @@ export const tier1Support = defineAgent({
 });
 ```
 
-Or in Console: **Console → Agents → New Agent**.
+Or in the UI: **Agents → New Agent**.
 
 Or — and this is the point — say to the AI Builder:
 
@@ -114,7 +114,7 @@ POST /api/v1/ai/chat   { context: { appName: 'crm' }, ... }
 
 When `context.appName` resolves to an app that declares a
 `defaultAgent`, the runtime auto-selects that agent — the user never
-picks from a list. Console's built-in AI panel uses this. The runtime
+picks from a list. The built-in AI panel uses this. The runtime
 resolves:
 
 1. The **default agent** for the active app (the app's `defaultAgent`),

--- a/content/docs/build/ai-builder.mdx
+++ b/content/docs/build/ai-builder.mdx
@@ -1,10 +1,10 @@
 ---
 title: AI Builder
-description: The in-Console chat that turns plain-language requirements into running metadata.
+description: The built-in chat that turns plain-language requirements into running metadata.
 ---
 
 The AI Builder is the **primary way customers extend ObjectOS**. Open
-Console, talk to the assistant in plain language, and it builds the
+ObjectOS, talk to the assistant in plain language, and it builds the
 metadata for you — packages, objects, fields, actions, flows. Every
 change is queued in a Human-in-the-Loop (HITL) approval list before it
 goes live.
@@ -33,7 +33,7 @@ AI:  ✓ Package created
      Done. Try it: /support_ticket
 ```
 
-You now have a working ticketing app — REST endpoints, Console views,
+You now have a working ticketing app — REST endpoints, generated views,
 audit log entries, permission checkpoints, the works. No file was
 edited; no restart happened.
 
@@ -132,11 +132,11 @@ Verified patterns, with one-liner prompts:
 | Translation | *"Translate the support_ticket labels and picklists to Spanish."* |
 
 If the AI can't do it, it says so — and points you at the manual path
-(usually a 30-line `*.ts` file or a Console form).
+(usually a 30-line `*.ts` file or a form).
 
 ## Live preview
 
-After each approved change, Console re-renders the affected views in
+After each approved change, ObjectOS re-renders the affected views in
 place. No reload needed. The runtime hot-loads the touched package's new
 metadata; subsequent requests use it.
 

--- a/content/docs/build/ai-skills.mdx
+++ b/content/docs/build/ai-skills.mdx
@@ -3,7 +3,7 @@ title: IDE Skills (Claude Code / Cursor / Copilot)
 description: Install ObjectOS skills into your coding agent so Claude Code, Cursor, Copilot, Codex and friends know how to author ObjectOS metadata correctly.
 ---
 
-The [AI Builder](./ai-builder) lives inside Console and talks to your
+The [AI Builder](./ai-builder) lives inside ObjectOS and talks to your
 tenant's database. But sometimes you want the same domain knowledge
 inside your IDE — when you're hand-editing `*.object.ts`, designing a
 flow, or asking Cursor to write a CEL predicate.
@@ -89,7 +89,7 @@ disappear once the skills are installed.
 
 |  | [AI Builder](./ai-builder) | IDE Skills |
 |:--|:--|:--|
-| Where it runs | Console (browser) | Your IDE / coding agent |
+| Where it runs | Your browser | Your IDE / coding agent |
 | What it changes | Live metadata in your tenant | Files in your repo |
 | Acts on behalf of | Your end users / admins | Your developers |
 | Approval model | HITL queue (`ai:approve`) | Pull request review |
@@ -108,6 +108,6 @@ helpers, and metadata vocabulary.
 
 ## Related
 
-- [AI Builder](./ai-builder) — the in-Console counterpart
+- [AI Builder](./ai-builder) — the in-browser counterpart
 - [Agents](./agents) — declare server-side agents that run *inside* ObjectOS
 - [Templates](./templates) — every official template is built with these skills loaded

--- a/content/docs/build/automation/approvals.mdx
+++ b/content/docs/build/automation/approvals.mdx
@@ -287,7 +287,7 @@ reject, reassign, send-back for revision (`/revise`), request-info, remind,
 recall, resubmit — is declared as `type: 'api'` actions on
 `sys_approval_request`, with typed params, pending-only visibility gates, and
 submitter-vs-approver predicates (e.g. `record.submitter_id == ctx.user.id`).
-The Console approvals inbox renders those declared actions instead of
+The approvals inbox renders those declared actions instead of
 hand-written buttons, so new decision capabilities ship as metadata — no
 client release required.
 

--- a/content/docs/build/automation/flows.mdx
+++ b/content/docs/build/automation/flows.mdx
@@ -6,7 +6,7 @@ description: Declarative business logic — described to AI or written in TypeSc
 Flows are how you express business logic without writing a server.
 Every flow is declarative metadata that the runtime executes — same
 as objects and views. That means flows show up in `os diff`, the
-audit log, Console's flow builder, and the [AI Builder](/docs/build/ai-builder)
+audit log, the flow builder, and the [AI Builder](/docs/build/ai-builder)
 all at once.
 
 Most customers create flows by asking the AI:
@@ -33,7 +33,7 @@ export default defineStack({
 | **Autolaunched** | A record change (insert/update/delete) | "Send welcome email when user registers" |
 | **Scheduled** | Cron expression or interval | "Mark stale tasks every night at 2am" |
 | **Time-relative** *(16.0)* | A date field's proximity to today, via a daily sweep | "Remind me 60 days before the contract ends" |
-| **Manual** | User clicks a button in Console, or an API call | "Approve invoice" actions |
+| **Manual** | User clicks a button, or an API call | "Approve invoice" actions |
 
 ## Autolaunched: react to a record change
 
@@ -202,7 +202,7 @@ export const approveInvoice = defineFlow({
 });
 ```
 
-Surface it in Console as a button on the Invoice view, or call it via
+Surface it as a button on the Invoice view, or call it via
 REST:
 
 ```bash
@@ -276,7 +276,7 @@ auditable in the flow builder.
 
 ## Visual builder
 
-Console ships a visual flow builder that round-trips with the
+ObjectOS ships a visual flow builder that round-trips with the
 declarative metadata — non-engineers can edit a flow, and it serializes
 back to the same shape as the TypeScript you'd hand-author.
 

--- a/content/docs/build/data/index.mdx
+++ b/content/docs/build/data/index.mdx
@@ -4,7 +4,7 @@ description: Objects, fields, relationships, validation, indexes — described t
 ---
 
 The data model is the single source of truth for your app. Once an
-object exists, ObjectOS gives you REST APIs, a Console view, RBAC
+object exists, ObjectOS gives you REST APIs, a generated view, RBAC
 checkpoints, audit log entries, and AI tool exposure — for free.
 
 **Most customers never write the schema by hand.** They describe what
@@ -18,7 +18,7 @@ is generating and can edit it directly when you want to.
 | Path | Looks like |
 |---|---|
 | **AI Builder** (primary) | *"Create a `support_ticket` object with subject, description, priority, status, assignee."* |
-| **Console click-build** | Console → Objects → New Object → forms |
+| **Click-build** | **Objects → New Object** → forms |
 | **TypeScript (`*.object.ts`)** | The TS shown below — typically inside a forked [template](/docs/build/templates) |
 
 All three produce the same schema. The schema is canonical; everything
@@ -74,7 +74,7 @@ export default defineStack({
 ```
 
 That's all you need. `os dev` recompiles, and `/api/v1/data/todo_task`,
-the Console Task view, and the Console permission row all appear.
+the generated Task view, and its permission row all appear.
 
 ## Field types
 
@@ -167,7 +167,7 @@ ObjectSchema.create({
 });
 ```
 
-Validation runs on every write — REST, Console, ObjectQL — so there's
+Validation runs on every write — REST, the UI, ObjectQL — so there's
 no "back door."
 
 ## Indexes & performance
@@ -187,7 +187,7 @@ The driver creates real DB indexes on schema sync.
 
 ## Field groups
 
-For long forms, group fields in Console:
+For long forms, group fields:
 
 ```ts
 ObjectSchema.create({

--- a/content/docs/build/data/relationships.mdx
+++ b/content/docs/build/data/relationships.mdx
@@ -5,7 +5,7 @@ description: Connect objects with lookups and master-detail — cascade rules, f
 
 **A relationship is just a field.** Point a `lookup` or `masterDetail`
 field at another object and ObjectOS wires up everything on top:
-foreign-key integrity, the record picker in Console, related lists on
+foreign-key integrity, the record picker, related lists on
 the parent page, and `expand` in queries.
 
 | Type | Cardinality | Delete default | Use for |
@@ -118,7 +118,7 @@ that loops back on itself is not automatically rejected.
 
 > **Tip:** Pair a `tree` / self-lookup field with a
 > [tree list view](/docs/build/interface/views) to render the hierarchy
-> as nested rows in Console.
+> as nested rows.
 
 ## Related lists
 

--- a/content/docs/build/data/validation-rules.mdx
+++ b/content/docs/build/data/validation-rules.mdx
@@ -3,7 +3,7 @@ title: Validation Rules
 description: Required fields, unique constraints, and CEL-powered rules that stop bad data at the platform level — with error messages you control.
 ---
 
-**Validation runs on every write path.** REST, Console forms, ObjectQL
+**Validation runs on every write path.** REST, forms, ObjectQL
 — the same rules fire everywhere, so there is no back door for bad
 data. Since 16.0 that includes multi-row updates: a bulk update
 evaluates the rules once per matched row. A validation rule is a deterministic, synchronous, side-effect-free
@@ -193,7 +193,7 @@ lifecycle hook, and delete-time guards in a `beforeDelete` hook.
 ## Custom error messages
 
 The `message` is what the user sees when the rule fires — in the
-Console form and in the API error response. Make it actionable:
+form and in the API error response. Make it actionable:
 
 | Weak | Strong |
 |---|---|

--- a/content/docs/build/index.mdx
+++ b/content/docs/build/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build
-description: How apps come to life in ObjectOS — by chatting with AI, by clicking in Console, or by forking a template.
+description: How apps come to life in ObjectOS — by chatting with AI, by clicking through forms, or by forking a template.
 ---
 
 In ObjectOS the customer doesn't write metadata. **They describe what
@@ -10,7 +10,7 @@ most people actually use the platform:
 | Path | Who's it for | Output |
 |---|---|---|
 | **[AI Builder](/docs/build/ai-builder)** (primary) | Business users, product owners, anyone | Live metadata in your tenant, queued for approval |
-| **Console click-build** (fallback) | Admins who prefer forms | The same live metadata |
+| **Click-build** (fallback) | Admins who prefer forms | The same live metadata |
 | **[Template fork](/docs/build/templates)** (dev path) | Engineers who want code under source control | A TypeScript package shipped via the marketplace |
 
 All three paths produce **the same artifact shape** — packages of
@@ -26,14 +26,14 @@ Every app is composed from the same primitives. Learn these once.
 | **[Package](/docs/build/packages)** | The unit of organization — `com.acme.crm`, versioned, installable | Packages |
 | **[Data model](/docs/build/data)** | Objects + fields + relationships + state machines | Data Model |
 | **[Interface](/docs/build/interface)** | Apps, views, forms, dashboards, and pages — what your users see | Interface |
-| **[Actions](/docs/build/interface/actions)** | Named operations callable from REST, Console buttons, flows, or AI agents | Actions |
+| **[Actions](/docs/build/interface/actions)** | Named operations callable from REST, buttons, flows, or AI agents | Actions |
 | **[Flows](/docs/build/automation/flows)** | Declarative business logic (autolaunched / scheduled / manual) | Flows |
 | **[Agents](/docs/build/agents)** | End-user AI assistants — Agent → Skill → Tool | Agents |
 | **[Marketplace](/docs/build/marketplace)** | Ready-made packages anyone can install in one click | Marketplace |
 
 ## Where to start
 
-1. **Just exploring?** → Open Console, start the [AI Builder](/docs/build/ai-builder),
+1. **Just exploring?** → Open ObjectOS, start the [AI Builder](/docs/build/ai-builder),
    say *"I need to track customer support tickets with priority, status, and assignee."*
    You'll have a working object in under 30 seconds.
 
@@ -49,12 +49,12 @@ Every app is composed from the same primitives. Learn these once.
 ## What you'll never have to do
 
 - Write a REST endpoint. The platform generates one per object.
-- Wire a Console form. The form renders from the schema.
+- Wire a form. The form renders from the schema.
 - Write RBAC checks. Permissions are declared, not coded.
-- Build an admin UI. Console + Account cover both system and business admin.
+- Build an admin UI. Setup and Account cover system administration and sign-in.
 - Generate types. `@objectstack/spec` derives them from the schema.
 
 ObjectOS is opinionated about this on purpose: **once metadata
-exists, every surface (REST, Console, ObjectQL, audit, AI tools)
+exists, every surface (REST, the UI, ObjectQL, audit, AI tools)
 appears for free.** That's why the AI Builder works — it only needs
 to produce metadata, and the platform handles the rest.

--- a/content/docs/build/interface/actions.mdx
+++ b/content/docs/build/interface/actions.mdx
@@ -1,13 +1,13 @@
 ---
 title: Actions
-description: Named operations the platform exposes as REST endpoints, Console buttons, flow steps, and AI tools — from one declaration.
+description: Named operations the platform exposes as REST endpoints, buttons, flow steps, and AI tools — from one declaration.
 ---
 
 An **Action** is a named operation on an object. Declare it once and
 it appears as:
 
 - a **REST endpoint** at `/api/v1/actions/<object>/<action>`
-- a **button** in Console's record detail
+- a **button** on the record detail page
 - a **flow step** (`type: 'action'`) for automation
 - an **AI tool** (`action_<name>`) for Agents and the AI Builder
 
@@ -58,7 +58,7 @@ export const approveInvoice = Action.create({
 After `os dev` recompiles:
 
 - `POST /api/v1/actions/invoice/approve_invoice` works
-- The Invoice record page in Console shows an **Approve Invoice** button
+- The Invoice record page shows an **Approve Invoice** button
 - A flow can include `{ type: 'action', action: 'approve_invoice', inputs: { note: '…' } }`
 - The AI assistant can call `action_approve_invoice` if its skills allow
 
@@ -109,9 +109,9 @@ either as a trailing path segment (`.../approve_invoice/:recordId`) or in
 the body. The response is your script body's return value (or the call
 result for `api`-type actions).
 
-### Console
+### From the UI
 
-By default, Console shows actions as buttons on the record detail page,
+By default, actions appear as buttons on the record detail page,
 filtered by the action's `visible` predicate. Override placement
 in your view config:
 
@@ -152,7 +152,7 @@ Actions run with the calling user's permissions. The platform checks:
    must have write access (FLS).
 3. **UI gating** — the `visible` and `disabled` predicates (CEL,
    evaluated against `record`, `os.user`, and params) control whether the
-   button renders or is greyed out in Console.
+   button renders or is greyed out.
 
 Failed permission checks return `403` with a `PERMISSION_DENIED` error.
 
@@ -192,7 +192,7 @@ This is your first stop for *"who pushed the button?"* questions.
 
 The [AI Builder](/docs/build/ai-builder) generates the action metadata and
 queues the change for approval. After approval, the action is callable from
-REST, Console, flows, and — recursively — the AI itself.
+REST, the UI, flows, and — recursively — the AI itself.
 
 ## Where to go next
 

--- a/content/docs/build/interface/index.mdx
+++ b/content/docs/build/interface/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Interface
-description: Apps, views, forms, dashboards, pages, and actions — every user-facing surface declared as metadata, rendered by Console.
+description: Apps, views, forms, dashboards, pages, and actions — every user-facing surface declared as metadata, rendered by ObjectOS.
 ---
 
 **Everything a user sees is metadata.** You declare interfaces as data —
@@ -19,7 +19,7 @@ The pieces compose top-down:
 6. **Pages** break out of the object frame entirely — free-form layouts
    composed from components and regions.
 7. **Actions** put buttons on all of the above — one declaration, callable
-   from Console, REST, flows, and AI agents.
+   from the UI, REST, flows, and AI agents.
 
 ## The concepts
 

--- a/content/docs/build/interface/pages.mdx
+++ b/content/docs/build/interface/pages.mdx
@@ -142,7 +142,7 @@ navigation entry, or make it the app's landing page via `homePageId`.
 
 A **doc** is a page of package documentation: plain Markdown files in a
 flat `src/docs/` directory, compiled into the package artifact and
-rendered in the console at `/docs/<name>`. Docs also ground the AI
+rendered in the UI at `/docs/<name>`. Docs also ground the AI
 assistant when it answers questions about your package.
 
 ```
@@ -159,7 +159,7 @@ resolve by basename, never by path.
 |:--|:--|
 | Naming | `snake_case`, and the build lint requires a **namespace prefix** (`crm_user_guide`, not `user_guide`) |
 | Frontmatter | Optional; `title` and `description` are read. Title resolves: frontmatter → first `#` heading → doc name |
-| Cross-references | Plain relative links (`[overview](./crm_index.md)`) — rewritten to `/docs/<target>` in console, native on GitHub. **Broken same-package links fail the build** |
+| Cross-references | Plain relative links (`[overview](./crm_index.md)`) — rewritten to `/docs/<target>` in the UI, native on GitHub. **Broken same-package links fail the build** |
 | Markdown | CommonMark + GFM: tables, fenced code with highlighting, heading anchors, GitHub alerts (`> [!TIP]`) |
 | Rejected at build | **MDX / embedded components** (docs are data, not code — a trust boundary) and **image references** (no asset service yet; fail fast beats broken images) |
 

--- a/content/docs/build/interface/views.mdx
+++ b/content/docs/build/interface/views.mdx
@@ -1,9 +1,9 @@
 ---
 title: Views
-description: List, Form, Kanban, Calendar, Gantt and more — how every object surface in Console is declared.
+description: List, Form, Kanban, Calendar, Gantt and more — how every object surface is declared.
 ---
 
-A **view** is how a user sees and edits records in Console. Views are
+A **view** is how a user sees and edits records. Views are
 declarative metadata — same lifecycle as objects: declare them once,
 ship them with your package, render anywhere.
 
@@ -246,7 +246,7 @@ You usually don't write view metadata by hand. Tell the AI Builder:
 > amber / green by status."*
 
 It calls the metadata tools, queues the diff, and once you approve the
-view shows up in Console. See [AI Builder](/docs/build/ai-builder).
+view shows up. See [AI Builder](/docs/build/ai-builder).
 
 ## See also
 

--- a/content/docs/build/marketplace.mdx
+++ b/content/docs/build/marketplace.mdx
@@ -39,7 +39,7 @@ plane `OS_CLOUD_URL` points at. Once an app is installed it lives in
 your runtime's own kernel — nothing at runtime depends on the catalog
 staying reachable.
 
-When you open Console (`/_console/`), the marketplace tab queries the
+When you open ObjectOS (`/_console/`), the marketplace tab queries the
 configured app catalog and shows installable apps.
 
 ```text
@@ -67,7 +67,7 @@ vars; see [Runtime Configuration](/docs/configure/runtime).
 
 ## What's in the default catalog
 
-These apps are ready to install with one click in Console:
+These apps are ready to install with one click:
 
 | App | What it gives you |
 |---|---|
@@ -86,11 +86,11 @@ clone any of them as a starting point for a custom app.
 
 ## Install flow
 
-1. **Open Console** — http://localhost:3000/_console/
+1. **Open ObjectOS** — http://localhost:3000/_console/
 2. **Sign in** — if no account exists yet, register one at `/_account/register`
 3. **Navigate to the marketplace tab**
 4. **Pick an app, click Install**
-5. **Reload Console** — the new app's objects, views, and flows appear
+5. **Reload the page** — the new app's objects, views, and flows appear
 
 Behind the scenes, the marketplace fetches the app's compiled artifact,
 merges it into the running kernel, and registers its objects with
@@ -99,7 +99,7 @@ install.
 
 ## Uninstall
 
-From Console → Marketplace → installed app → Uninstall. The app's
+From **Marketplace → installed app → Uninstall**. The app's
 objects are removed from the kernel and its tables are marked for
 cleanup (data is retained by default; you choose whether to drop
 tables).
@@ -124,12 +124,12 @@ at your own.
 
 Every published app is immutable. Updates produce a new version. The
 runtime tracks installed version + available updates per app. Users see
-an "Update available" badge in Console when a new version is published
+an "Update available" badge when a new version is published
 to a catalog they're tracking.
 
 ## Installing from the CLI
 
-Console is the primary install surface, but the same install-local
+The marketplace tab is the primary install surface, but the same install-local
 endpoint is scriptable for CI and air-gapped operations:
 
 ```bash
@@ -143,7 +143,7 @@ os package install ./dist/objectstack.json --runtime http://localhost:3000 \
 ```
 
 The credentials are an account on the **target runtime** (not your
-cloud login) — the same authorization Console install uses.
+cloud login) — the same authorization the in-app install uses.
 
 ## Permissions
 

--- a/content/docs/build/packages.mdx
+++ b/content/docs/build/packages.mdx
@@ -49,9 +49,9 @@ cd my-crm
 pnpm dev
 ```
 
-### From Console
+### From the UI
 
-**Console → Packages → New Package** — name, id, version, namespace.
+**Packages → New Package** — name, id, version, namespace.
 
 ## Active package
 
@@ -124,7 +124,7 @@ environment login. You never need to know an environment id to install.
 
 | Path | How |
 |---|---|
-| Console (recommended) | Sign in to the environment → **Marketplace** → pick the package → **Install**. Installs into the current environment. |
+| In the UI (recommended) | Sign in to the environment → **Marketplace** → pick the package → **Install**. Installs into the current environment. |
 | CLI → running runtime | `os package install com.acme.crm --runtime <url>` — the runtime resolves the package from its configured catalog and merges it into its own kernel |
 | CLI air-gapped | `os package install ./dist/objectstack.json --runtime <url>` — compiled artifact sent inline, no catalog round-trip |
 | REST | `POST /api/v1/marketplace/install-local` (body: `{ packageId, versionId? }` or `{ manifest }`) |

--- a/content/docs/build/templates.mdx
+++ b/content/docs/build/templates.mdx
@@ -32,7 +32,7 @@ Apache-2.0. Fork without asking.
 
 ## Install in 30 seconds (zero code)
 
-In Console:
+In ObjectOS:
 
 1. Open **Marketplace** → search for the template.
 2. Click **Install**.

--- a/content/docs/configure/ai.mdx
+++ b/content/docs/configure/ai.mdx
@@ -13,7 +13,7 @@ layers**:
 | **Knowledge / RAG** | `@objectstack/service-knowledge` + adapter | Documents → indexed knowledge bases |
 
 All three are optional, all three are provider-agnostic, and all three
-can be reconfigured at runtime from **Console → Configuration**
+can be reconfigured at runtime from **Setup → Configuration**
 without a restart.
 
 ## Chat / generation
@@ -48,7 +48,7 @@ The `models` list feeds the runtime model registry — it drives
 default-model resolution and cost attribution in traces. By default the
 plugin also binds to the `ai` settings namespace and rebuilds the
 adapter live when an operator edits the provider/credentials/model in
-Console, so no restart is needed.
+Setup, so no restart is needed.
 
 Provider API keys come from each SDK's normal env vars:
 
@@ -59,7 +59,7 @@ Provider API keys come from each SDK's normal env vars:
 | Google | `GOOGLE_GENERATIVE_AI_API_KEY` |
 | AI Gateway | `AI_GATEWAY_API_KEY` |
 
-In Console you can paste these as runtime settings instead — they go
+In Setup you can paste these as runtime settings instead — they go
 through the same precedence (env > settings) but live editing means
 no restart.
 
@@ -126,7 +126,7 @@ const embedder = createOpenAIEmbedder({
 });
 ```
 
-Or pick at runtime from **Console → Configuration → AI → Embedder**.
+Or pick at runtime from **Setup → Configuration → AI → Embedder**.
 Switch providers without restart; existing vectors stay searchable
 (you can re-index in the background).
 
@@ -153,7 +153,7 @@ kernel.use(new KnowledgeRagflowPlugin({
 ```
 
 Indexed knowledge bases become first-class objects — query them from
-flows, surface them in Console, attach them to AI assistants as
+flows, surface them in your apps, attach them to AI assistants as
 retrieval context.
 
 ## MCP — Model Context Protocol
@@ -180,7 +180,7 @@ registry, including universal tools such as `list_objects`,
 
 - **No mandatory cloud dependency.** Use Ollama for chat + Ollama
   embedder + memory knowledge — entirely air-gapped.
-- **Live swappable.** Change provider in Console; new requests use the
+- **Live swappable.** Change provider in Setup; new requests use the
   new provider on next call. No restart.
 - **Per-tenant config.** Each Environment has its own AI settings.
   Tenant A on OpenAI, tenant B on Anthropic — same runtime.

--- a/content/docs/configure/api-access.mdx
+++ b/content/docs/configure/api-access.mdx
@@ -73,7 +73,7 @@ leaked key cannot be reconstructed from the database.
 
 Issue a key in either of two ways:
 
-- **Console** — sign in to **Console → API Keys** as an administrator,
+- **Setup** — sign in to **Setup → API Keys** as an administrator,
   choose the owning user, optionally set an expiration date, and copy the
   displayed secret **once**.
 - **Self-serve endpoint** — `POST /api/v1/keys` mints a key for the
@@ -100,7 +100,7 @@ curl https://app.example.com/api/v1/data/account \
 ```
 
 To revoke a key, run the `revoke_api_key` action on the corresponding
-`sys_api_key` record (also available in the Console UI). Revocation takes
+`sys_api_key` record (also available in Setup). Revocation takes
 effect immediately on the next request.
 
 ## MCP clients & OAuth 2.1 (ObjectStack 13+)

--- a/content/docs/configure/email.mdx
+++ b/content/docs/configure/email.mdx
@@ -64,9 +64,9 @@ subject/body and hands it to the configured transport.
 
 For Resend / Postmark, verify that the sending domain is configured in
 the provider dashboard (SPF, DKIM, optionally DMARC). The fastest
-end-to-end check is the Console's **Send test email** action on the
-email settings page — it uses the live transport and surfaces transport
-errors inline.
+end-to-end check is the **Send test email** action on the email
+settings page in Setup — it uses the live transport and surfaces
+transport errors inline.
 
 ## Operational guidance
 

--- a/content/docs/configure/index.mdx
+++ b/content/docs/configure/index.mdx
@@ -14,9 +14,9 @@ app packages you install.
 > administration never leaves Setup — you enter Studio only to author
 > permission sets or to run the explain engine.
 
-## The Setup console
+## The Setup app
 
-The built-in administration console lives at **`/apps/setup`** and
+The built-in administration app lives at **`/apps/setup`** and
 requires the `setup.access` permission. Its left-hand navigation is
 contributed at runtime by the capability plugins that are loaded, so the
 menu you see reflects exactly what your deployment runs — a disabled

--- a/content/docs/configure/permissions/index.mdx
+++ b/content/docs/configure/permissions/index.mdx
@@ -52,7 +52,7 @@ In a multi-tenant deployment:
 - Control-plane users are **not** automatically business users — they
   must be mapped in via platform SSO or explicit provisioning.
 
-You create/manage these from **Console** (`/_console/`) at runtime, or
+You create/manage these from **Setup** (`/_console/`) at runtime, or
 seed them in `objectstack.config.ts` for fresh environments.
 
 ## Layer 2 — Positions
@@ -80,7 +80,7 @@ to users directly or via positions.
 | Application access | Open CRM, open the support portal |
 | Object permissions | Create / read / update / delete records of an object |
 | Field permissions | Read or update specific fields |
-| System permissions | Access Console, run reports, view audit log |
+| System permissions | Access Setup, run reports, view audit log |
 | Integration permissions | Use API keys, configure webhooks, run admin actions |
 
 ### Object permission flags
@@ -144,7 +144,7 @@ Field security is per object + per permission set. Typical use:
 - Make `external_account_id` readable but not editable to support reps.
 
 It's enforced in the same evaluator as object permissions, so it
-applies uniformly across REST, ObjectQL, and Console.
+applies uniformly across REST, ObjectQL, and the UI.
 
 ## Where to start
 
@@ -161,7 +161,7 @@ applies uniformly across REST, ObjectQL, and Console.
 - The **explain engine** (`explain(principal, object, operation)`)
   reports the verdict of every layer in order — required permissions,
   object CRUD, field security, OWD baseline, sharing, row-level
-  security — with per-layer attribution. Console surfaces it as the
+  security — with per-layer attribution. It surfaces as the
   "Why can this user access?" panel. Explaining another user requires
   the `manage_users` capability.
 - `/_console/` shows the effective permissions of any user as they're

--- a/content/docs/configure/permissions/permission-sets.mdx
+++ b/content/docs/configure/permissions/permission-sets.mdx
@@ -13,10 +13,10 @@ resolving immediately.
 
 | Permission type | Examples |
 |---|---|
-| Application access | User can open CRM or Console |
+| Application access | User can open CRM or Setup |
 | Object permissions | Create, read, update, delete records |
 | Field permissions | Read or update selected fields |
-| System permissions | Access Console, run reports, view audit logs |
+| System permissions | Access Setup, run reports, view audit logs |
 | Integration permissions | Use API keys, webhooks, or admin actions |
 
 ## Object permissions
@@ -90,7 +90,7 @@ outcome. Reports are covered by the same axis.
 
 System permissions are for platform actions such as:
 
-- Console access;
+- Setup access;
 - manage users;
 - manage positions and permission sets;
 - run reports;
@@ -143,13 +143,13 @@ read a record, individual fields can be hidden or made read-only.
 
 | Mode | Effect |
 |---|---|
-| **Hidden** | Field is stripped from API responses and Console views entirely |
+| **Hidden** | Field is stripped from API responses and generated views entirely |
 | **Read-only** | Field is returned but writes are rejected |
 
 ### Where it's enforced
 
 The same evaluator that checks object permissions applies field rules
-on every path — REST, ObjectQL, generated Console forms, exports. There
+on every path — REST, ObjectQL, generated forms, exports. There
 is no "back door" through a lower-level API.
 
 ### Typical patterns

--- a/content/docs/configure/storage.mdx
+++ b/content/docs/configure/storage.mdx
@@ -14,7 +14,7 @@ enabled by default in standalone and project boots.
 
 | Surface | Behavior |
 |---|---|
-| Console file/image fields | Browser uploads directly to storage via presigned URLs |
+| File / image fields in the UI | Browser uploads directly to storage via presigned URLs |
 | REST `/api/v1/storage/*` | Programmatic upload/download endpoints |
 | Object `file` / `image` fields | Render as upload widgets; metadata persists in `sys_file` |
 
@@ -163,7 +163,7 @@ storage-layer ACLs.
 ## Live configuration
 
 When the settings service is enabled (it is by default), an admin can
-swap storage adapter in **Console → Configuration → Storage** without
+swap storage adapter in **Setup → Configuration → Storage** without
 restarting:
 
 - pick adapter, bucket, region, endpoint;

--- a/content/docs/configure/system-settings.mdx
+++ b/content/docs/configure/system-settings.mdx
@@ -4,7 +4,7 @@ description: Configure tenant and user settings through manifests and a shared K
 ---
 
 ObjectStack includes a settings service for runtime and plugin settings.
-ObjectOS exposes those settings through the Console when the application
+ObjectOS exposes those settings through Setup when the application
 artifact requires the settings capability.
 
 ## Settings model
@@ -37,7 +37,7 @@ Manifest default
 ```
 
 Environment overrides are locked. If a value is set through an
-environment variable, the Console UI shows it as managed by the host
+environment variable, Setup shows it as managed by the host
 and rejects runtime edits. A locked value anywhere up the chain also
 locks the effective value, so lower scopes cannot shadow it.
 

--- a/content/docs/configure/webhooks.mdx
+++ b/content/docs/configure/webhooks.mdx
@@ -15,7 +15,7 @@ include `@objectstack/plugin-webhooks`, and the application artifact
 must register webhook subscriptions (typically as records of a
 `sys_webhook` object).
 
-When enabled, two objects show up in the Console:
+When enabled, two objects show up in Setup:
 
 | Object | Purpose |
 |---|---|
@@ -88,7 +88,7 @@ When something fails:
    `response_body`, and `attempts` are recorded.
 2. Confirm outbound network access from ObjectOS to the receiver.
 3. If the receiver was permanently changed, update the subscription URL
-   and re-deliver the row from the Console.
+   and re-deliver the row from Setup.
 4. For incident review, audit logs (`sys_audit_log`) capture
    subscription edits but not payloads — payloads stay in the outbox.
 

--- a/content/docs/extend-existing-systems.mdx
+++ b/content/docs/extend-existing-systems.mdx
@@ -69,7 +69,7 @@ Once the tables are modeled as objects bound to your existing database:
   the answer is computed against live data through ObjectQL.
 - **Governed automation.** Flows and actions can read and (where allowed)
   write the same data, with every step audited.
-- **A generated API and Console.** REST endpoints and admin screens come
+- **A generated API and UI.** REST endpoints and admin screens come
   from the same metadata — no extra integration layer.
 - **One permission model.** The boundary that applies to humans applies
   identically to AI traffic.

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: The runtime for internal tools that stays in your network. One comm
 
 **ObjectOS is a self-hosted runtime for building internal tools, admin
 panels, and back-office apps without giving up your data.** Describe
-what you need to the in-Console AI Builder — or fork a template — and
+what you need to the built-in AI Builder — or fork a template — and
 get REST APIs, a generated admin UI, authentication, RBAC, audit logs,
 file storage, background jobs, webhooks, and AI integration. All
 running in your network, on your database.
@@ -21,7 +21,7 @@ os start
 ```
 
 Open **http://localhost:3000** and you have a working ObjectOS with
-Console and Account, an audit log, and a SQLite database — zero
+its UI and Account portal, an audit log, and a SQLite database — zero
 configuration, zero scaffolding.
 
 Then either:
@@ -29,7 +29,7 @@ Then either:
 - **Talk to the AI Builder** — *"I need to track support tickets with
   priority and assignee"* — and watch the metadata get generated. See
   [Build → AI Builder](/docs/build/ai-builder).
-- **Install a template** from the in-Console marketplace (Todo,
+- **Install a template** from the built-in marketplace (Todo,
   Contracts, Helpdesk, …) and have a real app in one click.
 - **Fork a [template](/docs/build/templates)** if you want TypeScript
   source under your control.
@@ -48,7 +48,7 @@ Then either:
 | Surface | What it is |
 |---|---|
 | **Auto REST API** | Every object you declare gets `/api/v1/data/<object>` with filter/sort/paginate |
-| **Console** (`/_console/`) | Generated admin UI: browse and edit records, manage users/roles/permission sets, view audit log, sessions, API keys, settings |
+| **The UI** (`/_console/`) | Generated screens: browse and edit records, and **Setup** to manage users/roles/permission sets, view audit log, sessions, API keys, settings |
 | **Account** (`/_account/`) | Login, register, password reset, OAuth, OIDC/SSO, passkeys, 2FA |
 | **20+ plugins** | RBAC + row-level security, audit, file storage, queues, jobs, email, AI, webhooks — declarative, on demand |
 

--- a/content/docs/operate/audit-logs.mdx
+++ b/content/docs/operate/audit-logs.mdx
@@ -23,8 +23,8 @@ Reach for the audit log when you need to prove or investigate:
 
 At **Setup → Diagnostics → Audit Logs** (`sys_audit_log`). The object is
 **read-only and immutable** — an append-only trail of platform events. You can
-filter, group, and inspect rows, but nothing can edit or delete them from the
-Console.
+filter, group, and inspect rows, but nothing can edit or delete them from
+Setup.
 
 ### Preset views
 

--- a/content/docs/operate/observability.mdx
+++ b/content/docs/operate/observability.mdx
@@ -78,7 +78,7 @@ counts a rejected credential, so there is no series to alert on. Counting
 endpoints do not feed that counter, a rejected API key is indistinguishable
 from a request that carried no credential at all, and both statuses are
 dominated by ordinary permission denials against users who authenticated
-perfectly well. Review sign-in activity in the Console's `Auth` audit view
+perfectly well. Review sign-in activity in Setup's `Auth` audit view
 instead — see [Audit Logs](/docs/operate/audit-logs).
 
 For OpenTelemetry, set `OS_OBS_EXPORTER=otlp` **and** `OS_OTLP_ENDPOINT`
@@ -109,9 +109,9 @@ database or storage layer and define a retention policy.
 For the full field reference, preset views, and the sibling diagnostics logs,
 see [Audit Logs](/docs/operate/audit-logs).
 
-## Console diagnostics
+## Setup diagnostics
 
-The Console exposes operational surfaces such as:
+Setup exposes operational surfaces such as:
 
 - Sessions;
 - Audit Logs;

--- a/content/docs/operate/troubleshooting.mdx
+++ b/content/docs/operate/troubleshooting.mdx
@@ -96,7 +96,7 @@ Check:
 - the ObjectOS image includes the optional service package;
 - queue/job service configuration is available;
 - outbound network access to the target is allowed;
-- delivery logs or job runs are visible in Console diagnostics.
+- delivery logs or job runs are visible in Setup diagnostics.
 
 ## Database errors
 

--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -10,7 +10,7 @@ There are two ways to start, depending on what you're doing.
 | Trying ObjectOS for the first time, or running it in production | [Path A — `os start`](#path-a--os-start-operator-first-time-evaluator) |
 | Building or customizing an app in code | [Path B — `os init`](#path-b--os-init-developer) |
 
-Both produce a running server with Console + Account. The
+Both produce a running server with the UI + Account. The
 difference is whether you scaffold source files.
 
 ## Prerequisites
@@ -57,8 +57,8 @@ That's it. You're running ObjectOS.
 | URL | What it is |
 |---|---|
 | http://localhost:3000/_account/register | Create your first account |
-| http://localhost:3000/_console/ | The admin UI — and the **app marketplace** |
-| http://localhost:3000/_console/ | Users, roles, audit log, settings |
+| http://localhost:3000/_console/ | The generated UI — and the **app marketplace** |
+| http://localhost:3000/_console/ | **Setup** — users, roles, audit log, settings |
 | http://localhost:3000/api/v1/health | Liveness — is the process up |
 | http://localhost:3000/api/v1/ready | Readiness — is it up **and** serving data |
 
@@ -76,7 +76,7 @@ show which probe goes where.
 
 ### Build by chat — the AI Builder
 
-Once you're signed in, open the AI assistant in Console (top-right
+Once you're signed in, open the AI assistant (top-right
 sparkle icon) and describe what you need:
 
 > *"I need to track customer support tickets. Each has a subject,
@@ -84,7 +84,7 @@ sparkle icon) and describe what you need:
 > assignee. Add a kanban view grouped by status."*
 
 The AI proposes a plan, you approve, and the metadata is live —
-REST endpoints, Console views, audit log entries, permission gates.
+REST endpoints, generated views, audit log entries, permission gates.
 No file edited, no restart. See [Build → AI Builder](/docs/build/ai-builder)
 for the full vocabulary.
 
@@ -179,8 +179,8 @@ export const Task = ObjectSchema.create({
 Save. The dev server recompiles and you immediately have:
 
 - **`/api/v1/data/task`** — full CRUD with filter/sort/paginate
-- **A "Task" view in Console** — list, form, detail, all generated
-- **Permission rows in Console** — grant read/write per role
+- **A "Task" view** — list, form, detail, all generated
+- **Permission rows in Setup** — grant read/write per role
 - **Audit log entries** — every create/update/delete recorded
 
 No migrations. No code generation. No restarting.

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -18,7 +18,7 @@ os --help
 Auto-detects 4 escalating modes:
 
 1. **Empty boot** — no artifact, no config in cwd → boots a bare
-   kernel with Console + marketplace.
+   kernel with the UI + marketplace.
 2. **Project boot** — `objectstack.config.ts` in cwd → auto-compiles
    to `./dist/objectstack.json` and boots from it.
 3. **Artifact boot** — `dist/objectstack.json` reachable → boots from
@@ -71,9 +71,9 @@ os dev                         # port 3002 by default
 os dev -p 4002
 ```
 
-### `os studio` — Console with dev server
+### `os studio` — dev server with the UI enabled
 
-Same as `os dev` but with Console explicitly enabled.
+Same as `os dev` but with the UI explicitly enabled.
 
 ## Project commands
 
@@ -210,7 +210,7 @@ os test                       # run Quality Protocol scenarios against a running
 | `-d, --database` | Database URL |
 | `--home` | Persistent state directory |
 | `-v, --verbose` | Verbose output |
-| `--no-ui` | Disable Console / Account portals |
+| `--no-ui` | Disable the UI and Account portals |
 
 Run any command with `--help` for the full flag list:
 

--- a/content/docs/reference/field-types.mdx
+++ b/content/docs/reference/field-types.mdx
@@ -1,6 +1,6 @@
 ---
 title: Field Types
-description: Every field type you can declare on an object — what it stores, what options it accepts, how it surfaces in REST, Console, and the AI Builder.
+description: Every field type you can declare on an object — what it stores, what options it accepts, how it surfaces in REST, the UI, and the AI Builder.
 ---
 
 48 built-in field types, grouped by family. The full Zod schema is in
@@ -11,14 +11,14 @@ description: Every field type you can declare on an object — what it stores, w
 | Property | Type | Default | Purpose |
 |:--|:--|:--|:--|
 | `name` | string (snake_case) | — | Machine identifier — REST path segment, SQL column |
-| `label` | string | — | Display label in Console |
+| `label` | string | — | Display label in the UI |
 | `type` | FieldType | — | See type tables below |
 | `required` | boolean | `false` | NOT NULL constraint |
 | `unique` | boolean | `false` | Unique index |
 | `searchable` | boolean | `false` | Indexed for `/api/v1/search` |
 | `multiple` | boolean | `false` | Store an array of values |
 | `defaultValue` | unknown | — | Initial value (literal or CEL) |
-| `hidden` | boolean | `false` | Hide from default Console views |
+| `hidden` | boolean | `false` | Hide from default views |
 | `readonly` | boolean | `false` | Disable in forms |
 | `system` | boolean | `false` | Auto-injected (id, created_at, …) |
 | `externalId` | boolean | `false` | Eligible for upsert via external key |
@@ -41,9 +41,9 @@ description: Every field type you can declare on an object — what it stores, w
 | `phone` | phone | E.164 |
 | `password` | one-way secrets | hashed by the auth subsystem; never returned by GET |
 | `secret` | reversible secrets (API keys, tokens, DB passwords) | encrypted at rest via the crypto provider, stored as an opaque ref, masked on read. Fail-closed — with no provider configured, writes throw rather than persist cleartext |
-| `markdown` | markdown body | rendered in Console preview |
+| `markdown` | markdown body | rendered in preview |
 | `html` | sanitised HTML | DOMPurify on write |
-| `richtext` | WYSIWYG | Console editor + serialised JSON |
+| `richtext` | WYSIWYG | rich-text editor + serialised JSON |
 
 ## Numbers
 

--- a/content/docs/reference/rest-api.mdx
+++ b/content/docs/reference/rest-api.mdx
@@ -141,7 +141,7 @@ Each action is also exposed to the AI as a `action_<name>` tool — see
 ## Metadata — `/api/v1/meta/*`
 
 Read-only introspection into the running runtime's metadata. Useful
-for tooling and the Console.
+for tooling and the UI.
 
 | Path | Method | Purpose |
 |:--|:--|:--|

--- a/content/docs/reference/security.mdx
+++ b/content/docs/reference/security.mdx
@@ -147,7 +147,7 @@ many already are.
 | Settings stored in DB | Encrypted by the settings service at rest |
 
 **Never** bake secrets into the artifact (`objectstack.json`), the
-Docker image, the compose file, or Git. The settings UI in Console
+Docker image, the compose file, or Git. The settings UI in Setup
 shows env-managed values as locked, so operators can't accidentally
 override them.
 
@@ -252,7 +252,7 @@ construction:
   write to the database.
 - Tool calls inherit the **end user's permissions**, not the model's
   service-account permissions. A user can never use the AI to do
-  something they couldn't do themselves through Console or REST.
+  something they couldn't do themselves through the UI or REST.
 - Skills loaded into agents are versioned and explicit — see
   [Build → IDE Skills](/docs/build/ai-skills) and
   [Build → AI Builder](/docs/build/ai-builder).

--- a/content/docs/reference/skills-cli.mdx
+++ b/content/docs/reference/skills-cli.mdx
@@ -93,6 +93,6 @@ with the latest Zod schemas, CEL helpers, and metadata vocabulary.
 ## See also
 
 - [Build → IDE Skills](/docs/build/ai-skills) — conceptual overview, AI Builder vs skills
-- [Build → AI Builder](/docs/build/ai-builder) — the in-Console counterpart
+- [Build → AI Builder](/docs/build/ai-builder) — the in-browser counterpart
 - [vercel-labs/skills](https://github.com/vercel-labs/skills) — upstream CLI
 - [objectstack-ai/objectstack/skills](https://github.com/objectstack-ai/objectstack/tree/main/skills) — source of truth for every skill

--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -148,8 +148,8 @@ What moved:
   carry file attachments, progress ("2 of 3 · finance pending") is
   computed server-side, and approve / reject / reassign / send-back /
   request-info / remind / recall / resubmit are declared `type:'api'`
-  actions on `sys_approval_request` — the Console renders them through
-  its generic action runtime instead of hand-written buttons.
+  actions on `sys_approval_request` — the approvals inbox renders them
+  through its generic action runtime instead of hand-written buttons.
 - **Time-relative automations** — a flow start node can declare
   `timeRelative` (`offsetDays: [60, 30, 7]` or `withinDays`); a daily
   sweep launches the flow once per matching record, so "remind me 60

--- a/content/docs/resources/faq.mdx
+++ b/content/docs/resources/faq.mdx
@@ -27,12 +27,12 @@ for multi-environment / multi-app deployments with a control plane.
 A: Yes — Postgres, MySQL, SQLite, Turso/libSQL, and MongoDB are
 supported drivers. See [Runtime Configuration](/docs/configure/runtime).
 
-**Q: Can I disable Console / Account and use only the REST API?**
+**Q: Can I disable the UI / Account portals and use only the REST API?**
 A: Yes. Run `os start --no-ui` or set the corresponding flags. The
 REST API is the same whether the UIs are mounted or not.
 
-**Q: Can I use my own front-end instead of Console?**
-A: Yes. Console uses the same `/api/v1/*` endpoints you'd call from
+**Q: Can I use my own front-end instead of the generated UI?**
+A: Yes. The generated UI uses the same `/api/v1/*` endpoints you'd call from
 your own code. Use `@objectstack/client` SDK or any HTTP client.
 
 **Q: Does ObjectOS support GraphQL?**
@@ -85,7 +85,7 @@ add a migration step (rename column in DB before deploying the new
 artifact).
 
 **Q: Can I import data from CSV / Excel / Salesforce?**
-A: CSV: yes, via `os data create` in a loop or the Console bulk upload.
+A: CSV: yes, via `os data create` in a loop or the bulk upload in the UI.
 Salesforce: best path today is to export to CSV and import. Native
 connectors are on the roadmap.
 
@@ -105,10 +105,10 @@ injects the corresponding filter on every query. See
 **Q: Can I make some fields invisible to certain users?**
 A: Yes — field-level security in permission sets. Hide or read-only,
 per field per permission set. Enforced uniformly across REST, ObjectQL,
-and Console. See [Permission Sets](/docs/configure/permissions/permission-sets).
+and the UI. See [Permission Sets](/docs/configure/permissions/permission-sets).
 
 **Q: How do I integrate Okta / Entra / Keycloak?**
-A: OIDC. Configure the discovery URL + client id/secret in **Console →
+A: OIDC. Configure the discovery URL + client id/secret in **Setup →
 Authentication** (or via env). Provider callback URL is
 `/api/v1/auth/oauth2/callback/<provider-id>`. See [Authentication](/docs/configure/authentication).
 
@@ -136,8 +136,8 @@ A: Yes — plugins follow a simple DI + lifecycle pattern
 (`init → start → destroy`). See `@objectstack/plugin-*` packages on
 GitHub for examples.
 
-**Q: Can I customize Console's look?**
-A: Branding (logo, accent color, default theme) is in **Console →
+**Q: Can I customize how ObjectOS looks?**
+A: Branding (logo, accent color, default theme) is in **Setup →
 System Settings**. Deep UI customization means forking
 `@objectstack/client-react` or building your own front-end against the
 REST API.
@@ -162,7 +162,7 @@ the pair [Docker](/docs/deploy/docker) and
 
 **Q: What metrics should I monitor?**
 A: 5xx rate, p95 latency, readiness (`/api/v1/ready`), queue depth. There is
-no auth-failure metric to monitor — review sign-in activity in the Console's
+no auth-failure metric to monitor — review sign-in activity in Setup's
 `Auth` audit view instead. Minimal Prometheus example in [Observability](/docs/operate/observability).
 
 **Q: How do I take a backup?**

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -15,7 +15,7 @@ ObjectOS actually executes.
 ### Action
 
 A named operation declared in metadata, invocable via REST
-(`/api/v1/data/<object>/actions/<action>`), Console buttons, or flow
+(`/api/v1/data/<object>/actions/<action>`), buttons in the UI, or flow
 steps. Inherits the caller's permissions.
 
 ### Adapter
@@ -28,7 +28,7 @@ server.
 ### App
 
 A bundle of objects + views + permissions presented as a single
-navigable application in Console. Multiple apps can coexist in one
+navigable application. Multiple apps can coexist in one
 runtime (e.g. CRM + Helpdesk + Setup).
 
 ### Better Auth
@@ -49,12 +49,6 @@ Loaded on demand by ObjectOS. See
 Google's safe, sandboxed expression syntax. Used in formulas,
 validation rules, permission predicates, sharing rules, and flow
 conditions.
-
-### Console
-
-The system UI at `/_console/` — manages users, roles, permission sets,
-audit log, sessions, API keys, system settings. Distinct from Console
-(business UI).
 
 ### Control Plane
 
@@ -124,7 +118,7 @@ The top-level metadata at the head of an artifact: `id`, `namespace`,
 
 ### Marketplace
 
-The in-Console catalog of installable apps. Backed by a configurable
+The built-in catalog of installable apps. Backed by a configurable
 package registry. See [Marketplace](/docs/build/marketplace).
 
 ### MCP (Model Context Protocol)
@@ -136,7 +130,7 @@ ObjectOS can expose its objects + actions as MCP via
 ### Object
 
 A typed business entity — `task`, `account`, `invoice`. Declared as a
-TypeScript schema; generates REST APIs, Console views, audit entries,
+TypeScript schema; generates REST APIs, views, audit entries,
 RBAC checkpoints automatically. See [Data Model](/docs/build/data).
 
 ### ObjectOS
@@ -147,7 +141,7 @@ source, Apache-2.0. **This documentation site is for ObjectOS.**
 ### ObjectQL
 
 The data layer protocol and query engine. Compiles declarative queries
-to native SQL / Mongo queries. Used by REST endpoints, Console,
+to native SQL / Mongo queries. Used by REST endpoints, the UI,
 flows — all the same engine.
 
 ### ObjectStack
@@ -159,7 +153,7 @@ marketplace. Sometimes called "the platform."
 ### ObjectUI
 
 The view layer protocol — apps, views, pages, dashboards, actions,
-charts, navigation. Console renders ObjectUI declarations.
+charts, navigation. ObjectOS renders ObjectUI declarations.
 
 ### Permission Set
 
@@ -189,6 +183,14 @@ beneath it (`unit_and_subordinates`). Stored as `sys_record_share`
 rows, whose `recipient_type` column takes exactly those five values.
 Different from sharing rules (declarative criteria).
 
+### Setup
+
+The built-in administration app, at `/apps/setup` inside the UI served
+at `/_console/`, gated by the `setup.access` permission. Manages users,
+business units, teams, positions, permission sets, sharing rules,
+record shares and API keys, plus configuration, diagnostics and
+integrations. See [Administration](/docs/configure).
+
 ### Sharing Rule
 
 A declarative rule that grants record access based on criteria
@@ -197,16 +199,11 @@ query time, compiled into row-level filters. A rule stored **without**
 criteria shares nothing — it is not a match-all. See
 [Record Access](/docs/configure/permissions/record-access#both-switches-fail-closed).
 
-### Console
-
-The business UI at `/_console/` — browse, create, edit records,
-configure views, install apps from the marketplace. Distinct from
-Console (system UI).
-
 ### Surface
 
-One of the four HTTP entry points a running ObjectOS exposes:
-`/` (REST API), `/_console/`, `/_account/`, `/_console/`.
+One of the HTTP entry points a running ObjectOS exposes:
+`/` (REST API), `/_console/` (the UI, which hosts the Setup app), and
+`/_account/` (sign-in, registration, and account management).
 
 ### System Context
 
@@ -231,7 +228,7 @@ schedule (cron), or manual invocation.
 ### View
 
 A declarative UI configuration — list, form, kanban, calendar, gantt —
-attached to an Object. Console renders it; you don't write the
+attached to an Object. ObjectOS renders it; you don't write the
 component.
 
 ### Zod schema

--- a/content/docs/use/approvals.mdx
+++ b/content/docs/use/approvals.mdx
@@ -34,7 +34,7 @@ When there's nothing waiting on you, **My Pending** shows the empty state
 to see at the end of the day.
 
 > **Tip:** Bookmark the Approvals inbox, or just glance at the **Needs your
-> attention** list on the console home — pending approvals appear there too,
+> attention** list on the home page — pending approvals appear there too,
 > with how long they've been waiting.
 
 ## What an approval request is
@@ -54,8 +54,8 @@ history.
 When a request is routed to you, two things happen:
 
 1. **You get a notification** — the bell in the top bar shows an unread
-   badge, and the item appears in **Needs your attention** on the console
-   home and in **Account → Inbox → Notifications**.
+   badge, and the item appears in **Needs your attention** on the home
+   page and in **Account → Inbox → Notifications**.
 2. **The record shows approval actions for you** — open the record in
    question and you'll see **Approve** and **Reject** as record actions.
    These buttons appear only for the assigned approver; other people viewing
@@ -94,7 +94,7 @@ everything-in-one-place view.
 
 | What now | Read |
 |---|---|
-| Tour the console as an everyday user | [Using ObjectOS](/docs/use) |
+| Tour ObjectOS as an everyday user | [Using ObjectOS](/docs/use) |
 | Work with the records you're approving | [Records](/docs/use/records) |
 | Keep up with everything else routed to you | [Notifications](/docs/use/notifications) |
 | Slice lists the way approvers do | [Views](/docs/use/views) |

--- a/content/docs/use/dashboards.mdx
+++ b/content/docs/use/dashboards.mdx
@@ -82,4 +82,4 @@ number is telling you. From there you're in a normal list — see
 | Filter and group a list myself | [Using views](/docs/use/views) |
 | Handle requests waiting on me | [Approvals](/docs/use/approvals) |
 | Manage what notifications I get | [Notifications](/docs/use/notifications) |
-| Back to the Console tour | [Using ObjectOS](/docs/use) |
+| Back to the tour | [Using ObjectOS](/docs/use) |

--- a/content/docs/use/index.mdx
+++ b/content/docs/use/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using ObjectOS
-description: Sign in once and find every app, record, and notification your team shares — a five-minute tour of the Console.
+description: Sign in once and find every app, record, and notification your team shares — a five-minute tour of ObjectOS.
 ---
 
 ObjectOS is where your team's business apps live — projects, tasks,
@@ -17,7 +17,7 @@ Open the URL your team gave you and sign in with your **email and
 password**. Your session is remembered, so you stay signed in on that
 browser until you log out from the avatar menu.
 
-## The Console home
+## The home page
 
 After signing in you land on the home page. Top to bottom:
 

--- a/content/docs/use/notifications.mdx
+++ b/content/docs/use/notifications.mdx
@@ -11,20 +11,20 @@ history.
 | Surface | Where | Best for |
 |---|---|---|
 | **The bell** | Top bar, on every screen | A quick "anything new?" check — the red badge shows your unread count |
-| **Needs your attention** | Console home | Your morning triage — recent items with how long they've been waiting |
+| **Needs your attention** | The home page | Your morning triage — recent items with how long they've been waiting |
 | **The full inbox** | **Account → Inbox → Notifications** | Reading, searching, and working through everything |
 
 ## The bell and the home page
 
-The **bell icon** sits in the top bar wherever you are in the console. A red
+The **bell icon** sits in the top bar wherever you are in ObjectOS. A red
 badge on it counts your unread notifications — click it to see what's new
 without leaving your current screen.
 
-The console home adds a **Needs your attention** list: pending
+The home page adds a **Needs your attention** list: pending
 notifications and approvals, each with its age, so you can see at a glance
 what's newest and what's been waiting longest.
 
-> **Tip:** Start your day on the console home. **Needs your attention** plus
+> **Tip:** Start your day on the home page. **Needs your attention** plus
 > **Recently Accessed** is usually all the triage you need before diving in.
 
 ## The full inbox
@@ -71,7 +71,7 @@ theirs.
 If you use the ObjectOS desktop app, it can mirror your in-app
 notifications to your operating system's native notifications — the same
 banners and notification center entries as any other desktop app. You'll
-see new items even when the console window is in the background, and
+see new items even when the ObjectOS window is in the background, and
 clicking one takes you straight to it.
 
 ## Where to go next
@@ -81,4 +81,4 @@ clicking one takes you straight to it.
 | Act on the approvals your notifications point to | [Approvals](/docs/use/approvals) |
 | Filter and sort your inbox like any list | [Views](/docs/use/views) |
 | Adjust your personal settings | [Profile & settings](/docs/use/profile) |
-| Tour the console as an everyday user | [Using ObjectOS](/docs/use) |
+| Tour ObjectOS as an everyday user | [Using ObjectOS](/docs/use) |

--- a/content/docs/use/profile.mdx
+++ b/content/docs/use/profile.mdx
@@ -43,8 +43,8 @@ you'll find the Preferences:
 
 | Preference | Options |
 |---|---|
-| **Theme** | Light or dark — the whole console follows immediately. |
-| **Language** | Pick your display language for the console UI. |
+| **Theme** | Light or dark — the whole UI follows immediately. |
+| **Language** | Pick your display language for the UI. |
 
 Both take effect on the spot; no save button, no reload.
 
@@ -82,4 +82,4 @@ them out from **Active Sessions**.
 | Keep your inbox under control | [Notifications](/docs/use/notifications) |
 | Handle requests routed to you | [Approvals](/docs/use/approvals) |
 | Get productive with your data | [Records](/docs/use/records) |
-| Tour the console as an everyday user | [Using ObjectOS](/docs/use) |
+| Tour ObjectOS as an everyday user | [Using ObjectOS](/docs/use) |

--- a/content/docs/use/records.mdx
+++ b/content/docs/use/records.mdx
@@ -94,4 +94,4 @@ Above every list you'll find:
 | See totals and trends instead of rows | [Dashboards](/docs/use/dashboards) |
 | Approve a record waiting on me | [Approvals](/docs/use/approvals) |
 | Control which updates reach me | [Notifications](/docs/use/notifications) |
-| Back to the Console tour | [Using ObjectOS](/docs/use) |
+| Back to the tour | [Using ObjectOS](/docs/use) |

--- a/content/docs/use/views.mdx
+++ b/content/docs/use/views.mdx
@@ -92,4 +92,4 @@ counts are your bottleneck detector.
 | See aggregated numbers instead of rows | [Dashboards](/docs/use/dashboards) |
 | Act on approval requests | [Approvals](/docs/use/approvals) |
 | Tune what the bell tells me | [Notifications](/docs/use/notifications) |
-| Back to the Console tour | [Using ObjectOS](/docs/use) |
+| Back to the tour | [Using ObjectOS](/docs/use) |

--- a/content/docs/why.mdx
+++ b/content/docs/why.mdx
@@ -13,9 +13,9 @@ metadata, you own the runtime that runs it.**
 
 You don't hand-write objects, fields, views, flows, and permissions
 file-by-file. Your users describe what they need in plain language to
-the in-Console [AI Builder](/docs/build/ai-builder); it calls a small
+the built-in [AI Builder](/docs/build/ai-builder); it calls a small
 set of audited tools, queues every change for human approval, and the
-result is live — REST endpoints, Console screens, RBAC, audit log,
+result is live — REST endpoints, generated screens, RBAC, audit log,
 everything generated from the same metadata.
 
 The runtime sits in **your** VPC, on **your** database — the underlying
@@ -48,7 +48,7 @@ Common scenarios where it's a fit:
 
 - are building a high-traffic consumer product → use a traditional web
   framework, you'll have more control.
-- need a pixel-perfect bespoke UI for end users → ObjectOS's Console is
+- need a pixel-perfect bespoke UI for end users → the generated UI is
   for admin/internal use; pair it with your own front-end via REST.
 - want a no-code drag-and-drop builder for non-engineers and a hosted
   cloud → use Retool, Bubble, or Airtable. ObjectOS is code-first AI-driven, self-hosted.
@@ -76,7 +76,7 @@ Common scenarios where it's a fit:
 | Database | Postgres, theirs (self-host possible) | Any Postgres / MySQL / SQLite / Turso / Mongo, **yours** |
 | Auth | Built in | Built in |
 | Generated APIs | PostgREST | ObjectQL-generated REST |
-| Admin UI | Console (basic) | Console + Account |
+| Admin UI | Console (basic) | Setup + Account |
 | RBAC | Row-level via Postgres RLS | RBAC + row-level + field-level, declarative |
 | Audit log | DIY | First-class |
 | Vendor lock-in | Their auth + their storage + their realtime | None — every layer is a plugin |
@@ -109,9 +109,9 @@ Common scenarios where it's a fit:
 
 ## The honest tradeoffs
 
-- **Less UI freedom than Retool.** The Console is generated from your
+- **Less UI freedom than Retool.** The UI is generated from your
   metadata. You can pair it with a custom front-end (the REST API is
-  the same one Console uses), but if you need a hand-crafted pixel-
+  the same one the UI uses), but if you need a hand-crafted pixel-
   perfect UI, build it yourself and use ObjectOS as the backend.
 - **TypeScript-first.** Non-engineers won't author objects directly.
   Salesforce admins are used to clicking through a UI builder; here,

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -71,8 +71,8 @@ Product nouns stay in English in **every** locale. They are how the product
 names itself in its own UI, and a translated product noun sends the reader
 looking for a control that does not exist:
 
-> ObjectOS · ObjectStack · Console · AI Builder · Studio · ObjectQL · CEL ·
-> Setup · Free / Team / Business / Enterprise (plan names)
+> ObjectOS · ObjectStack · AI Builder · Studio · ObjectQL · CEL · Setup ·
+> Free / Team / Business / Enterprise (plan names)
 
 Everything else is translated, consistently. These are the established terms —
 they are what the existing corpus already uses, so departing from them creates


### PR DESCRIPTION
Fixes #79
Fixes #89

Verified on `adbcafc`.

## The line I drew

The card names three jobs the word does. Deciding 180 occurrences one at a
time needs a test that is mechanical enough to review, so I used this one:

> **Is the word naming a place the reader goes, or a thing the product ships?**

- **A place, end-user or builder** — the surface has no name. Drop the noun and
  rewrite so the sentence keeps its subject. *"Open Console, start the AI
  Builder"* becomes *"Open ObjectOS, start the AI Builder"*; *"a view is how a
  user sees records in Console"* becomes *"a view is how a user sees records"*.
- **A place, administration** — `Setup`. This was mostly ratification, not
  introduction: the corpus already spells navigation `Setup → Configuration →
  …` on ~30 lines, gates it on `setup.access`, and calls it *the Setup app* at
  `/apps/setup`.
- **A thing the product ships** — a URL, a plugin id (`Console UI`), a line the
  CLI prints, a box in an architecture diagram, a component named in the
  licence text. **Unchanged**, because those are identifiers a reader matches
  against their own terminal, config, or plugin list.

### Where `build/` landed

The PM's measurement put 57 of 160 occurrences in `build/`, a section the card
does not classify. Applying the test above, almost all of them are the first
kind — a builder creating an object does it *in ObjectOS*, exactly as an end
user opens a record — so the noun is dropped. The exceptions the PM predicted
are real and were kept or reshaped rather than renamed:

| Occurrence | Call |
|:--|:--|
| `architecture.mdx` "REST API, **Console UI**, permissions, jobs" | **Kept.** Naming the runtime's shipped components; `ConsoleUI` is a real plugin id in `objectstack`. |
| `quickstart.mdx` plugin list "…, Console UI, Account UI, Console UI, …" | **Kept.** A list of plugin identifiers. |
| `system-settings.mdx` settings-model row naming **Console UI** as the renderer | **Kept.** A layer in the settings model, alongside `sys_setting` and `Resolver`. |
| `license.mdx` "the protocol, kernel, CLI, production runtime, Console" / "the Console and Account UIs" | **Kept.** Enumerating Apache-2.0 deliverables, not places. |
| "install apps via the **Console** marketplace" | **Kept** — it is CLI output inside a fence. |
| "the **Console**'s generic action runtime" (changelog) | **Reshaped**, not kept: the subject is the approvals inbox, which is a place. Now "the approvals inbox renders them through its generic action runtime". |
| "**Console** views" (many) | **Dropped**, not kept: attributive use of the place noun. "REST endpoints, Console views, audit log entries" → "REST endpoints, generated views, audit log entries". |

### Code fences: a bright line

**Nothing inside a code fence changed.** All nine in-fence occurrences are
byte-identical to `origin/main`. That rule is mechanical and one grep verifies
it, which is worth more than case-by-case judgement inside blocks a reader
copies and runs.

Worth flagging: only **five** of the nine are output the product prints
(`quickstart.mdx` lines 40/46/48/151/153). The other four are authored content
that happens to live in a fence — two ASCII diagram lines in
`build/marketplace.mdx`, one in `reference/field-types.mdx`, and a `#` comment
in a `bash` block in `reference/cli.mdx`. They are left unchanged under the
card's instruction, but the stated rationale for that instruction (terminal
output a reader compares) does not cover them. `reference/cli.mdx` is where
this shows: the fenced comment still reads `# API only (no Console/Account)`
while the flag table three screens down now reads *Disable the UI and Account
portals*. One line, one follow-up, maintainer's call.

## The gap in the card's own measurement

The card counted `Console`, case-sensitively. The corpus also carries **20
lowercase `console`** occurrences doing the same job — *"the console home"*,
*"wherever you are in the console"*, *"the whole console follows immediately"*,
*"Tour the console as an everyday user"*. **Thirteen of them are in `use/`**,
the section measured at 6.

Leaving them would have left two spellings of the same surface live in the
corpus, which the card forbids. Fifteen were retired with the rest; five stay,
all category three: `/console/f/…` form URLs in `build/interface/forms.mdx`,
and the `OS_OBS_EXPORTER=console` config value in two pages.

## #89 — the glossary

The two `### Console` entries are one collapsed pair, and the entry bodies
survived intact even though the headings did not. **What they were
distinguishing is legible from the bodies**: platform administration (users,
roles, permission sets, audit log, sessions, API keys, system settings) versus
working in the apps (browse, create, edit records, configure views, install
apps). Two more pieces of evidence agree — the second entry sits in the
alphabetical slot *after* `Sharing Rule`, so it was never a C-word; and the
damage repeats elsewhere in the corpus with the same shape (`quickstart.mdx`
prints two identical `Console:` banner lines and lists two `Console UI`
plugins).

Under the decision that collapses to: one `Setup` entry, and no entry at all
for the end-user surface. Both were rewritten accordingly, and `Setup` moved to
its alphabetical position between `Record Share` and `Sharing Rule`.

**On the URL.** The triage asked that the address come from routing rather than
from either glossary sentence. It does: `objectstack@origin/main` defines
`CONSOLE_PATH = '/_console'` in `packages/cli/src/utils/console.ts` and defaults
`uiBasePath` to `/_console` in `packages/spec/src/system/auth-config.zod.ts`,
and the CLI banner prints exactly one `Console:` line. So the duplicated URL was
not a wrong URL — **there is one UI at `/_console/`**, and what was wrong was
presenting two areas of it as two separately-named surfaces. The glossary now
says Setup lives at `/apps/setup` inside the UI served at `/_console/`, which is
what `configure/index.mdx` and `configure/users.mdx` already said.

`Surface` claimed "four" entry points and listed three distinct ones with
`/_console/` repeated. I removed the numeral rather than asserting "three":
three is what this corpus can support, four is a claim nothing supports, and
inventing a fourth URL is out of scope.

## Verification

| Check | Result |
|:--|:--|
| `turbo run type-check --force` | `cache bypass, force executing 5f6f0dc855a640b1` · 1 successful |
| `turbo run build --force` | `cache bypass, force executing 002d42ca7ee9a0e6` · 1 successful, 79 English pages + 256 translations prerendered |
| `check-translation-ownership.mjs` | exit 0 — 0 translation artifacts touched, 48 other files |
| `check-translations.mjs` (freshness) | **exit 0, gate passed** — stale reported, not blocking, as designed |
| `check-translation-output.mjs --self-test` | exit 0 — 20 cases, every rule demonstrated able to fail |
| `check-translation-output.mjs --files` | exit 0 — 116 pre-existing findings reported, none in files this PR touches |
| Rendered HTML read | `/docs/use`, `/docs/use/notifications`, `/docs/configure`, `/docs/configure/permissions/permission-sets`, `/docs/build/marketplace`, `/docs/build/interface/actions`, `/docs/quickstart`, `/docs/resources/glossary` |
| Anchors | 6 headings renamed; a repo-wide grep for every old slug and for `glossary#` returns nothing. No internal link points at a renamed anchor. |

The rendered-text scan is the real proof of the fence rule: across those eight
pages the only surviving `Console` in rendered output is in `quickstart`'s two
banner blocks, its plugin list, and `marketplace`'s ASCII diagram.

### Category-3 count

The card asks that `_console` come out unchanged. Reporting it honestly, because
it does not, and the reason matters:

| Scope | Before | After |
|:--|--:|--:|
| `_console`, English pages | 17 | **15** |
| `_console`, English pages **outside `resources/glossary.mdx`** | 13 | **13** |
| `_console`, all `.mdx` including locales | 113 | 111 |
| `Console`, English pages | 160 | 16 |
| in-fence `Console` | 9 | **9, byte-identical** |

Every `/_console` **string** in the corpus is untouched — the diff shows only
surrounding prose changing on those lines. The two-occurrence delta is entirely
inside `resources/glossary.mdx` and is exactly what #89 asked for: the deleted
duplicate entry took its `/_console/` with it, and de-duplicating `Surface`
removed the repeated one. Those two instructions cannot both hold; I kept the
one that names a defect and reported the other rather than leaving the defect in
place.

## Scope held

Not split. `configure/**` alone would have left the administration surface
spelled `Setup` there and `Console` in `build/`, `use/`, `reference/`,
`operate/`, `resources/` and the root pages — two spellings of one surface,
which the card forbids. 47 files, but each hunk is one or two lines.

Untouched, as instructed: the `/_console` URL everywhere; the recipient-kind
wording in `record-access.mdx` and the `share` row in `actions.mdx` (#91);
`packages/console`; every locale sibling. `objectui` and `objectstack` UI copy
are separate cards in their own repos.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_