### PR TITLE
docs(configure): notifications route by explicit audience, not by subscription rows

### DIFF
--- a/content/docs/configure/notifications.mdx
+++ b/content/docs/configure/notifications.mdx
@@ -1,30 +1,32 @@
 ---
 title: Notifications
-description: Configure how ObjectOS routes events into user inboxes — subscriptions, per-user preferences, and render templates.
+description: Configure how ObjectOS routes events into user inboxes — the audience a producer emits to, per-user preferences, and render templates.
 ---
 
 This page covers the **administrator side** of notifications: how events become
-messages, and the three system-managed objects you use to route and render
-them. For the recipient's view of the inbox — reading and muting notifications —
-see [Notifications](/docs/use/notifications) under *Use*.
+messages, and the three system-managed objects that stand behind them. For the
+recipient's view of the inbox — reading and muting notifications — see
+[Notifications](/docs/use/notifications) under *Use*.
 
 ## The notification pipeline
 
 A notification is not a single record. It flows through four stages:
 
 ```text
-emit()  →  Notification Event  →  routed by Subscription + Preference + Template  →  Inbox Message
+emit() + explicit audience  →  Notification Event  →  recipients, filtered by Preference  →  Inbox Message
 ```
 
 1. **`emit()`** — Application code raises an event (an approval submitted, a
-   record shared, an invitation sent).
+   record shared, an invitation sent) and **names its audience**. The audience
+   is a required input, and it is what decides who is notified.
 2. **Notification Event** (`sys_notification`) — Each `emit()` writes one
    ingress row. This is the diagnostic log of *what happened*, before any
    delivery decision. See [Audit Logs](/docs/operate/audit-logs) for how to
    read it.
-3. **Routing** — For each event, ObjectOS resolves who should be notified
-   (**Subscriptions**), whether each recipient allows that topic on that channel
-   (**Preferences**), and how the message should be rendered (**Templates**).
+3. **Routing** — For each event, ObjectOS expands the audience the producer
+   passed into recipients, checks whether each recipient allows that topic on
+   that channel (**Preferences**), and renders the message for the recipient's
+   channel and locale (**Templates**).
 4. **Inbox Message** (`sys_inbox_message`) — The materialized, per-user result
    the recipient actually sees in their inbox.
 
@@ -33,18 +35,41 @@ configuration. Inbox Messages are the user-side output.
 
 ### How routing resolves
 
-For a single event, the three objects each answer one question:
+For a single event, these are the inputs that decide who gets what:
 
-| Object | Question it answers |
+| Input | Question it answers |
 |---|---|
-| Notification Subscription | *Who is interested?* — which principals stand subscribed to the topic |
-| Notification Preference | *Does this recipient allow it here?* — the per-user mute/allow for the topic and channel |
+| The audience passed to `emit()` | *Who receives this?* — the producer names the recipients, and this is the only input that puts anyone on the list |
+| Notification Preference | *Does this recipient allow it here?* — the per-user mute/allow for the topic and channel, applied to every (recipient × channel) pair |
 | Notification Template | *How is it written?* — the subject and body to render for the recipient's channel and locale |
+| Notification Subscription | *Who declared standing interest?* — admin-authored rows, **not consulted when an event is routed** |
 
-Only when a recipient is subscribed **and** their preference for the
-topic/channel is enabled does a template render and an inbox message
-materialize. All three objects are seeded and maintained by the platform, so
-the list views mostly show system-generated rows.
+A recipient reaches the inbox when the producer's audience resolves to them and
+their preference does not mute that topic on that channel. Allow is the
+default, so a recipient with no preference row still receives the notification,
+and mandatory topics (security alerts and the like) bypass preferences
+altogether.
+
+> **Warning:** Subscription rows do not route anything. The
+> subscription-to-recipient expansion is **not wired**: `emit()` requires an
+> explicit audience, and nothing in the pipeline above expands a topic's
+> subscriptions into recipients. Every delivery comes from the audience the
+> producer passed, which makes the Setup **Notification Subscriptions** grid
+> admin-authored data, not a live routing control — pausing a row
+> (`enabled = false`) stops nothing, and adding one delivers nothing.
+
+That is a statement about the notification pipeline described on this page. It
+is not a claim about what a capability or integration running on top of
+ObjectOS may do with these rows for its own purposes. ADR-0012 and ADR-0030
+describe subscription-driven
+routing as the **target state**, not today's behaviour: the expansion that
+would make these rows routing-relevant was not built, and it is not scheduled.
+If it is ever built, the behaviour described here changes with it.
+
+Preferences and Templates are seeded and maintained by the platform, so those
+list views mostly show system-generated rows. Subscription rows are the ones an
+admin authors from Setup, which is what makes that grid read like a routing
+control.
 
 ## Notification Preferences
 
