### PR TITLE
docs: rewrite the four authored-prose lines that still said "Console"

### DIFF
--- a/content/docs/build/marketplace.mdx
+++ b/content/docs/build/marketplace.mdx
@@ -43,11 +43,11 @@ When you open ObjectOS (`/_console/`), the marketplace tab queries the
 configured app catalog and shows installable apps.
 
 ```text
-You ─→ Console ─→ Marketplace tab ─→ pick app ─→ Install
+You ─→ ObjectOS ─→ Marketplace tab ─→ pick app ─→ Install
                                                   ↓
                                        Artifact merged into kernel
                                                   ↓
-                                       Console re-renders with new
+                                       The page re-renders with new
                                        objects / views / permissions
                                                   ↓
                                        Done — no restart

--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -35,7 +35,7 @@ os start --database postgres://user:pass@host:5432/mydb
 os start --database libsql://my-db.turso.io --database-auth-token $TURSO
 os start --auth-secret "$(openssl rand -hex 32)"
 os start --home /var/lib/objectos      # persistent home dir
-os start --no-ui                       # API only (no Console/Account)
+os start --no-ui                       # API only (no UI/Account portals)
 ```
 
 HOME directory default:

--- a/content/docs/reference/field-types.mdx
+++ b/content/docs/reference/field-types.mdx
@@ -222,7 +222,7 @@ You don't declare these — opt out per object with
    │
    ├─► Postgres / MySQL / SQLite column + index + constraint
    ├─► REST: validated on POST/PATCH, exposed on GET
-   ├─► Console: form widget + list column
+   ├─► UI: form widget + list column
    ├─► AI Builder: tool argument schema (so the AI knows what to ask)
    └─► Audit: change-tracked if `trackHistory: true`
 ```


### PR DESCRIPTION
Fixes #101

Verified at commit `5c14215`.

## What changed

Four lines, all of them content an author wrote that a code fence happens to render in a monospace box.

| File:line | What it was | What it is |
|:--|:--|:--|
| `build/marketplace.mdx:46` | `You ─→ Console ─→ Marketplace tab …` | `You ─→ ObjectOS ─→ Marketplace tab …` |
| `build/marketplace.mdx:50` | `Console re-renders with new` | `The page re-renders with new` |
| `reference/field-types.mdx:225` | `├─► Console: form widget + list column` | `├─► UI: form widget + list column` |
| `reference/cli.mdx:38` | `# API only (no Console/Account)` | `# API only (no UI/Account portals)` |

Untouched, as ruled: every `/_console/` URL in the corpus (the diff contains no line matching `_console`), and the command `os start --no-ui` itself, which is copy-run and is byte-identical — only the comment after the hash changes. The five in-fence occurrences in `quickstart.mdx` are #94's and are not touched here.

## The check that is the deliverable: what a reader now sees

The defect was visible on one screen in `reference/cli.mdx` — a fenced comment and a flag table three screens apart, naming the same flag two different ways. I read the **prerendered HTML from the production build** (`apps/docs/.next/server/app/en/docs/…`), not the source, for all three pages.

Rendered `reference/cli.mdx`, the fenced block:

```
os start --home /var/lib/objectos      # persistent home dir
os start --no-ui                       # API only (no UI/Account portals)
```

and the flag table row on the same rendered page: `--no-ui` → "Disable the UI and Account portals". One vocabulary, both places.

Sweeping the rendered text of all three English pages for the surface nouns:

| Rendered page | Surface vocabulary present |
|:--|:--|
| `build/marketplace` | ObjectOS, Setup, UI |
| `reference/field-types` | ObjectOS, UI, the UI |
| `reference/cli` | ObjectOS, the UI, the UI enabled |

`Console` appears **zero** times in the rendered English text of all three. No fourth or fifth spelling was introduced — those are the three names #79 landed (`ObjectOS` for a destination, `the UI` / `UI` for the capability and the stack layer, `Setup` for administration).

## Why these words and not others

Checked against what #79 actually landed rather than pattern-matched:

- **ObjectOS** on the marketplace node — the prose sentence directly above that fence already reads "When you open ObjectOS (`/_console/`)". The diagram now agrees with the sentence introducing it.
- **UI** as the field-types branch label — its siblings in that diagram are `REST:`, `AI Builder:`, `Audit:`, i.e. stack layers without articles, and #79 rewrote this file's own frontmatter to "how it surfaces in REST, the UI, and the AI Builder".
- **The page re-renders** rather than "ObjectOS re-renders" — #79 rewrote step 5 of this page's install flow to "**Reload the page** — the new app's objects, views, and flows appear", for the very same event. It is also the safer reading: the diagram's next line is "Done — no restart", and making ObjectOS the subject of "re-renders" invites the reader to hear a restart.

## Diagram alignment, measured in display columns

Counted as display columns, not bytes — the box-drawing characters are multi-byte (the field-types branch lines are 41 code points but 47 bytes), so a byte count would have misled. Measured on the **rendered** output:

marketplace flow diagram — the three `↓` stay in column 50 and the four text-block lines stay at indent 39. The node line grows one column (56 → 57), which moves `Install` from column 49 to 50, so the arrow spine now descends from its **first** character instead of its second. The one invariant that could have broken is the spine, and it did not move.

field-types diagram — every branch stays at indent 3; the block is ragged right with nothing aligned to the right edge, so shortening `Console:` to `UI:` changes no relationship.

`cli.mdx` — the comment hash stays in column 39; only the text after it changed.

## Verification

All at `5c14215`, after the final commit.

- `turbo run type-check build --filter=@objectos/docs --force` — both `cache bypass, force executing` (`6cdd55539dc94ec8`, `cc2e9329a2da2066`), `Tasks: 2 successful, 2 total`, `0 cached`.
- `check-translations.mjs` — `✓ translations gate passed`.
- `check-translation-ownership.mjs` — 0 translation artifacts, 3 other files (`TRANSLATION_BOT_LOGIN` unset, so reporting).
- `check-translation-output.mjs --self-test` — `20 case(s) … every rule demonstrated able to fail`, then `--files` as CI runs it on a PR: `blocking on 0 changed translation(s)`, exit 0.

Locale staleness this introduces, measured against `origin/main` in a second worktree rather than assumed: 6 new `fence` findings (`marketplace.zh-Hans`, `field-types.{de,es,fr,ja,ko}`) and one shifted (`marketplace.zh-Hans` #4 → #2). All are non-blocking — the gate's PR scope is changed **locale** files, and this PR changes none. This is the designed outcome of AGENTS.md's translation split; the next translation pass clears them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CJPxtTxoxTUnjNdTbiEaRa)_