### PR TITLE
docs(why): restore the multi-tenant internal portal fit row under the walled tenancy posture

### DIFF
--- a/content/docs/why.mdx
+++ b/content/docs/why.mdx
@@ -42,6 +42,7 @@ Common scenarios where it's a fit:
 | Building a compliance / risk / vendor management tool for a regulated business | Audit log, RBAC, field security, row-level isolation are first-class — and every AI-driven change is itself an audit entry |
 | Standing up an internal admin for a SaaS product | One Node process, slots in next to your existing services |
 | Air-gapped or on-prem deployment for an enterprise customer | First-class deployment target, no internet egress required (BYO local model) |
+| Multi-tenant internal portal (several organizations, one deployment) | A walled tenancy posture puts up the per-organization isolation wall, enforced inside the runtime — an Enterprise capability, see [License & Pricing](/docs/resources/license). It separates the organizations' data and memberships, not their schema: they share one database and one metadata set |
 | You want your users to "vibe-code" their own extensions safely | The AI Builder + HITL approval queue + audit log are the whole point |
 
 ## Don't use ObjectOS if you …


### PR DESCRIPTION
Fixes #90

Restores one row to the "Common scenarios where it's a fit" table in `content/docs/why.mdx`, re-worded for the walled tenancy posture. One line, one file.

Maintainer ruled **option A** on 2026-08-20 in a live decision-inbox session: restore the row, with the licensing caveat stated in the row itself.

## The row

| Scenario | Why it works |
|---|---|
| Multi-tenant internal portal (several organizations, one deployment) | A walled tenancy posture puts up the per-organization isolation wall, enforced inside the runtime — an Enterprise capability, see [License & Pricing](/docs/resources/license). It separates the organizations' data and memberships, not their schema: they share one database and one metadata set |

It sits back in its original slot — fifth of six, after the air-gapped row — and does not name the per-project kernel or the LRU cache, which is the dead claim PR #86 removed on factual grounds.

## What was measured before writing it

Every fact in the cell was measured rather than carried forward from the card.

**Mechanism — `OS_TENANCY_POSTURE`, values `isolated` and `group`.** Unmoved on both sides.
- `content/docs/reference/environment-variables.mdx:69` — "Whether organizations are isolated from one another. The walled values are `isolated` and `group`. A walled posture **requires a licence** …"
- `objectstack@origin/main:content/docs/deployment/tenancy-modes.mdx` — three postures `single` (default) / `group` / `isolated`; the wall is the authorization kernel's Layer 0. Also: "*enabling* a multi-organization posture is a commercial capability (ADR-0105 D12)", and **both** walled postures require the enterprise `@objectstack/organizations` runtime to activate. That is what licences the row, and it is why "enforced inside the runtime" is the accurate mechanism phrase.

**Licence — the tier name the product actually uses is `ObjectOS Enterprise`.** This was the assumption flagged as falsifiable; it survives, and the row uses the product's own word rather than a generic one.
- `content/docs/resources/license.mdx:44` — editions table row "Clustering / HA, **multi-org self-host**, air-gap, SCIM" is checked in the **Enterprise** column only.
- `content/docs/resources/license.mdx:71` — "**ObjectOS Enterprise** — … multi-organization self-host …"
- Phrasing matches the corpus's existing idiom for gated capabilities: `deploy/air-gapped.mdx:17` "is an Enterprise capability — see [License & Pricing](/docs/resources/license)"; same sentence in `deploy/docker.mdx:149` and `deploy/kubernetes.mdx:71`.

**Shared-database / shared-metadata boundary.** Confirmed, and the cell reuses the corpus's own vocabulary rather than inventing a phrasing.
- `content/docs/resources/glossary.mdx` (Tenant) — "Those organizations still share the deployment's app, its database and its metadata, so the wall separates their data and memberships rather than their schema."
- `content/docs/resources/faq.mdx:48-59` — same, plus the escape hatch: "a customer that must have its own database gets its own deployment".
- `content/docs/reference/environment-variables.mdx` (`OS_AI_STUDIO_AGENTS`) — "metadata is scoped to the deployment, not to an organization, so on a shared database one customer's `build` turn rewrites the schema every other customer runs on."

**Table shape.** Two columns (`Scenario | Why it works`), five rows on `origin/main`; the restored row fits without a third column. The removal is `acc5b6a` (PR #86), a one-line deletion of exactly this row from this table — so this is a restore, not an edit.

## Verification

Gate union re-run after the final commit, at `c44bccc`, with `--force` so nothing is a cache replay (`Cached: 0 cached, 1 total` on every turbo task). Working tree clean, one changed path: `content/docs/why.mdx`.

| Gate | Verdict line |
|---|---|
| `pnpm install --frozen-lockfile` | `Done in 2.9s` |
| `pnpm turbo run type-check --continue` | `✓ Types generated successfully` · `Tasks: 1 successful, 1 total` |
| `pnpm turbo run build` | `✓ Compiled successfully in 32.5s` · `✓ Generating static pages … (740/740)` |
| `pnpm turbo run test` | `✓ 2 self-test(s) passed` · `Tasks: 1 successful, 1 total` |
| `check-node-floor.mjs --self-test` / `check-node-floor.mjs` | self-test green; `1 note(s), reported and not blocking` (pre-existing `ungoverned` note on `tools/ci-scripts`) |
| `check-translation-ownership.mjs` | `This PR touches 0 translation artifact(s) and 1 other file(s)` |
| `check-translations.mjs` | `✓ translations gate passed` |
| `check-translation-output.mjs --self-test` / `--files` | self-test green; `✓ translation output gate passed (138 pre-existing finding(s) reported)` |

Rendered output checked in the built page rather than inferred: `apps/docs/.next/server/app/en/docs/why.html` carries the row as a table row in the intended slot, with the licence link resolving to `/docs/resources/license`.

No locale siblings touched — English-only, per `AGENTS.md`. The six `why.*` translations are now stale and the freshness gate reports them non-blockingly, which is the designed behaviour.

No changeset: this repo has no changeset flow.

## Filed separately, not changed here

#144 — the **vs. rolling your own** table two sections down still sells multi-tenancy as an unqualified "Built in", with no licence or shared-schema caveat. Out of this card's ruled scope (the fit table), and the right wording there is a positioning judgement of the same kind #90 needed, so it is recorded rather than acted on.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V8AcCw8C1feB7b5kiaJd7b)_