### PR TITLE
docs(quickstart): transcribe both boot samples from @objectstack/cli 17.1.0, delete the expired Path B warning

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -193,8 +193,10 @@ You'll see:
 
 That block is transcribed from `pnpm dev` on a scaffold created by
 `@objectstack/cli` 17.1.0. Project paths show as `my-app/…` — the CLI prints
-yours expanded — and it also prints per-step compile progress and the full
-list of loaded plugin names.
+yours expanded. Your own run also prints pnpm's script header above the block,
+per-step compile progress, startup advisories (configuration load, dev
+secret-field crypto), the full list of loaded plugin names, and an MCP
+connection trailer below the banner.
 
 Note the dev server asks for port **3000**, the same port `os start` uses. If
 that port is taken it binds the next free one and says so:

--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -51,7 +51,6 @@ You'll see:
   ➜  MCP:       http://localhost:3000/api/v1/mcp
       connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill
 
-  Config:  objectstack.config.ts
   Mode:    production
   Driver:  SqlDriver(better-sqlite3)  → ~/.objectstack/data/objectstack.db
   Tenancy: single
@@ -62,10 +61,11 @@ You'll see:
 
 That's it. You're running ObjectOS.
 
-That block is transcribed from `@objectstack/cli` 17.0.0 booting an empty
+That block is transcribed from `@objectstack/cli` 17.1.0 booting an empty
 kernel. Home paths show as `~/…` — the CLI prints yours expanded. Your own boot
-also prints startup advisories (local storage driver, dev crypto key) and the
-full list of loaded plugin names, both of which depend on your environment.
+also prints startup advisories (local storage driver, dev crypto key, boot
+diagnostics) and the full list of loaded plugin names, both of which depend on
+your environment.
 
 ### What's running
 
@@ -150,32 +150,55 @@ cd my-app
 pnpm dev
 ```
 
-> **Warning:** On `@objectstack/cli` 17.0.0 — the currently published
-> `latest` — this sequence does not reach a dev server. The project
-> `init` scaffolds declares no `sharingModel`, which the CLI's own
-> `security-owd-unset` author-time rule rejects, so `pnpm dev` exits 1
-> during compile instead of starting. The fix is merged and awaiting a
-> release —
-> [objectstack#9666](https://github.com/objectstack-ai/objectstack/issues/9666).
-
 You'll see:
 
 ```text
-✓ Project initialized!
+◆ Development Mode
+────────────────────────────────────────
+📂 Config: my-app/objectstack.config.ts
+  → Compiling objectstack.config.ts → dist/objectstack.json...
 
 ◆ Compile
-  ✓ Build complete (462ms)
+────────────────────────────────────────
+  ✓ Build complete (117ms)
+
   Data: 1 Objects  3 Fields
 
-◆ Development Mode
+  Artifact: my-app/dist/objectstack.json (1.9 KB)
+
+  → Starting dev server (local mode)...
+🎯 Environment ID: env_local
+📦 Artifact: dist/objectstack.json
+🗄️ Database: file:my-app/.objectstack/data/objectstack.db
+  👁  watching objectstack.config.ts, src — rebuild + restart on change
+
   ✓ Server is ready
 
-  ➜  API:       http://localhost:3002/
-  ➜  Console:   http://localhost:3002/_console/
+  ➜  API:       http://localhost:3000/
+  ➜  Console:   http://localhost:3000/_console/
+  ➜  MCP:       http://localhost:3000/api/v1/mcp
+      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill
+
+  🔑  Dev admin: admin@objectos.ai / admin123
+      seeded on empty DB · dev only — do not use in production
+
+  Config:  objectstack.config.ts
+  Mode:    development
+  Driver:  SqlDriver(better-sqlite3)  → my-app/.objectstack/data/objectstack.db
+  Tenancy: single
+  Plugins: 30 loaded
+
+  Press Ctrl+C to stop
 ```
 
-Note the dev server uses port **3002** to avoid colliding with a
-running `os start` on 3000.
+That block is transcribed from `pnpm dev` on a scaffold created by
+`@objectstack/cli` 17.1.0. Project paths show as `my-app/…` — the CLI prints
+yours expanded — and it also prints per-step compile progress and the full
+list of loaded plugin names.
+
+Note the dev server asks for port **3000**, the same port `os start` uses. If
+that port is taken it binds the next free one and says so:
+`↪ server bound to port 3001 (requested 3000)`.
 
 ### Add your own object
 


### PR DESCRIPTION
Fixes #94

Completes objectos#141 items 1-4 — the four things that page owed the moment a
CLI carrying objectstack#9736 and objectstack#9347 published. `@objectstack/cli`
**17.1.0** published 2026-08-20T11:21:17Z; every sample line below comes from a
boot of that version that I ran in this container.

## What changed

| # | objectos#141 item | Done |
|---|---|---|
| 1 | Re-transcribe Path A | `Config:  objectstack.config.ts` row **gone**, as predicted. Nothing else moved. |
| 2 | Measure + transcribe Path B | First real measurement of this block. `pnpm dev` **compiles and serves**. |
| 3 | Delete the Path B `Warning:` blockquote | Deleted outright — not edited, not softened, not repointed. |
| 4 | Update the Path A version pin | 17.0.0 → 17.1.0. |

Plus one correction I did not go looking for, described under *Measurement vs
expectation* below: the sentence under Path B's block asserted a port that
neither boot produced.

## Verification of the two upstream fixes, in the published tarball

Not merge dates — the shipped files:

```
$ grep -n "sharingModel: 'private'" node_modules/@objectstack/cli/dist/commands/init.js
180:  sharingModel: 'private',
245:  sharingModel: 'private',
$ grep -n "SCAFFOLD_RULE_COMMAND" node_modules/@objectstack/cli/dist/utils/scaffold-validate.js
42:export const SCAFFOLD_RULE_COMMAND = 'build';
$ grep -n "8978" node_modules/@objectstack/cli/dist/commands/serve.js
3125:            // #8978 — the Config:/Artifact: row must name what actually booted,
$ node -p "require('@objectstack/cli/package.json').version"
17.1.0
```

## Raw capture — Path A, `os start`, clean home (no `~/.objectstack` existed)

Verbatim, nothing removed:

```text

