### PR TITLE
docs: rename pages.mdx component visibility key to visibleWhen

### DIFF
--- a/content/docs/build/interface/pages.mdx
+++ b/content/docs/build/interface/pages.mdx
@@ -78,7 +78,7 @@ Components are the building blocks inside regions:
   properties: { chartType: 'line', dataset: 'sales',
                 dimensions: ['close_month'], values: ['revenue'] },
   events: { onClick: "navigate_to('opportunity_detail', { id: $event.id })" },
-  visibility: "'sales_manager' in os.user.positions",
+  visibleWhen: "'sales_manager' in os.user.positions",
 }
 ```
 
@@ -95,7 +95,7 @@ parse error since 16.0, not a silently ignored no-op.
 | `id` | `string` | Unique component instance id |
 | `properties` | `object` | Component-specific configuration |
 | `events` | `object` | Event handlers (action expressions) |
-| `visibility` | `string` | CEL visibility predicate |
+| `visibleWhen` | `string` | CEL visibility predicate — component rendered only when TRUE. (`visibility` is a deprecated alias, still accepted and normalized to `visibleWhen`.) |
 | `style` / `className` | — | Ad-hoc CSS |
 | `responsiveStyles` | `object` | **Preferred** styling channel: desktop-first per-breakpoint style maps (`large` base, then `medium` / `small` / `xsmall` overrides), compiled to scoped CSS — prefer design tokens like `var(--space-8)` |
 


### PR DESCRIPTION
Fixes #129

## What changed

`content/docs/build/interface/pages.mdx` was the last English page spelling the
page-component conditional-visibility key as `visibility` instead of the
ADR-0089 canonical `visibleWhen`. Renamed it in both places:

- Line 81 — the Components code example: `visibility: "..."` → `visibleWhen: "..."`.
- Line 98 — the component property-table row: key renamed, and the description
  now keeps a one-line note that `visibility` is still accepted as a
  deprecated alias, since it genuinely parses and normalizes at the schema
  boundary and silence would read as "my metadata just broke" to an existing
  author.

Editorial-call note (per the card): I looked for an established corpus
convention for documenting an accepted-but-deprecated alias inside a
property-table row and found none — the one precedent
(`content/docs/build/automation/approvals.mdx`) documents its deprecated
alias in prose above the table, not as a table row annotation, and links to
matching `os lint` rule ids. Since no table-row precedent exists, I followed
the PM triage recommendation: a short parenthetical note in the description
cell rather than a separate row or silence.

English source only — no locale siblings touched. `pages.zh-Hans.mdx` is now
reported stale by the translation freshness gate, which is the designed
non-blocking behavior (see below).

## Premise re-verification (on branch point `5fd04d8`)

```
content/docs/build/interface/pages.mdx:81:  visibility: "'sales_manager' in os.user.positions",
content/docs/build/interface/pages.mdx:98:| `visibility` | `string` | CEL visibility predicate |
```

Corpus grep for the three spellings across English `.mdx` (locale siblings
excluded) confirms this was still the only `visibility:`/`` `visibility` ``
hit, with a `visibleWhen`/`visibleOn` control probe returning real hits
elsewhere (`formulas.mdx`, `validation-rules.mdx`, `views.mdx`,
`changelog.mdx`) — the single-hit reading is a real measurement, not a
broken grep.

## Verification (HEAD `94b76e5`)

- `pnpm turbo run type-check --filter=@objectos/docs --force` — 1 successful, 1 total.
- `pnpm turbo run build --filter=@objectos/docs --force` — 1 successful, 1 total; confirmed the rendered `/en/docs/build/interface/pages.html` output contains `visibleWhen` in both the code sample and the property table, with the deprecated-alias note.
- `node .github/scripts/check-translations.mjs` — exit 0, "✓ translations gate passed"; `pages.zh-Hans.mdx` now listed as stale, which is the designed non-blocking outcome (English lands on its own; the next translation pass re-derives it).
- `pnpm turbo run test` was not run — it executes zero tasks in this repo.

_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_