@@ -73,30 +98,40 @@ channel.
 
 At **Setup → Configuration → Notification Subscriptions** (`sys_notification_subscription`).
 
-A **standing subscription** of a principal (role, team, or user) to a
-notification topic. Subscriptions answer *who is interested* in a topic before
-per-user preferences filter delivery.
+A **standing subscription** of a principal to a notification topic: the row
+records that someone declared interest in the topic. It is reference data — no
+part of the delivery path reads it, so a subscription row neither adds a
+recipient nor removes one (see [How routing resolves](#how-routing-resolves)).
 
 | Field | Purpose |
 |---|---|
 | `topic` | The topic being subscribed to |
-| `principal` | Role, team, or user that receives the topic — a selector string; see [What to type in `principal`](#what-to-type-in-principal) |
-| `enabled` | Boolean — activate or pause the subscription |
+| `principal` | The subscriber — a selector string; see [What to type in `principal`](#what-to-type-in-principal) |
+| `enabled` | Boolean — marks the row active or paused. No delivery consults it |
 
 ### What to type in `principal`
 
 `principal` is a single text field, not a picker: the value is a **selector
-string**, and its prefix decides what the value is matched against. A value
-with no recognized prefix is read as a bare user id — so typing
-`sales_manager` (or `Sales team`) addresses a user that does not exist, rather
-than the group you meant.
+string**, and its prefix decides what the value is matched against. The forms
+below are what the platform's recipient resolver **accepts** for any selector
+string — the same grammar an `emit()` audience is written in. A value with no
+recognized prefix is read as a bare user id — so typing `sales_manager` (or
+`Sales team`) addresses a user that does not exist, rather than the group you
+meant.
 
 | Value | Who it resolves to | Example |
 |---|---|---|
 | `role:name` | Everyone whose organization-membership tier is that name, within the organization (`sys_member.role`) | `role:admin` |
 | `team:id` | Every member of that team, matched on the team **id**, not its label (`sys_team_member.team_id`) | `team:team_123` |
 | `user:id` | That one user, by user id | `user:usr_123` |
-| `id` | No prefix — the whole value is taken as a bare user id | `usr_123` |
+| `owner_of:object:id` | Whoever owns that one record — the first owner/assignee field the record carries | `owner_of:invoice:inv_123` |
+| An email address | The user whose email matches it. **An address that matches no user is kept verbatim** as the recipient id rather than rejected | `ada@example.com` |
+| `id` | No recognized prefix — the whole value is taken as a bare user id | `usr_123` |
+
+That list is what the resolver accepts, not a designed contract for
+subscription rows: `owner_of:` and the email form are there because every
+selector string goes through the same resolver. Whether either belongs in a
+standing subscription is an open question the platform has not settled.
 
 > **`role:` here means the organization-membership tier, not a job function.**
 > The tiers are `owner`, `admin`, `delegated_admin`, and `member` — the standing
@@ -109,9 +144,11 @@ than the group you meant.
 
 Directory lookups behind a selector are deliberately best-effort — an event is
 never failed because a lookup missed. A selector that matches nothing therefore
-resolves to **zero recipients silently**: the subscription row stays valid and
-enabled, and nothing is reported on it. When a topic reaches no one, check the
-prefix and the spelling of the value first.
+resolves to **zero recipients silently**: the row stays valid and enabled, and
+nothing is reported on it. An unmatched email is the sharper edge — it is kept
+as the recipient id itself, so a typo becomes a recipient that can never be
+reached. When a topic reaches no one, check the prefix and the spelling of the
+value first.
 
 ## Notification Templates
 


### PR DESCRIPTION
Fixes #132

`content/docs/configure/notifications.mdx` taught a routing gate the product does not enforce. Three places said it:

- the numbered **Routing** step resolved who should be notified "(**Subscriptions**)";
- the "How routing resolves" table answered *"Who is interested?"* with subscription rows;
- "Only when a recipient is subscribed **and** their preference for the topic/channel is enabled does a template render and an inbox message materialize."

## What the page says now

- **Routing is driven by the explicit audience a producer passes to `emit()`** — a required input, and the only thing that puts anyone on the recipient list. The pipeline line and step 3 say so; the routing table's first row is the audience, not a subscription.
- A `> **Warning:**` callout states plainly that the subscription→recipient expansion is **not wired**, that the Setup **Notification Subscriptions** grid is admin-authored data rather than a live routing control, and that pausing a row (`enabled = false`) stops nothing while adding one delivers nothing.
- **ADR-0012 / ADR-0030 are named as the target state, not today's behaviour.** The page did not cite them before; citing them *with* that distinction is what stops the same claim re-entering from the design-document direction.
- **No roadmap promise.** The expansion "was not built, and it is not scheduled. If it is ever built, the behaviour described here changes with it." The word *yet* appears nowhere on the page — it was rejected on measured zero pull, not scheduled.
- **Subscriptions, Preferences and Templates are kept, described at their true current force.** They are real objects with real admin meaning; only the routing gate was fiction. Preferences gained the two facts that make them checkable: allow is the default (no row still delivers), and mandatory topics bypass the matrix.
- **The `principal` selector table goes from four forms to six** — `role:x`, `team:x`, `user:id`, `owner_of:object:id`, an email address, a bare user id — matching what `RecipientResolver.resolveOne()` accepts after the same upstream PR widened its shipped description. It is framed as *what the resolver accepts*, explicitly **not** as a designed subscription contract, and the unmatched-email edge is called out: the address is kept verbatim as the recipient id, so a typo becomes a recipient that can never be reached.

## Scoping — deliberately not a universal

The framework's own annotation is narrowed to "**NOT WIRED in this repo**": `objectstack` was measured, `objectui` was measured, and `cloud` was **not** — recorded upstream as a declared narrowing rather than guessed. The page keeps that shape instead of asserting a universal:

> That is a statement about the notification pipeline described on this page. It is not a claim about what a capability or integration running on top of ObjectOS may do with these rows for its own purposes.

## Evidence — measured on `objectstack` `origin/main` @ `2866d5f97e`

| Claim | Where |
|---|---|
| Expansion not wired, with the "in this repo" scoping | `packages/services/service-messaging/src/objects/notification-subscription.object.ts:12-21` |
| `AudienceSpec` has no `'subscribers'` member | `src/messaging-service.ts:51-53` |
| `EmitInput.audience` is required | `src/messaging-service.ts` (`readonly audience: Audience;`) |
| No resolver branch reads subscriptions; six string forms | `src/recipient-resolver.ts:113-146` |
| Unmatched email kept verbatim as the recipient id | `src/recipient-resolver.ts` `resolveEmail()` — "keeping verbatim" |
| Preferences *are* wired (so the page keeps that claim) | `src/messaging-service.ts:707` + `src/preference-resolver.ts` — most-specific-wins, default on, mandatory bypass, fail-open |
| Nothing else reads `sys_notification_subscription` | repo grep: outside its declaration, only the Setup nav entry and tests |

`objectui` re-measured at `origin/main` `6ff0eb1e7`: zero hits for `sys_notification_subscription`, control-probed against `sys_inbox_message` (many hits) so the zero is a real zero and not a broken search. `cloud` is not checked out in this container and was **not** measured — which is why the page does not claim more than its own pipeline.

## Gates — run at `dc64d8f` (this PR's head)

| Gate | Result |
|---|---|
| `pnpm install --frozen-lockfile` | `Done in 2.5s` |
| `pnpm turbo run type-check --continue --force` | `Tasks: 1 successful, 1 total` (cache miss, executed) |
| `pnpm turbo run build --force` | `✓ Compiled successfully in 31.0s`, `✓ Generating static pages using 3 workers (740/740)` |
| `pnpm turbo run test --force` | `✓ 2 self-test(s) passed`, `Tasks: 1 successful, 1 total` |
| `node .github/scripts/check-translations.mjs` | `✓ translations gate passed` |
| `node .github/scripts/check-node-floor.mjs` | `✅ Every declared floor clears what the dependency tree requires` |

Every turbo task was run with `--force`, so none of these is a cache replay from a sibling worktree. Rendering was checked on the build's own output (`apps/docs/.next/server/app/en/docs/configure/notifications.html`): the new warning and selector rows are present, the old *"Who is interested?"* row is gone, and both in-page anchors (`#how-routing-resolves`, `#what-to-type-in-principal`) resolve. No browser session was driven — this is a content-only change and the production build renders the page.

No changeset (this repo has no changeset flow) and no locale siblings touched — `configure/notifications.mdx` has none.

## For whoever wires the expansion later

The framework's NOT WIRED marker and this page's correction have to be reverted **in the same change**, or the docs contradict the code in the opposite direction. Nothing in this repo records that coupling mechanically today; a place to record it is proposed in the dev report on #132 rather than invented here.

## Out of scope — recorded as separate issues, not changed here

- #146 — `operate/audit-logs.mdx` gives the same unwired gate as *diagnostic advice* ("a subscription or preference filtered the event out"). Outside this card's file surface.
- #147 — this page still implies every delivery renders from a Notification Template; the in-app inbox row does not. A rendering claim, not a routing one, and it needs the product's own statement first.

Neither is addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8AcCw8C1feB7b5kiaJd7b)_