◆ ObjectStack
────────────────────────────────────────
🏠 Home: /root/.objectstack
📦 Artifact: none (empty kernel — install apps via the Console marketplace)
🗄️ Database: file:/root/.objectstack/data/objectstack.db
🎯 Environment: env_local
🖥️ Console: http://localhost:3000/_console/
  → Starting server...

  No objectstack.config.ts or artifact found — booting empty kernel...
  ⚠ StorageServicePlugin using local driver (.objectstack/data/uploads) — switch to S3/GCS/Azure for production (set OS_STORAGE_* or configure storage in Setup → Settings).
[LocalCryptoProvider] No OS_SECRET_KEY set — minted a new AES-256-GCM key and persisted it to /root/.objectstack/dev-crypto-key (mode 0600). Restarts on this host reuse it automatically. For containers, CI, or multi-node, set OS_SECRET_KEY so every node shares one key.
[LocalCryptoProvider] No OS_SECRET_KEY set — using the persisted key at /root/.objectstack/dev-crypto-key. For containers / multi-node, prefer setting OS_SECRET_KEY so every node shares one key.

  ✓ Server is ready

  ➜  API:       http://localhost:3000/
  ➜  Console:   http://localhost:3000/_console/
  ➜  MCP:       http://localhost:3000/api/v1/mcp
      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill

  Mode:    production
  Driver:  SqlDriver(better-sqlite3)  → /root/.objectstack/data/objectstack.db
  Tenancy: single
  Plugins: 30 loaded
           HonoServer, Marketplace, PlatformObjects, Auth, @objectstack/setup, @objectstack/account, Security, Audit, com.objectstack.runtime.default-datasource, com.objectstack.metadata, ObjectQL, empty, RestAPI, Dispatcher, MCPServerPlugin, QueueServicePlugin, JobServicePlugin, CacheServicePlugin, SettingsServicePlugin, EmailServicePlugin, StorageServicePlugin, SmsServicePlugin, SharingServicePlugin, MessagingServicePlugin, AnalyticsServicePlugin, ExternalDatasourceServicePlugin, ExternalValidationPlugin, DatasourceAdminServicePlugin, DatasourceAdminRoutes, ConsoleUI

  ⚠ Boot diagnostics — 1 warning logged during startup:
    2026-08-20T14:10:17.195Z WARN [AppPlugin] [protocol] package 'com.objectstack.empty' declares no engines.protocol range; loading under protocol 17.0.0 without a compatibility check (ADR-0087).
    run with --log-level debug to watch the boot stream live

  Press Ctrl+C to stop

