### PR TITLE
ci: gate the declared Node floor against the dependency tree

### DIFF
--- a/.github/scripts/check-node-floor.mjs
+++ b/.github/scripts/check-node-floor.mjs
@@ -71,7 +71,7 @@
  *   node .github/scripts/check-node-floor.mjs --self-test  # prove every rule can fail
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -83,7 +83,23 @@ const ROOT = resolve(HERE, '../..');
 const DECLARATION_FILES = ['package.json', 'apps/docs/package.json'];
 
 /** Every rule this script enforces; the self-test asserts each one has a red fixture. */
-const RULES = ['lockfile', 'declarations', 'node-version', 'range', 'coverage'];
+const RULES = ['lockfile', 'declarations', 'node-version', 'range', 'coverage', 'ungoverned'];
+
+/**
+ * Reported, never blocking — the same split `check-translations.mjs` already
+ * makes between blocking and reported findings.
+ *
+ * `ungoverned` names this gate's own blind spot. `DECLARATION_FILES` is an
+ * explicit list, so a workspace package that declares `engines.node` outside
+ * it is simply not checked, and a gate silently covering two of three
+ * declarations is the same structurally-silent shape this one exists to end.
+ * It is advisory rather than blocking because "this file is not governed" is
+ * not a claim that its value is WRONG: `tools/ci-scripts` declares `>=20.0.0`
+ * and has no dependencies of its own, so that may well be correct in
+ * isolation. Whether the workspace should hold one floor or several is a
+ * decision for the seat, not something for this script to force by going red.
+ */
+const ADVISORY = new Set(['ungoverned']);
 
 /**
  * Rules that must ALSO ship a fixture proving they stay silent. A rule that
@@ -93,7 +109,7 @@ const RULES = ['lockfile', 'declarations', 'node-version', 'range', 'coverage'];
  * overwhelmingly common case, and a rule that fired on it would be reverted
  * within a day.
  */
-const SILENT_RULES = ['lockfile', 'declarations', 'node-version'];
+const SILENT_RULES = ['lockfile', 'declarations', 'node-version', 'ungoverned'];
 
 /* ------------------------------------------------------- semver, a subset --
  * Only what `engines.node` ranges actually use, and only the LOWER bound —
@@ -196,6 +212,52 @@ function scanLockfile(text) {
   return { entries, unreadable, raw };
 }
 
+/* ------------------------------------------------- workspace discovery -- */
+
+/** The `packages:` globs from `pnpm-workspace.yaml`. */
+function workspaceGlobs(root) {
+  const path = join(root, 'pnpm-workspace.yaml');
+  if (!existsSync(path)) return [];
+  const globs = [];
+  let inPackages = false;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (/^packages:\s*$/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (!inPackages) continue;
+    const item = /^\s+-\s*['"]?([^'"#\s]+)['"]?\s*$/.exec(line);
+    if (item) globs.push(item[1]);
+    else if (/^\S/.test(line)) inPackages = false;
+  }
+  return globs;
+}
+
+/**
+ * Every workspace `package.json`, plus the globs that could not be expanded.
+ * Only the `dir/*` shape is expanded — anything else is reported rather than
+ * silently skipped, so the blind spot stays visible.
+ */
+function workspacePackages(root) {
+  const files = ['package.json'];
+  const unexpanded = [];
+  for (const glob of workspaceGlobs(root)) {
+    const m = /^([^*!]+)\/\*$/.exec(glob);
+    if (!m) {
+      unexpanded.push(glob);
+      continue;
+    }
+    const dir = join(root, m[1]);
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const rel = `${m[1]}/${entry.name}/package.json`;
+      if (existsSync(join(root, rel))) files.push(rel);
+    }
+  }
+  return { files, unexpanded };
+}
+
 /* --------------------------------------------------------------- inputs -- */
 
 /** Read the declared surface off disk. Missing inputs are findings, not throws. */
@@ -217,6 +279,21 @@ function collect(root) {
     }
     declarations.push({ source: file, value: parsed?.engines?.node ?? null });
   }
+  // Declarations this gate does NOT govern, reported so the blind spot is visible.
+  const ungoverned = [];
+  const { files: wsFiles, unexpanded } = workspacePackages(root);
+  for (const file of wsFiles) {
+    if (DECLARATION_FILES.includes(file)) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(join(root, file), 'utf8'));
+    } catch {
+      continue;
+    }
+    const value = parsed?.engines?.node;
+    if (value) ungoverned.push({ source: file, value });
+  }
+
   const nvPath = join(root, '.node-version');
   const lockPath = join(root, 'pnpm-lock.yaml');
   if (!existsSync(nvPath)) missing.push('.node-version');
@@ -226,12 +303,14 @@ function collect(root) {
     nodeVersion: existsSync(nvPath) ? readFileSync(nvPath, 'utf8') : null,
     lock: existsSync(lockPath) ? readFileSync(lockPath, 'utf8') : null,
     missing,
+    ungoverned,
+    unexpanded,
   };
 }
 
 /* ---------------------------------------------------------------- rules -- */
 
