### PR TITLE
docs(configure): repoint the dead /docs/build/objects link to /docs/build/data

### DIFF
--- a/content/docs/configure/data-sources.mdx
+++ b/content/docs/configure/data-sources.mdx
@@ -255,5 +255,5 @@ non-production copy first.
 - [Runtime](/docs/configure/runtime) — the primary database behind `default`
 - [AI Service](/docs/configure/ai) — chat, embeddings, RAG, MCP
 - [AI Agents](/docs/build/agents) — declarative agents over your objects
-- [Objects](/docs/build/objects) — the `ObjectSchema.create` authoring surface
+- [Data Model](/docs/build/data) — the `ObjectSchema.create` authoring surface
 - [`examples/app-crm` datasources](https://github.com/objectstack-ai/objectstack/tree/main/examples/app-crm/src/datasources) — a real datasource + routing example


### PR DESCRIPTION
Fixes #99

`content/docs/configure/data-sources.mdx:258` linked to `/docs/build/objects` in its
"Where to go next" list. No such page exists and no redirect covers it, so it was a
live 404 on a customer-facing page.

One line changed:

```
- [Objects](/docs/build/objects) — the `ObjectSchema.create` authoring surface
+ [Data Model](/docs/build/data) — the `ObjectSchema.create` authoring surface
```

## Repoint vs redirect — decided on evidence

**Repoint. `/docs/build/objects` has never existed as a page in this repository.**

- `git log --all --diff-filter=D` over `content/docs/build/` lists every deletion the
  section has ever had: the six `packages.{locale}.mdx` files and five `*.cn.mdx`
  files. No `objects.mdx`.
- Widening past deletions to the whole history — walking `git ls-tree -r` over every
  commit reachable from every ref — finds no path matching `docs/build/objects` at any
  point.
- By contrast the four sources already in the redirect table (`data-model`, `views`,
  `actions`, `flows`) each have real commit history at `content/docs/build/{name}.mdx`.
  That table's meaning is "this URL was live and the Build restructure moved it".

A URL that never resolved cannot be in anyone's bookmark, index, or external link as a
working address, so a redirect would be dead config — and a fifth entry of a different
kind would blur what the table documents. `apps/docs/next.config.mjs` is untouched.

## Why `/docs/build/data`, labelled "Data Model"

`content/docs/build/data/index.mdx` still documents `ObjectSchema.create` after #82's
17.0 alignment pass — 7 occurrences, including the located-error note on `abstract`.
Its frontmatter title is `Data Model`, and all 19 other English links to that page label
it "Data Model" / "Data model", never "Objects". The trailing description is unchanged
and still accurate.

## Locale siblings — reported, not edited

All six carry the same dead link and are left alone as generated artifacts:

| File | Line |
|---|---|
| `content/docs/configure/data-sources.de.mdx` | 267 |
| `content/docs/configure/data-sources.es.mdx` | 260 |
| `content/docs/configure/data-sources.fr.mdx` | 272 |
| `content/docs/configure/data-sources.ja.mdx` | 179 |
| `content/docs/configure/data-sources.ko.mdx` | 179 |
| `content/docs/configure/data-sources.zh-Hans.mdx` | 214 |

They clear when the translation pass regenerates them from this English source. The
existing gates already carry the work item: after this change
`check-translation-output.mjs` reports a **url** finding on each of the six naming
`/docs/build/objects` exactly, where the baseline reported none — measured by restoring
the `origin/main` file, re-running, and restoring the branch file (116 findings / 0
`data-sources` url hits before, 122 / 6 after; non-blocking, `blocking on 0 changed
translation(s)`).

## Verification, all at `4176b4a`

- `turbo run type-check --filter=@objectos/docs --force` — `cache bypass, force executing 0edb23119da91b7f`, 1 successful.
- `turbo run build --filter=@objectos/docs --force` — `cache bypass, force executing b2ef76cdbd3badb4`, 1 successful.
- Rendered HTML read: `apps/docs/.next/server/app/en/docs/configure/data-sources.html`
  now contains `a href="/docs/build/data" >Data Model` and zero occurrences of
  `docs/build/objects`.
- The target prerenders: `.next/server/app/en/docs/build/data.html` exists, 254,982
  bytes, `title` reads `Data Model | ObjectOS` — plus the six locale variants.
- Ownership gate: 0 translation artifacts touched, 1 other file.
- Freshness gate: passed. The six `data-sources.*` siblings join the stale list, which
  is non-blocking by design.
- Output validator self-test: 20 cases, every rule demonstrated able to fail.
- Output gate: passed.
- Control-byte self-scan on the changed file: clean.

## Corpus re-sweep — reported, not fixed

Re-ran the sweep that found this card with all three of its stated narrowings widened:
locale siblings included, link forms extended to reference-style definitions, JSX
`href=` (quoted and braced) and bare URLs, and `#fragment` anchors resolved against
each page's generated heading ids.

- English, 79 files, **504** internal `/docs/...` links (the original narrow run saw 502):
  **0 missing pages, 0 missing anchors** with this fix applied.
- Locale siblings, 256 files, 1,207 links: the only missing-page hits are the six copies
  of this same link, listed above.
- Two zh-Hans anchor hits were checked by hand and are **false positives** of the sweep,
  not findings — `permission-sets#委托管理delegated-administration` and
  `permissions#诊断与审计` resolve correctly against their own locale sibling's headings.

No second broken link found, so there is no follow-up card to file. Sweep script kept
out of the diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_