[HonoServerPlugin] Server stopped
```

The block on the page omits, exactly as the 17.0.0 transcription in #140 did:
the empty-kernel/storage/crypto advisories, the plugin-name list, and the boot
diagnostics trailer (now named in the page's own omission sentence). Home paths
are shown as `~/…`; the CLI printed `/root/…`. **Omission and one declared path
substitution — no alteration.**

### Absence discipline for the `Config:` row

An empty grep is not evidence until a neighbouring positive grep proves the
probe works. Same capture, same probe style:

```
$ grep -c 'Config:'  pathA-boot.log   ->  0     (exit 1, zero hits)
$ grep -c 'Mode:'    pathA-boot.log   ->  1     control
$ grep -c 'Driver:'  pathA-boot.log   ->  1     control
$ grep -c 'Tenancy:' pathA-boot.log   ->  1     control
$ grep -c 'Plugins:' pathA-boot.log   ->  1     control
$ grep -c 'MCP:'     pathA-boot.log   ->  1     control
$ grep -c 'Account:' pathA-boot.log   ->  0     (still absent, as #140 found)
```

Three further checks that the zero is real and not a broken probe:

1. **A second, independent `os start` boot** — `Config:` 0 hits again, `Mode:`
   and `Plugins:` 1 each, and the two banners are byte-identical:
   `diff <(grep -A9 'Server is ready' boot1) <(grep -A9 'Server is ready' boot2)`
   is empty.
2. **The same probe goes positive on Path B** — 3 hits there, one of them the
   banner row itself. The row was not deleted from the CLI; it is suppressed
   when nothing was found, which is what objectstack#8978 asked for.
3. **The string is still in the Path A capture, in the diagnostic that replaces
   the row**: `No objectstack.config.ts or artifact found — booting empty
   kernel...`. So the grep can see that text when it is printed.

## Raw capture — Path B, the page's own sequence, verbatim

`npx @objectstack/cli init my-app -t app --install` exited 0:

```text
  → Validating scaffold...
  ✓ Scaffold validated (namespace: my_app; 41 author-time rules passed)
  ✓ Project initialized!
```

41 rules pass. On 17.0.0 this was 40 rules with one failure
(`security-owd-unset`) and no dev server. The scaffold now ships
`src/objects/my_app_item.ts:32:  sharingModel: 'private',`.

Then `pnpm dev`, verbatim, nothing removed:

```text

> my-app@0.1.0 dev /tmp/claude-0/-home-user/7ba0d6d5-fbff-5c79-b73e-b6102626a092/scratchpad/issue-94/pathB/my-app
> objectstack dev


◆ Development Mode
────────────────────────────────────────
📂 Config: /tmp/claude-0/-home-user/7ba0d6d5-fbff-5c79-b73e-b6102626a092/scratchpad/issue-94/pathB/my-app/objectstack.config.ts
  → Compiling objectstack.config.ts → dist/objectstack.json...

◆ Compile
────────────────────────────────────────
  → Loading configuration...
  Config: objectstack.config.ts
  Load time: 86ms
  → Normalizing stack definition...
  → Lowering inline handlers...
  → Validating protocol compliance...
  → Running author-time rules (41)...
  → Checking capability providers (#3366)...
  → Collecting package docs (ADR-0046)...
  → Writing artifact...

  ✓ Build complete (117ms)

  Data: 1 Objects  3 Fields

  Artifact: /tmp/claude-0/-home-user/7ba0d6d5-fbff-5c79-b73e-b6102626a092/scratchpad/issue-94/pathB/my-app/dist/objectstack.json (1.9 KB)

  → Starting dev server (local mode)...
🎯 Environment ID: env_local
📦 Artifact: dist/objectstack.json
🗄️ Database: file:/tmp/claude-0/-home-user/7ba0d6d5-fbff-5c79-b73e-b6102626a092/scratchpad/issue-94/pathB/my-app/.objectstack/data/objectstack.db
  👁  watching objectstack.config.ts, src — rebuild + restart on change

  Loading objectstack.config.ts...
  ↪ secret fields: LocalCryptoProvider wired (dev) — set OS_SECRET_KEY and swap for KMS/Vault in production

  ✓ Server is ready

  ➜  API:       http://localhost:3000/
  ➜  Console:   http://localhost:3000/_console/
  ➜  MCP:       http://localhost:3000/api/v1/mcp
      connect an AI client (Claude Code, Cursor, …) · skill: http://localhost:3000/api/v1/mcp/skill

  🔑  Dev admin: admin@objectos.ai / admin123
      seeded on empty DB · dev only — do not use in production

  Config:  objectstack.config.ts
  Mode:    development
  Driver:  SqlDriver(better-sqlite3)  → /tmp/claude-0/-home-user/7ba0d6d5-fbff-5c79-b73e-b6102626a092/scratchpad/issue-94/pathB/my-app/.objectstack/data/objectstack.db
  Tenancy: single
  Plugins: 30 loaded
           HonoServer, Marketplace, PlatformObjects, Auth, @objectstack/setup, @objectstack/account, Security, Audit, com.objectstack.runtime.default-datasource, com.objectstack.metadata, ObjectQL, my_app, RestAPI, Dispatcher, MCPServerPlugin, QueueServicePlugin, JobServicePlugin, CacheServicePlugin, SettingsServicePlugin, EmailServicePlugin, StorageServicePlugin, SmsServicePlugin, SharingServicePlugin, MessagingServicePlugin, AnalyticsServicePlugin, ExternalDatasourceServicePlugin, ExternalValidationPlugin, DatasourceAdminServicePlugin, DatasourceAdminRoutes, ConsoleUI

  Press Ctrl+C to stop


  🤖 MCP server — connect a coding agent:
     Endpoint  http://localhost:3000/api/v1/mcp
     Skill     http://localhost:3000/api/v1/mcp/skill
     Connect   claude mcp add --transport http my-app http://localhost:3000/api/v1/mcp
     Disable   OS_MCP_SERVER_ENABLED=false
```

`Compile failed` and `security-owd-unset`: **0 hits** in that capture.
`Config:  objectstack.config.ts`: **1 hit** — Path B has a config, so the row
appears. `MCP:` is on the page for Path B because Path B printed it, not
because Path A did.

The page's block omits the per-step compile progress lines, the
`Loading objectstack.config.ts` / secret-fields advisories and the plugin-name
list, and shows the project path as `my-app/…` — both declared in the sentence
under the block.

## Measurement vs expectation — one contradiction, please read this one

The page said, directly under Path B's block:

> Note the dev server uses port **3002** to avoid colliding with a
> running `os start` on 3000.

Neither reading of that survives measurement:

- **Path B alone** (3000 free): the dev server binds **3000** — the same port
  `os start` uses. See the capture above.
- **Path B with `os start` already on 3000** (I re-booted Path A, confirmed
  `200` on `http://localhost:3000/_console/`, then ran `pnpm dev` again): it
  binds **3001** and says so.

```text
  ✓ Server is ready

  ➜  API:       http://localhost:3001/
  ➜  Console:   http://localhost:3001/_console/
  ➜  MCP:       http://localhost:3001/api/v1/mcp
...
  Press Ctrl+C to stop

  ↪ server bound to port 3001 (requested 3000)
```

`grep -o 'localhost:[0-9]*' | sort -u` over that whole run returns exactly one
value: `localhost:3001`. 3002 appears in neither boot.

This is outside objectos#141's four items, and I would have left it as a filed
finding — except that the ports **are** the block I was told to transcribe. A
faithful Path B block showing `localhost:3000` sitting above a sentence saying
the dev server uses 3002 is a contradiction this PR would have created. So the
sentence is rewritten from the two measurements above and nothing else. If you
would rather it were deleted outright, or split off into its own card, say so
and I will do that instead — it is one paragraph.

## Everything else the boots could have contradicted

- `Plugins: 30 loaded` — still 30, on **both** paths. The count in the sample
  blocks stands; the out-of-the-box blockquote still carries no count (#140).
- The plugin-name list contains `ConsoleUI` exactly once on both paths, so the
  blockquote's naming is still right.
- Path B's list is Path A's with `empty` replaced by `my_app` — the scaffold's
  own package, which is the only difference between the two boots' plugin sets.
- `http://localhost:4002` in *Or start from a template* is the templates repo,
  not this CLI. **Not measured, not touched.**
- Probes on the Path A boot, for the *What's running* table: `/` 302,
  `/_console/` 200, `/_console/register` 200, `/_console/apps/setup` 200,
  `/api/v1/health` 200, `/api/v1/ready` 200 — and the control that makes those
  200s worth little on their own, `/_console/zzz-nonexistent-control` **200**
  (SPA fallback). `/_account/register` is still **404**, as #140 established.

## Gates

Local, on this exact commit (`git rev-parse --short HEAD` = `2b4cb10`):

```
turbo run type-check build --filter=@objectos/docs   Tasks: 2 successful, 2 total
                                                     Cached: 0 cached, 2 total
check-translation-ownership.mjs --actor ... --files   exit 0 — 0 translation artifacts, 1 other file
check-translations.mjs                                exit 0 — "translations gate passed"
check-translation-output.mjs --self-test              exit 0 — 29 rule cases, every rule shown able to fail
check-translation-output.mjs --files changed.txt      exit 0 — "passed (138 pre-existing finding(s) reported)"
check-node-floor.mjs                                  exit 0
```

Exit codes captured before any pipe (`cmd > file 2>&1; EXIT=$?`), never from a
`tail`.

**Turbo hash moved, and moved back** — the check this repo asks for on a
content-only change, so a green here cannot be a replayed cache entry:

```
type-check hash, my content        e0f4236856c45574
type-check hash, origin/main file  9dc3fcdcddbe29c9   (the value #140's review recorded)
type-check hash, restored          e0f4236856c45574
```

English source only; the locale siblings are stale and the freshness gate says
so, which is the design (AGENTS.md § Translation workflow), not an oversight.

## Teardown

Every server I started is dead — killed by recorded PID, never by name, and
each PID checked against `/proc/PID/cwd` before the signal. Ports 3000, 3001
and 3002 all answer nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXBoKN4MauvPdbMemPMqpr)_