-function evaluate({ declarations, nodeVersion, lock, missing = [] }) {
+function evaluate({ declarations, nodeVersion, lock, missing = [], ungoverned = [], unexpanded = [] }) {
   const findings = [];
   const add = (rule, detail) => findings.push({ rule, detail });
 
@@ -339,14 +418,38 @@ function evaluate({ declarations, nodeVersion, lock, missing = [] }) {
     }
   }
 
+  for (const u of ungoverned) {
+    add(
+      'ungoverned',
+      `${u.source} declares engines.node ${JSON.stringify(u.value)}, which this gate does not check — ` +
+        `it governs ${DECLARATION_FILES.join(' and ')} only`,
+    );
+  }
+  for (const g of unexpanded) {
+    add(
+      'ungoverned',
+      `pnpm-workspace.yaml pattern ${JSON.stringify(g)} is not a shape this gate expands, so any ` +
+        'package.json it matches was not inspected for an engines.node declaration',
+    );
+  }
+
   return { findings, required, requiredBy, floors, scan };
 }
 
 /* --------------------------------------------------------------- output -- */
 
+/** Split findings into what fails the job and what is only reported. */
+function classify(findings) {
+  const blocking = [];
+  const advisory = [];
+  for (const f of findings) (ADVISORY.has(f.rule) ? advisory : blocking).push(f);
+  return { blocking, advisory };
+}
+
 function gate() {
   const inputs = collect(ROOT);
   const { findings, required, requiredBy, floors, scan } = evaluate(inputs);
+  const { blocking, advisory } = classify(findings);
 
   console.log('## Node floor');
   console.log('');
@@ -366,15 +469,27 @@ function gate() {
   }
   console.log('');
 
-  if (findings.length) {
-    console.log(`❌ ${findings.length} finding(s).`);
+  if (blocking.length) {
+    console.log(`❌ ${blocking.length} finding(s).`);
     console.log('');
-    for (const f of findings) console.log(`- **${f.rule}** — ${f.detail}`);
-    console.error(`\n✗ node floor: ${findings.length} finding(s)`);
-    for (const f of findings) console.error(`    [${f.rule}] ${f.detail}`);
+    for (const f of blocking) console.log(`- **${f.rule}** — ${f.detail}`);
+    console.log('');
+  } else {
+    console.log('✅ Every declared floor clears what the dependency tree requires, and the declarations agree.');
+    console.log('');
+  }
+
+  if (advisory.length) {
+    console.log(`ℹ️ ${advisory.length} note(s), reported and not blocking:`);
+    console.log('');
+    for (const f of advisory) console.log(`- **${f.rule}** — ${f.detail}`);
+  }
+
+  if (blocking.length) {
+    console.error(`\n✗ node floor: ${blocking.length} finding(s)`);
+    for (const f of blocking) console.error(`    [${f.rule}] ${f.detail}`);
     process.exit(1);
   }
-  console.log('✅ Every declared floor clears what the dependency tree requires, and the declarations agree.');
 }
 
 /* ------------------------------------------------------------ self-test --
@@ -422,8 +537,9 @@ const CASES = [
   {
     name: 'clean baseline',
     expect: [],
-    // ">=22" and ">=22.0.0" are byte-different and identical as floors.
-    ignores: ['declarations'],
+    // ">=22" and ">=22.0.0" are byte-different and identical as floors, and
+    // every workspace package.json that declares a floor is a governed one.
+    ignores: ['declarations', 'ungoverned'],
   },
   {
     name: 'declared floor below what the tree requires',
@@ -491,6 +607,16 @@ const CASES = [
     lock: CLEAN_LOCK.replace("    engines: {node: '>=10'}", "    engines:\n      node: '>=24'"),
     expect: ['coverage'],
   },
+  {
+    name: 'a workspace package outside the governed set',
+    extra: { 'tools/thing/package.json': { engines: { node: '>=20.0.0' } } },
+    expect: ['ungoverned'],
+  },
+  {
+    name: 'a workspace glob shape this gate cannot expand',
+    workspace: 'packages:\n  - apps/*\n  - tools/**\n',
+    expect: ['ungoverned'],
+  },
 ];
 
 /** The reduction, pinned on the exact range shapes this repo's lockfile contains. */
@@ -530,6 +656,14 @@ function selfTest() {
       );
       writeFileSync(join(dir, '.node-version'), `${c.nodeVersion ?? '22'}\n`);
       writeFileSync(join(dir, 'pnpm-lock.yaml'), c.lock ?? CLEAN_LOCK);
+      // A real workspace file, so the baseline exercises the governed-file
+      // exclusion rather than skipping discovery altogether.
+      writeFileSync(join(dir, 'pnpm-workspace.yaml'), c.workspace ?? 'packages:\n  - apps/*\n  - tools/*\n');
+      rmSync(join(dir, 'tools'), { recursive: true, force: true });
+      for (const [rel, body] of Object.entries(c.extra ?? {})) {
+        mkdirSync(dirname(join(dir, rel)), { recursive: true });
+        writeFileSync(join(dir, rel), JSON.stringify(body));
+      }
 
       const { findings } = evaluate(collect(dir));
       const fired = [...new Set(findings.map((f) => f.rule))].sort();
@@ -560,6 +694,17 @@ function selfTest() {
     const ok = got === expected;
     if (!ok) failed += 1;
     console.log(`${ok ? '✓' : '✗'} range ${JSON.stringify(range).padEnd(38)} -> ${got ?? 'unparseable'}` + (ok ? '' : `  expected ${expected ?? 'unparseable'}`));
+  }
+
+  console.log('');
+  // An advisory rule that quietly became blocking would turn this gate red on
+  // a repo it was never meant to judge, so the split is asserted, not assumed.
+  for (const rule of RULES) {
+    const { blocking, advisory } = classify([{ rule, detail: 'probe' }]);
+    const wantAdvisory = ADVISORY.has(rule);
+    const ok = wantAdvisory ? advisory.length === 1 && blocking.length === 0 : blocking.length === 1 && advisory.length === 0;
+    if (!ok) failed += 1;
+    console.log(`${ok ? '✓' : '✗'} classify ${rule.padEnd(14)} -> ${wantAdvisory ? 'advisory (reported)' : 'blocking'}`);
   }
 
   console.log('');

--- a/.github/scripts/check-node-floor.mjs
+++ b/.github/scripts/check-node-floor.mjs
@@ -1,0 +1,596 @@
+#!/usr/bin/env node
+/**
+ * Node floor gate — the repo's declared Node floor, checked against what its
+ * own dependency tree actually demands.
+ *
+ * ## Why this exists
+ *
+ * Three files declare the Node floor:
+ *
+ *     package.json            engines.node
+ *     apps/docs/package.json  engines.node
+ *     .node-version
+ *
+ * Nothing in the install path reads any of them. `.npmrc` does not set
+ * `engine-strict=true` and pnpm does not enforce `engines` by default, so
+ * `pnpm install --frozen-lockfile` completes with no engines-related output at
+ * all. CI does not consult them either — all three workflows pin
+ * `node-version: 22` explicitly in `actions/setup-node`. Their audience is a
+ * human reading the file, plus version managers (fnm / nvm / asdf) for
+ * `.node-version` only.
+ *
+ * So a floor that is WRONG is structurally silent. This repo's floor stayed
+ * wrong across the whole Node 20 era and was caught by someone reading a file,
+ * not by a red job. A declaration nothing reads is the declared-but-unenforced
+ * shape this project retires on sight; this gate is what makes it read.
+ *
+ * The alternative routes were considered and rejected: `engine-strict=true`
+ * turns every contributor's install into a hard failure to enforce a
+ * declaration CI never consults, punishing deliberate local variance to buy
+ * nothing CI does not already have; and treating the declarations as
+ * documentation keeps exactly the failure mode above.
+ *
+ * ## The direction, which is the whole rule
+ *
+ * The defect is a declared floor BELOW what a dependency requires — the repo
+ * claims to run on a Node that something in the tree does not support. A
+ * dependency floor lower than the declaration is the normal case and must stay
+ * green: almost every package in the lockfile asks for far less than 22.
+ *
+ * So: reduce every `engines.node` range in `pnpm-lock.yaml` to the lowest Node
+ * version that satisfies it, take the maximum across the tree, and require
+ * each declared floor to be at least that. `RANGE_CASES` in the self-test pins
+ * that reduction on the exact range shapes this lockfile contains.
+ *
+ * ## Known limitation, deliberately not enforced here
+ *
+ * The reduction above is max-of-minimums, which is blind to a GAP inside a
+ * disjunctive range. `yargs@18.0.0` declares
+ * `^20.19.0 || ^22.12.0 || >=23`: its minimum is 20.19.0, far below 22, so it
+ * never moves the maximum — yet Node 22.0.0 through 22.11.x satisfies none of
+ * its three branches, and `>=22` claims exactly that window is supported. A
+ * stricter rule ("the declared floor version must itself satisfy every
+ * dependency range") would catch it and is RED on `main` today. Closing that
+ * gap means changing a declared value, which is a separate decision — filed as
+ * its own card rather than decided by this script. This gate is honest about
+ * what it proves: no dependency requires a floor higher than the one declared.
+ *
+ * ## Why there is no YAML dependency
+ *
+ * Zero-dependency `.mjs`, like its three siblings in this directory, so it
+ * runs before `pnpm install` and cannot be broken by the install it checks.
+ * The lockfile scan is line-based. That is safe only because it FAILS LOUD
+ * when it stops understanding the file: every line carrying `engines:` must
+ * parse into a flow map, and finding zero `engines.node` entries at all is a
+ * `coverage` failure rather than a vacuous pass. A gate that silently matches
+ * nothing is the same defect class as the declaration it is here to enforce.
+ *
+ * ## Usage
+ *
+ *   node .github/scripts/check-node-floor.mjs              # gate
+ *   node .github/scripts/check-node-floor.mjs --self-test  # prove every rule can fail
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '../..');
+
+/** The `package.json` files whose `engines.node` this gate governs. */
+const DECLARATION_FILES = ['package.json', 'apps/docs/package.json'];
+
+/** Every rule this script enforces; the self-test asserts each one has a red fixture. */
+const RULES = ['lockfile', 'declarations', 'node-version', 'range', 'coverage'];
+
+/**
+ * Rules that must ALSO ship a fixture proving they stay silent. A rule that
+ * quietly stopped firing is invisible to a suite that only asserts rules can
+ * fire, and for `lockfile` the silent case is the load-bearing one: it is the
+ * direction guard. A dependency asking for less than the declaration is the
+ * overwhelmingly common case, and a rule that fired on it would be reverted
+ * within a day.
+ */
+const SILENT_RULES = ['lockfile', 'declarations', 'node-version'];
+
+/* ------------------------------------------------------- semver, a subset --
+ * Only what `engines.node` ranges actually use, and only the LOWER bound —
+ * this gate never asks "does version X satisfy range R", it asks "what is the
+ * lowest version that satisfies R". Upper bounds are parsed and discarded.
+ */
+
+function cmp(a, b) {
+  for (let i = 0; i < 3; i += 1) if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  return 0;
+}
+
+const fmt = (v) => v.join('.');
+const show = (b) => fmt(b.v) + (b.exclusive ? ' (exclusive)' : '');
+
+/** Lower bound of one comparator, or null if this parser does not understand it. */
+function comparatorLowerBound(token) {
+  const t = token.trim();
+  if (t === '' || t === '*' || t === 'x' || t === 'X') return { v: [0, 0, 0], exclusive: false };
+  const m = /^(>=|<=|>|<|=|\^|~)?\s*v?(\d+|[xX*])(?:\.(\d+|[xX*]))?(?:\.(\d+|[xX*]))?(?:[-+][0-9A-Za-z.-]+)?$/.exec(t);
+  if (!m) return null;
+  const op = m[1] ?? '';
+  // `<` and `<=` constrain only the top of the range; they leave the floor at zero.
+  if (op === '<' || op === '<=') return { v: [0, 0, 0], exclusive: false };
+  const wild = (p) => p === undefined || p === 'x' || p === 'X' || p === '*';
+  if (wild(m[2])) return { v: [0, 0, 0], exclusive: false };
+  const v = [Number(m[2]), wild(m[3]) ? 0 : Number(m[3]), wild(m[4]) ? 0 : Number(m[4])];
+  return { v, exclusive: op === '>' };
+}
+
+/** Lower bound of one space-separated conjunction (`14 >=14.17`, `1.0.0 - 2.0.0`). */
+function disjunctLowerBound(text) {
+  // A comparator may be separated from its version by spaces — `>= 0.10` and
+  // `>= 10.*` are both in this repo's lockfile today. Glue those back together
+  // before splitting, or the operator becomes a token of its own and the whole
+  // range reads as unparseable. (The self-test caught exactly that.) The
+  // hyphen of a `A - B` range is deliberately not in this operator set.
+  const tokens = text.replace(/(>=|<=|>|<|=|\^|~)\s+/g, '$1').trim().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return { v: [0, 0, 0], exclusive: false };
+  // Hyphen range: "A - B" is inclusive of A, so A is the floor.
+  if (tokens.length === 3 && tokens[1] === '-') return comparatorLowerBound(tokens[0]);
+  let best = { v: [0, 0, 0], exclusive: false };
+  for (const token of tokens) {
+    const bound = comparatorLowerBound(token);
+    if (!bound) return null;
+    const c = cmp(bound.v, best.v);
+    if (c > 0 || (c === 0 && bound.exclusive)) best = bound;
+  }
+  return best;
+}
+
+/** Lowest version satisfying a whole range, or null if any part is unparseable. */
+function rangeLowerBound(range) {
+  let best = null;
+  for (const part of String(range).split('||')) {
+    const bound = disjunctLowerBound(part);
+    if (!bound) return null;
+    const c = best === null ? -1 : cmp(bound.v, best.v);
+    if (c < 0 || (c === 0 && best.exclusive && !bound.exclusive)) best = bound;
+  }
+  return best;
+}
+
+/** Does a declared floor version clear a required lower bound? */
+function meets(declared, required) {
+  const c = cmp(declared, required.v);
+  return required.exclusive ? c > 0 : c >= 0;
+}
+
+/* ------------------------------------------------------------- lockfile -- */
+
+/**
+ * Pull every `engines.node` out of a pnpm lockfile without a YAML parser.
+ *
+ * `raw` counts the lines that mention `engines:` and `unreadable` collects the
+ * ones that did not yield a flow map. Both exist so that a lockfile format
+ * change surfaces as a red `coverage` finding instead of an empty scan that
+ * exits 0.
+ */
+function scanLockfile(text) {
+  const entries = [];
+  const unreadable = [];
+  let raw = 0;
+  let pkg = null;
+  for (const line of text.split('\n')) {
+    const header = /^ {2}(\S.*):$/.exec(line);
+    if (header) pkg = header[1].replace(/^'(.*)'$/, '$1');
+    if (!/(^|\s)engines:/.test(line)) continue;
+    raw += 1;
+    const flow = /engines:\s*\{(.*)\}\s*$/.exec(line);
+    if (!flow) {
+      unreadable.push(line.trim());
+      continue;
+    }
+    const node = /(?:^|[,{\s])node:\s*(?:'([^']*)'|"([^"]*)"|([^,}]+))/.exec(flow[1]);
+    // An engines block with no `node` key (npm/pnpm only) is legal and not a finding.
+    if (!node) continue;
+    entries.push({ pkg: pkg ?? '(unknown)', range: (node[1] ?? node[2] ?? node[3]).trim() });
+  }
+  return { entries, unreadable, raw };
+}
+
+/* --------------------------------------------------------------- inputs -- */
+
+/** Read the declared surface off disk. Missing inputs are findings, not throws. */
+function collect(root) {
+  const missing = [];
+  const declarations = [];
+  for (const file of DECLARATION_FILES) {
+    const path = join(root, file);
+    if (!existsSync(path)) {
+      missing.push(file);
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(path, 'utf8'));
+    } catch (err) {
+      missing.push(`${file} (unparseable JSON: ${err.message})`);
+      continue;
+    }
+    declarations.push({ source: file, value: parsed?.engines?.node ?? null });
+  }
+  const nvPath = join(root, '.node-version');
+  const lockPath = join(root, 'pnpm-lock.yaml');
+  if (!existsSync(nvPath)) missing.push('.node-version');
+  if (!existsSync(lockPath)) missing.push('pnpm-lock.yaml');
+  return {
+    declarations,
+    nodeVersion: existsSync(nvPath) ? readFileSync(nvPath, 'utf8') : null,
+    lock: existsSync(lockPath) ? readFileSync(lockPath, 'utf8') : null,
+    missing,
+  };
+}
+
+/* ---------------------------------------------------------------- rules -- */
+
+function evaluate({ declarations, nodeVersion, lock, missing = [] }) {
+  const findings = [];
+  const add = (rule, detail) => findings.push({ rule, detail });
+
+  for (const file of missing) {
+    add('coverage', `${file} is not where this gate looks for it — it checked nothing for that file`);
+  }
+
+  const scan = lock === null ? { entries: [], unreadable: [], raw: 0 } : scanLockfile(lock);
+  for (const line of scan.unreadable) {
+    add('coverage', `an engines line is not the flow-map form this parser reads, so its floor was not counted: ${line}`);
+  }
+  if (lock !== null && scan.entries.length === 0) {
+    add(
+      'coverage',
+      'no engines.node entries were found in pnpm-lock.yaml. The scan matched nothing, ' +
+        'so a green result here would prove nothing. Re-verify this parser against the lockfile format.',
+    );
+  }
+
+  // Maximum floor the dependency tree demands.
+  let required = null;
+  let requiredBy = [];
+  for (const entry of scan.entries) {
+    const bound = rangeLowerBound(entry.range);
+    if (!bound) {
+      add('range', `${entry.pkg}: engines.node ${JSON.stringify(entry.range)} is not a range this parser understands`);
+      continue;
+    }
+    const c = required === null ? 1 : cmp(bound.v, required.v);
+    if (c > 0 || (c === 0 && bound.exclusive && !required.exclusive)) {
+      required = bound;
+      requiredBy = [entry.pkg];
+    } else if (c === 0 && bound.exclusive === required.exclusive) {
+      requiredBy.push(entry.pkg);
+    }
+  }
+
+  // Declared floors.
+  const floors = [];
+  for (const decl of declarations) {
+    if (decl.value === null || decl.value === undefined) {
+      add('declarations', `${decl.source} declares no engines.node — this gate has nothing to check there`);
+      continue;
+    }
+    const bound = rangeLowerBound(decl.value);
+    if (!bound) {
+      add('range', `${decl.source}: engines.node ${JSON.stringify(decl.value)} is not a range this parser understands`);
+      continue;
+    }
+    floors.push({ source: decl.source, raw: decl.value, v: bound.v });
+  }
+
+  // The declarations must agree with each other, semantically — ">=22" and
+  // ">=22.0.0" are byte-different and mean the same floor, which is fine.
+  for (let i = 1; i < floors.length; i += 1) {
+    if (cmp(floors[i].v, floors[0].v) !== 0) {
+      add(
+        'declarations',
+        `${floors[0].source} declares ${JSON.stringify(floors[0].raw)} (floor ${fmt(floors[0].v)}) but ` +
+          `${floors[i].source} declares ${JSON.stringify(floors[i].raw)} (floor ${fmt(floors[i].v)})`,
+      );
+    }
+  }
+
+  // The rule this gate exists for.
+  if (required !== null) {
+    for (const floor of floors) {
+      if (!meets(floor.v, required)) {
+        add(
+          'lockfile',
+          `${floor.source} declares engines.node ${JSON.stringify(floor.raw)} (floor ${fmt(floor.v)}), below the ` +
+            `${show(required)} the dependency tree requires — demanded by ${requiredBy.slice(0, 3).join(', ')}` +
+            `${requiredBy.length > 3 ? ` and ${requiredBy.length - 3} more` : ''}`,
+        );
+      }
+    }
+  }
+
+  // `.node-version` is a version-manager pin, not a range. A bare major is a
+  // LINE pin ("latest 22.x"), so only its major is comparable; comparing it as
+  // 22.0.0 against a floor of 22.12.0 would be a false red on a correct repo.
+  // A pin that names a minor is a concrete version and must clear the floor.
+  if (nodeVersion !== null) {
+    const nvRaw = nodeVersion.trim();
+    const m = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?$/.exec(nvRaw);
+    if (!m) {
+      add('node-version', `.node-version is ${JSON.stringify(nvRaw)}, which is not a version this gate can compare`);
+    } else {
+      const pin = [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)];
+      const pinsMinor = m[2] !== undefined;
+      for (const floor of floors) {
+        if (pin[0] !== floor.v[0]) {
+          add(
+            'node-version',
+            `.node-version pins ${nvRaw} (major ${pin[0]}) but ${floor.source} declares ` +
+              `${JSON.stringify(floor.raw)} (major ${floor.v[0]})`,
+          );
+        } else if (pinsMinor && cmp(pin, floor.v) < 0) {
+          add(
+            'node-version',
+            `.node-version pins ${nvRaw}, below the ${fmt(floor.v)} floor declared in ${floor.source}`,
+          );
+        }
+      }
+    }
+  }
+
+  return { findings, required, requiredBy, floors, scan };
+}
+
+/* --------------------------------------------------------------- output -- */
+
+function gate() {
+  const inputs = collect(ROOT);
+  const { findings, required, requiredBy, floors, scan } = evaluate(inputs);
+
+  console.log('## Node floor');
+  console.log('');
+  console.log('| Declaration | Value | Floor |');
+  console.log('| --- | --- | --- |');
+  for (const floor of floors) console.log(`| \`${floor.source}\` | \`${floor.raw}\` | ${fmt(floor.v)} |`);
+  if (inputs.nodeVersion !== null) console.log(`| \`.node-version\` | \`${inputs.nodeVersion.trim()}\` | pin |`);
+  console.log('');
+  console.log(
+    `Scanned \`pnpm-lock.yaml\`: ${scan.raw} \`engines\` block(s), ${scan.entries.length} with a \`node\` range.`,
+  );
+  if (required !== null) {
+    console.log(
+      `Highest floor the tree requires: **${show(required)}** ` +
+        `(${requiredBy.slice(0, 3).join(', ')}${requiredBy.length > 3 ? `, +${requiredBy.length - 3}` : ''}).`,
+    );
+  }
+  console.log('');
+
+  if (findings.length) {
+    console.log(`❌ ${findings.length} finding(s).`);
+    console.log('');
+    for (const f of findings) console.log(`- **${f.rule}** — ${f.detail}`);
+    console.error(`\n✗ node floor: ${findings.length} finding(s)`);
+    for (const f of findings) console.error(`    [${f.rule}] ${f.detail}`);
+    process.exit(1);
+  }
+  console.log('✅ Every declared floor clears what the dependency tree requires, and the declarations agree.');
+}
+
+/* ------------------------------------------------------------ self-test --
+ * 裁决 (PR #74): a validator observed only green is indistinguishable from one
+ * that cannot go red. Every rule ships the fixture that trips it, and the
+ * assertion is on the EXACT set of rules fired — a fixture that goes red for
+ * the wrong reason proves nothing about the rule it was written for.
+ *
+ * Fixtures are written to a temp directory and read back through `collect()`,
+ * so the reader is exercised too: a gate whose rules are all provably able to
+ * fire, wired to a reader that silently returns nothing, is still a gate that
+ * cannot go red.
+ */
+
+const CLEAN_LOCK = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+packages:
+
+  left-pad@1.0.0:
+    resolution: {integrity: sha512-aaa}
+    engines: {node: '>=10'}
+
+  wrangler@4.95.0:
+    resolution: {integrity: sha512-bbb}
+    engines: {node: '>=22.0.0'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-ccc}
+    engines: {node: '^20.19.0 || ^22.12.0 || >=23'}
+
+  only-npm@1.0.0:
+    resolution: {integrity: sha512-ddd}
+    engines: {npm: '>=8'}
+`;
+
+const LOW_LOCK = CLEAN_LOCK.replace("'>=22.0.0'", "'>=18.0.0'").replace(
+  "'^20.19.0 || ^22.12.0 || >=23'",
+  "'>=18'",
+);
+
+const CASES = [
+  {
+    name: 'clean baseline',
+    expect: [],
+    // ">=22" and ">=22.0.0" are byte-different and identical as floors.
+    ignores: ['declarations'],
+  },
+  {
+    name: 'declared floor below what the tree requires',
+    root: '>=20',
+    docs: '>=20.0.0',
+    nodeVersion: '20',
+    expect: ['lockfile'],
+  },
+  {
+    name: 'dependency floors far below the declaration',
+    lock: LOW_LOCK,
+    expect: [],
+    // The direction guard: this is the normal case and must never fire.
+    ignores: ['lockfile'],
+  },
+  {
+    name: 'the two engines declarations disagree',
+    root: '>=22',
+    docs: '>=22.5.0',
+    expect: ['declarations'],
+  },
+  {
+    name: 'a declaration was removed',
+    docs: null,
+    expect: ['declarations'],
+  },
+  {
+    name: 'node-version on a different major',
+    nodeVersion: '20',
+    expect: ['node-version'],
+  },
+  {
+    name: 'node-version pinned below the declared floor',
+    root: '>=22.12.0',
+    docs: '>=22.12.0',
+    nodeVersion: '22.5.0',
+    expect: ['node-version'],
+  },
+  {
+    name: 'node-version as a bare major line pin',
+    root: '>=22.12.0',
+    docs: '>=22.12.0',
+    nodeVersion: '22',
+    expect: [],
+    // A bare major is "latest 22.x"; judging it as 22.0.0 would be a false red.
+    ignores: ['node-version'],
+  },
+  {
+    name: 'a lockfile range this parser cannot read',
+    lock: CLEAN_LOCK.replace("'>=10'", "'latest'"),
+    expect: ['range'],
+  },
+  {
+    name: 'a declared range this parser cannot read',
+    root: 'lts/*',
+    expect: ['range'],
+  },
+  {
+    name: 'a lockfile with no engines at all',
+    lock: "lockfileVersion: '9.0'\n\npackages:\n\n  left-pad@1.0.0:\n    resolution: {integrity: sha512-aaa}\n",
+    expect: ['coverage'],
+  },
+  {
+    name: 'an engines block the parser cannot read',
+    lock: CLEAN_LOCK.replace("    engines: {node: '>=10'}", "    engines:\n      node: '>=24'"),
+    expect: ['coverage'],
+  },
+];
+
+/** The reduction, pinned on the exact range shapes this repo's lockfile contains. */
+const RANGE_CASES = [
+  ['>=22.0.0', '22.0.0'],
+  ['>= 0.10', '0.10.0'],
+  ['18 || 20 || >=22', '18.0.0'],
+  ['20 || >=22', '20.0.0'],
+  ['^20.19.0 || ^22.12.0 || >=23', '20.19.0'],
+  ['>=16 || 14 >=14.17', '14.17.0'],
+  ['6.* || 8.* || >= 10.*', '6.0.0'],
+  ['4.x || >=6.0.0', '4.0.0'],
+  ['^18.17.0 || ^20.3.0 || >=21.0.0', '18.17.0'],
+  ['^12.17.0 || ^14.13 || >=16.0.0', '12.17.0'],
+  ['^10 || ^12 || ^13.7 || ^14 || >=15.0.1', '10.0.0'],
+  ['~18.2.0', '18.2.0'],
+  ['*', '0.0.0'],
+  ['18.0.0 - 20.0.0', '18.0.0'],
+  ['<=18.0.0', '0.0.0'],
+  ['>20.1.0', '20.1.0 (exclusive)'],
+  ['lts/*', null],
+  ['latest', null],
+];
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'node-floor-'));
+  let failed = 0;
+  try {
+    for (const c of CASES) {
+      const root = 'root' in c ? c.root : '>=22';
+      const docs = 'docs' in c ? c.docs : '>=22.0.0';
+      mkdirSync(join(dir, 'apps/docs'), { recursive: true });
+      writeFileSync(join(dir, 'package.json'), JSON.stringify(root === null ? {} : { engines: { node: root } }));
+      writeFileSync(
+        join(dir, 'apps/docs/package.json'),
+        JSON.stringify(docs === null ? {} : { engines: { node: docs } }),
+      );
+      writeFileSync(join(dir, '.node-version'), `${c.nodeVersion ?? '22'}\n`);
+      writeFileSync(join(dir, 'pnpm-lock.yaml'), c.lock ?? CLEAN_LOCK);
+
+      const { findings } = evaluate(collect(dir));
+      const fired = [...new Set(findings.map((f) => f.rule))].sort();
+      const want = [...c.expect].sort();
+      let ok = fired.join(',') === want.join(',');
+      // A case cannot both expect and ignore a rule: `ignores` is a claim that
+      // the rule stayed silent, and it only counts as coverage if it is one.
+      const mislabelled = (c.ignores ?? []).filter((r) => want.includes(r));
+      if (mislabelled.length) {
+        ok = false;
+        console.error(`  case declares ignores [${mislabelled.join(' ')}] that it also expects`);
+      }
+      if (!ok) failed += 1;
+      console.log(
+        `${ok ? '✓' : '✗'} ${c.name.padEnd(46)} fired [${fired.join(' ') || '—'}]` +
+          (ok ? '' : `  expected [${want.join(' ') || '—'}]`),
+      );
+      if (!ok) for (const f of findings) console.error(`      [${f.rule}] ${f.detail}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  console.log('');
+  for (const [range, expected] of RANGE_CASES) {
+    const bound = rangeLowerBound(range);
+    const got = bound === null ? null : show(bound);
+    const ok = got === expected;
+    if (!ok) failed += 1;
+    console.log(`${ok ? '✓' : '✗'} range ${JSON.stringify(range).padEnd(38)} -> ${got ?? 'unparseable'}` + (ok ? '' : `  expected ${expected ?? 'unparseable'}`));
+  }
+
+  console.log('');
+  const covered = new Set(CASES.flatMap((c) => c.expect));
+  for (const rule of RULES) {
+    if (!covered.has(rule)) {
+      console.error(`✗ rule "${rule}" has no fixture that trips it`);
+      failed += 1;
+    }
+  }
+  const silent = new Set(CASES.flatMap((c) => c.ignores ?? []));
+  for (const rule of SILENT_RULES) {
+    if (!silent.has(rule)) {
+      console.error(`✗ rule "${rule}" has no fixture that proves it stays silent`);
+      failed += 1;
+    }
+  }
+
+  if (failed) {
+    console.error(`\n✗ self-test: ${failed} case(s) did not behave as declared`);
+    process.exit(1);
+  }
+  console.log(
+    `✓ self-test: ${CASES.length} rule case(s) and ${RANGE_CASES.length} range case(s) — every rule ` +
+      'demonstrated able to fail, every silence-bearing rule demonstrated able to stay silent',
+  );
+}
+
+function main() {
+  if (process.argv.slice(2).some((a) => a === '--self-test')) return selfTest();
+  return gate();
+}
+
+main();

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,40 @@ on:
   merge_group:
 
 jobs:
