### PR TITLE
docs(quickstart): transcribe the os start banner from a real boot, retire /_account/ from the page

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -10,7 +10,8 @@ There are two ways to start, depending on what you're doing.
 | Trying ObjectOS for the first time, or running it in production | [Path A — `os start`](#path-a--os-start-operator-first-time-evaluator) |
 | Building or customizing an app in code | [Path B — `os init`](#path-b--os-init-developer) |
 
-Both produce a running server with the UI + Account. The
+Both produce a running server with the UI — account sign-in, registration
+and self-service are routes inside that UI, not a separate surface. The
 difference is whether you scaffold source files.
 
 ## Prerequisites
@@ -37,28 +38,42 @@ You'll see:
 ◆ ObjectStack
 ────────────────────────────────────────
 🏠 Home: ~/.objectstack
-📦 Artifact: none (empty kernel — install apps via Console marketplace)
+📦 Artifact: none (empty kernel — install apps via the Console marketplace)
 🗄️ Database: file:~/.objectstack/data/objectstack.db
+🎯 Environment: env_local
+🖥️ Console: http://localhost:3000/_console/
+  → Starting server...
 
   ✓ Server is ready
 
   ➜  API:       http://localhost:3000/
-  ➜  Console:    http://localhost:3000/_console/
-  ➜  Account:   http://localhost:3000/_account/
   ➜  Console:   http://localhost:3000/_console/
+  ➜  MCP:       http://localhost:3000/api/v1/mcp
+      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill
 
-  Plugins: 23 loaded
+  Config:  objectstack.config.ts
+  Mode:    production
+  Driver:  SqlDriver(better-sqlite3)  → ~/.objectstack/data/objectstack.db
+  Tenancy: single
+  Plugins: 30 loaded
+
+  Press Ctrl+C to stop
 ```
 
 That's it. You're running ObjectOS.
+
+That block is transcribed from `@objectstack/cli` 17.0.0 booting an empty
+kernel. Home paths show as `~/…` — the CLI prints yours expanded. Your own boot
+also prints startup advisories (local storage driver, dev crypto key) and the
+full list of loaded plugin names, both of which depend on your environment.
 
 ### What's running
 
 | URL | What it is |
 |---|---|
-| http://localhost:3000/_account/register | Create your first account |
+| http://localhost:3000/_console/register | Create your first account |
 | http://localhost:3000/_console/ | The generated UI — and the **app marketplace** |
-| http://localhost:3000/_console/ | **Setup** — users, roles, audit log, settings |
+| http://localhost:3000/_console/apps/setup | **Setup** — users, roles, audit log, settings |
 | http://localhost:3000/api/v1/health | Liveness — is the process up |
 | http://localhost:3000/api/v1/ready | Readiness — is it up **and** serving data |
 
@@ -148,8 +163,6 @@ You'll see:
   ✓ Server is ready
 
   ➜  API:       http://localhost:3002/
-  ➜  Console:    http://localhost:3002/_console/
-  ➜  Account:   http://localhost:3002/_account/
   ➜  Console:   http://localhost:3002/_console/
 ```
 
@@ -219,11 +232,13 @@ Each template is < 2500 LOC, readable in one sitting, runs standalone.
 
 ## What's loaded out of the box
 
-Either path gives you these 23 plugins automatically:
+Either path gives you these plugins automatically:
 
-> Auth, Security (RBAC + RLS + FLS), Audit, REST API, Console UI,
-> Account UI, Console UI, AI Service, Queue, Jobs, Cache, Settings,
-> Email, Storage, Marketplace, Metadata, ObjectQL, plus the SQL driver.
+> HTTP server, REST API, Dispatcher, MCP server, Auth, Security (RBAC + RLS +
+> FLS), Audit, Sharing, Platform objects, Metadata, ObjectQL, the default
+> datasource plus the external-datasource and datasource-admin services, Queue,
+> Jobs, Cache, Settings, Email, SMS, Messaging, Storage, Analytics, external
+> validation, Marketplace, the Setup and Account apps, and the Console UI.
 
 You don't import or wire any of them — they activate when something
 declares it needs them.

--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -150,6 +150,14 @@ cd my-app
 pnpm dev
 ```
 
+> **Warning:** On `@objectstack/cli` 17.0.0 — the currently published
+> `latest` — this sequence does not reach a dev server. The project
+> `init` scaffolds declares no `sharingModel`, which the CLI's own
+> `security-owd-unset` author-time rule rejects, so `pnpm dev` exits 1
+> during compile instead of starting. The fix is merged and awaiting a
+> release —
+> [objectstack#9666](https://github.com/objectstack-ai/objectstack/issues/9666).
+
 You'll see:
 
 ```text


### PR DESCRIPTION
Part of #94

Not `Fixes` — deliberately. Path A is fully measured and landed; **Path B could not be measured**. Per the PM ruling on the card (option **B combined with D**), Path B gets a caveat now and stays open until a fixed CLI publishes and its banner can be transcribed from a real boot. Merging this must not silently close a card with an open half. See "Path B" below.

## What was measured

`@objectstack/cli` 17.0.0 installed into a scratch dir (`require(...).version` reported `17.0.0`), booted with a bare `os start` — no flags — on a host with no `~/.objectstack`, so the default port 3000 and default home are the literal ones the page instructs. The readiness banner it printed, verbatim:

```text
  ✓ Server is ready

  ➜  API:       http://localhost:3000/
  ➜  Console:   http://localhost:3000/_console/
  ➜  MCP:       http://localhost:3000/api/v1/mcp
      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill

  Config:  objectstack.config.ts
  Mode:    production
  Driver:  SqlDriver(better-sqlite3)  → /root/.objectstack/data/objectstack.db
  Tenancy: single
  Plugins: 30 loaded
           HonoServer, Marketplace, PlatformObjects, Auth, @objectstack/setup, @objectstack/account, Security, Audit, com.objectstack.runtime.default-datasource, com.objectstack.metadata, ObjectQL, empty, RestAPI, Dispatcher, MCPServerPlugin, QueueServicePlugin, JobServicePlugin, CacheServicePlugin, SettingsServicePlugin, EmailServicePlugin, StorageServicePlugin, SmsServicePlugin, SharingServicePlugin, MessagingServicePlugin, AnalyticsServicePlugin, ExternalDatasourceServicePlugin, ExternalValidationPlugin, DatasourceAdminServicePlugin, DatasourceAdminRoutes, ConsoleUI
```

One `Console:` line, not two. An `MCP:` line the sample lacked entirely. No `Account:` line at all. `Plugins: 30 loaded`, not 23. Exactly one `ConsoleUI` in the loaded list.

**Two deviations from verbatim, both declared in the page itself:**

1. Home paths are written `~/.objectstack`; the CLI printed `/root/.objectstack`, which is this container's home, not the reader's. The page already used the `~` form and continues to.
2. The block omits the startup advisories (local storage driver, dev crypto key), the boot-diagnostics warning, and the long plugin-name line. Omission, not alteration — every line shown is verbatim. A short note under the block says so and pins the CLI version, so the sample's freshness is checkable rather than assumed.

## The changes

**Path A sample block** — transcribed from the boot above, replacing the hand-corrected one. Adds the `MCP:` pair, the `Config` / `Mode` / `Driver` / `Tenancy` block, the `🎯 Environment` and `🖥️ Console` header lines, and `Press Ctrl+C to stop`; corrects `Plugins: 23 loaded` to 30 and `install apps via Console marketplace` to `via the Console marketplace`.

**The phantom `Account:` lines are deleted, not repointed** (both blocks). Per the `Surface` entry in `content/docs/resources/glossary.mdx`, there are two HTTP entry points — `/` and `/_console/` — and account is not a surface. The real CLI prints no `Account:` line, so repointing would have produced a correct URL inside a fabricated banner line, on the one page whose subject is that the sample does not match reality.

**"What's running" table** — the register row repointed to `http://localhost:3000/_console/register`; the two rows that carried the same `/_console/` URL deduped, with Setup taking the deeper `http://localhost:3000/_console/apps/setup` so this page agrees with the glossary instead of quietly diverging from it.

**Line 13** — "a running server with the UI + Account" implied Account is a second server surface. It is inside the UI.

**Plugin blockquote** — no count at all. A version-pinned number still invites the next editor to bump the number and forget the pin. The name list is rewritten from the measured boot: it had named `Console UI` twice where the real boot loads exactly one `ConsoleUI`, named an `Account UI` and an `AI Service` that no longer appear, and omitted MCP, SMS, Sharing, Messaging, Analytics, Dispatcher, the datasource services and the HTTP server. One measured name is intentionally not listed — `empty`, which is the empty-kernel artifact package rather than a capability.

## Evidence bar

A `200` under `/_console/*` proves nothing and was not used as proof. Control, on the same running server: `/_console/zzz-nonexistent-garbage` also returns `200`. The console routes cited here rest on the landed glossary entry, not on probes. The probes that *are* meaningful are the ones no fallback catches: `/_account/`, `/_account/register` both `404`.

## Path B — still not measurable, and now flagged to the reader

The scaffold bug is merged upstream (PR objectstack-ai/objectstack#9736, merged 2026-08-18) but **not published**. `npm view @objectstack/cli dist-tags` returns `{ latest: '17.0.0', rc: '17.0.0-rc.6' }`, and 17.0.0 was published 2026-08-14 — before the merge. Running the page's own instructions against the published CLI today:

```
npx @objectstack/cli init my-app -t app --install    → exit 0, "✓ Scaffold validated (namespace: my_app)"
pnpm dev                                             → exit 1
```

```
  ✗ Author-time rules failed (1 issue)
  • object "my_app_item": custom object "my_app_item" declares no sharingModel (OWD). …
      rule: security-owd-unset  at objects[0].sharingModel
  ✗ Compile failed — fix errors above before starting dev server
```

`grep -rn sharingModel src/ objectstack.config.ts` in the generated project returns nothing — the published CLI still ships the unfixed template.

So no Path B banner was transcribed, and none was invented — including by adjusting Path A's output to stand in for it. **No `MCP:` line was added to Path B**, because none was measured there.

### PM ruling: warn now, transcribe at publish

The page-shape question was escalated rather than decided here, and the ruling is **B combined with D**: add the caveat now, and keep the card open until a fixed CLI publishes and Path B's banner can be transcribed from a real boot. The reasoning recorded on the card is that leaving Path B unmarked would have this PR ship a page that is still lying — just about a different line — which is this card's own defect class.

Landed in the second commit:

- A `> **Warning:**` blockquote above Path B's sample, in the corpus's existing convention. There is no `Callout` component in this repo and no `:::` admonition syntax — a bold-lead blockquote is what the docs use, and `> **Warning:**` specifically appears in `build/data/formulas.mdx`, `build/data/validation-rules.mdx` and `build/data/relationships.mdx`. No component was invented.
- It names the published version, names `security-owd-unset`, links objectstack#9666, and says the fix is merged and awaiting a release. It is pinned to `@objectstack/cli` 17.0.0 the same way the Path A transcription note is, so it is checkable rather than open-ended.
- **Path B's sample block is untouched by that commit** — the second commit's diff is 8 added lines and nothing else. The block stays unmeasured; transcribing it is the publish-time job.

The admonition was accepted on the condition that a card carries its expiry, so objectos#141 was updated to track it as a third trigger item, recorded explicitly as **delete, do not update** — a warning that has stopped being true is worse than no warning.

## Verification

Re-run in full on the new head `7a8e2be`, heavy steps serialized on the shared verify lock. Exit codes captured before any pipe.

| Check | Result on `7a8e2be` |
|---|---|
| `pnpm turbo run type-check --filter=@objectos/docs` | RC=0 — `cache miss, executing 9dc3fcdcddbe29c9`, `1 successful, 1 total` |
| `pnpm turbo run build --filter=@objectos/docs` | RC=0 — `cache miss, executing 025e21a7ad40d364`, `1 successful, 1 total`, `0 cached` |
| `check-translations.mjs` | exit 0 — `✓ translations gate passed` |
| `check-translation-output.mjs --self-test` | exit 0 — `✓ self-test: 29 rule case(s) and 9 split case(s) … every rule demonstrated able to fail` |
| `check-translation-output.mjs --files` (PR-scoped, as CI runs it) | exit 0 — `✓ translation output gate passed (138 pre-existing finding(s) reported)` |
| `check-translation-ownership.mjs --actor … --files …` | exit 0 — "touches 0 translation artifact(s) and 1 other file(s)" |
| `check-node-floor.mjs` | exit 0 — `✅ Every declared floor clears what the dependency tree requires` |
| control-byte sweep on the changed file | no match |

Both turbo tasks reported **cache miss**, and the type-check hash **moved** between the two heads — `b0e76990c1c001b8` on `697096f`, `9dc3fcdcddbe29c9` on `7a8e2be`. That is the check `AGENTS.md` asks for on a content-only change: the `$TURBO_ROOT$/content/docs/**` input glob is live, so these are real runs and not a replayed green from a sibling worktree.

Rendering was verified from the prerendered output rather than a browser, which is the stronger check here. In `.next/server/app/en/docs/quickstart.html` the admonition renders as a blockquote reading, in full:

> Warning: On @objectstack/cli 17.0.0 — the currently published latest — this sequence does not reach a dev server. The project init scaffolds declares no sharingModel, which the CLI's own security-owd-unset author-time rule rejects, so pnpm dev exits 1 during compile instead of starting. The fix is merged and awaiting a release — objectstack#9666.

and the Path A assertions are unregressed on the new head: `_account` occurs **0** times, `23 plugins` **0**, `Account UI` **0**, while `_console/register`, `_console/apps/setup`, `api/v1/mcp`, `Plugins: 30 loaded` and one `Console UI` are all present.

English source only — one file changed, `content/docs/quickstart.mdx`, across both commits. No `quickstart.{locale}.mdx` sibling was touched; they go stale by design and the freshness gate reports it non-blockingly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_