+  # The three Node floor declarations (root `engines.node`, `apps/docs`
+  # `engines.node`, `.node-version`) are read by nothing in the install path:
+  # `.npmrc` sets no `engine-strict`, pnpm does not enforce `engines` by
+  # default, and every workflow here pins `node-version` explicitly instead of
+  # consulting them. This job is what makes them mechanically checkable. It
+  # needs no install — the script is zero-dependency and reads the lockfile as
+  # text — so it stays a seconds-long job that can run alongside `build`.
+  node-floor:
+    name: Node floor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # 裁决 (PR #74): a validator observed only green is indistinguishable
+      # from one that cannot go red. The fixtures run before the real scan, so
+      # a rule that stopped being able to fail fails the job on its own.
+      - name: Self-test
+        shell: bash
+        run: node .github/scripts/check-node-floor.mjs --self-test
+
+      # `shell: bash` is load-bearing here, not tidiness. The DEFAULT shell for
+      # a `run:` step is `bash -e {0}` with no pipefail, so in `node ... | tee`
+      # the step takes tee's exit status and a gate that exits 1 passes the job
+      # silently. Naming the shell gets `bash --noprofile --norc -eo pipefail
+      # {0}`, which propagates it.
+      - name: Check
+        shell: bash
+        run: node .github/scripts/check-node-floor.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/tools/ci-scripts/run-self-tests.mjs
+++ b/tools/ci-scripts/run-self-tests.mjs
@@ -57,7 +57,7 @@ const ROOT = resolve(HERE, '../..');
 const SCRIPTS = join(ROOT, '.github/scripts');
 
 /** Scripts whose `--self-test` mode this step runs. Never let this go empty. */
-const SELF_TESTED = ['check-translation-output.mjs'];
+const SELF_TESTED = ['check-translation-output.mjs', 'check-node-floor.mjs'];
 
 /**
  * The argv dispatch, in the two shapes the scripts here use: a quoted


### PR DESCRIPTION
Fixes #127

Implements **option 3** from the card: a CI check asserting the declared Node floor is consistent with what the repo's own dependency tree demands. Options 1 (`engine-strict=true`) and 2 (treat the declarations as documentation) were ruled out — this PR adds no `engine-strict` and changes none of the declared values.

All evidence below is from `7666a44`, the head of this branch.

## The rule, and its direction

`check-node-floor.mjs` reduces every `engines.node` range in `pnpm-lock.yaml` to the lowest Node version that satisfies it, takes the maximum across the tree, and requires each declared floor to clear it.

The direction is the whole rule. The defect being caught is a declared floor **below** what a dependency requires. A dependency asking for less than the declaration is the normal case — almost every one of the 428 entries does — and must stay green. There is a fixture asserting exactly that silence, because a rule that fired on the common case would be reverted within a day.

It also asserts the declarations agree with each other, semantically rather than byte-wise: `">=22"` and `">=22.0.0"` are different bytes and the same floor, and a gate demanding cosmetic uniformity would be noise.

Green on `main` today, with zero headroom:

```
| Declaration              | Value      | Floor  |
| package.json             | >=22       | 22.0.0 |
| apps/docs/package.json   | >=22.0.0   | 22.0.0 |
| .node-version            | 22         | pin    |

Scanned pnpm-lock.yaml: 428 engines block(s), 428 with a node range.
Highest floor the tree requires: 22.0.0 (@cloudflare/kv-asset-handler@0.5.0, miniflare@4.20260526.0, wrangler@4.95.0).
```

Worth noting against the card's framing: the highest floor in the tree is **22.0.0**, not the 20.19.0 a reading of the lockfile suggested. The declared 22 clears it exactly, with nothing to spare — the next dependency that raises its floor turns this job red, which is the point.

## It is demonstrably able to go red

Per the precedent set by #74, `--self-test` builds fixtures and asserts each case fires exactly the rules it declares, that every rule has a fixture able to trip it, and that the silence-bearing rules have a fixture proving they stay quiet. It runs as its own step **before** the real scan, so a rule that stopped being able to fail fails the job on its own.

That was not ceremony. The self-test ran before the gate ever did and **caught two real parser bugs**: `>= 0.10` and `>= 10.*` — the space-after-operator form, which this lockfile contains 40-odd times — were being read as unparseable. Unfixed, the gate would have been red on `main` for a reason that had nothing to do with the floor.

Measured red paths, both from the committed tree, both restored to a byte-identical tree afterwards:

| Experiment | Result |
| --- | --- |
| gate on unmodified `main` surface | exit 0 |
| declarations lowered to `>=20` | **exit 1**, 2 `lockfile` findings |
| `wrangler` floor raised to `>=24.0.0`, declarations untouched | **exit 1**, 2 `lockfile` findings |
| gate re-run after restore | exit 0 |
| `--self-test` | exit 0, 14 rule cases + 18 range cases |

The 18 range cases pin the reduction on the exact shapes this lockfile contains, disjunctions included.

## The pipefail trap, measured on this gate

The default step shell is `bash -e {0}` with no pipefail, so a piped gate hands the step `tee`'s exit status. Measured here with a deliberately-failing gate:

```
bash -e             (default)      => 0   <-- red gate reads as PASS
bash -eo pipefail   (shell: bash)  => 1   <-- red gate fails the job
```

Both `run:` steps in the new job therefore name `shell: bash`, as #74 did for the two existing steps.

## Beyond the declared file surface

The claim named `.github/scripts/check-node-floor.mjs` plus a step in `ci.yml`. One more file changed, and the reason is worth reading:

**`tools/ci-scripts/run-self-tests.mjs`** — this repo already fails the required `build` job when a script under `.github/scripts/` declares a `--self-test` dispatch but is not listed in `SELF_TESTED`. The new gate declares one, so until it was registered the runner exited 1 naming the file. That guard did exactly what it was written for; registering the script is a one-entry, mechanically-pinned change in the same gate family. Measured before: exit 1. After: exit 0, 2 self-tests passing.

This also means the self-test runs twice — once in the fast `node-floor` job, once through `pnpm turbo run test` in `build`. That redundancy is deliberate: the `node-floor` job has to stand on its own if it is ever made a required check, and a gate whose self-test lived only in another job could go green while unable to fail.

## Two findings this surfaced, filed rather than folded in

- **#137** — root `engines.node: ">=22"` claims support for Node 22.0.0 through 22.11.x, and `yargs@18.0.0` (via `wrangler`) declares `^20.19.0 || ^22.12.0 || >=23`, which none of those versions satisfy. Max-of-minimums is structurally blind to a gap **inside** a disjunctive range: that range's minimum is 20.19.0, so it never moves the maximum. A stricter rule would catch it and is red on `main` today, so it cannot land without also changing a declared value — out of scope here by ruling. The limitation is documented in the script header rather than left implicit.
- **#138** — there is a **fourth** declaration, not the three the card names: `tools/ci-scripts/package.json` declares `engines.node: ">=20.0.0"`. It may well be correct in isolation (that package has no dependencies of its own), so the gate does not judge it. It does **report** it: the gate discovers every workspace `package.json` and emits an advisory, never-blocking `ungoverned` note for any declaring a floor it does not govern. An explicit file list that silently covered two of three declarations would be the same structurally-silent shape this card exists to end.

## Follow-up for the maintainer

Making **Node floor** a *required* status check is a repo-settings action only the maintainer can take. This PR does not and cannot do it, and nothing here should be read as claiming the check is enforced on merge. Until then the job runs and reports on every PR, push to `main`, and merge-group entry.

## Notes

No changeset — this repo has no changeset flow. `pnpm turbo run test` was not run through turbo (that needs an install); the task's script, `tools/ci-scripts/run-self-tests.mjs`, was run directly with node and is reported above.

_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_