### PR TITLE
docs: define Studio in the glossary, make the Setup/Studio split canonical

### DIFF
--- a/content/docs/build/agents.mdx
+++ b/content/docs/build/agents.mdx
@@ -47,7 +47,7 @@ export const tier1Support = defineAgent({
 });
 ```
 
-Or in the UI: **Agents → New Agent**.
+Or in the UI: **Studio → Agents → New Agent**.
 
 Or — and this is the point — say to the AI Builder:
 

--- a/content/docs/build/data/index.mdx
+++ b/content/docs/build/data/index.mdx
@@ -18,7 +18,7 @@ is generating and can edit it directly when you want to.
 | Path | Looks like |
 |---|---|
 | **AI Builder** (primary) | *"Create a `support_ticket` object with subject, description, priority, status, assignee."* |
-| **Click-build** | **Objects → New Object** → forms |
+| **Click-build** | **Studio → Objects → New Object** → forms |
 | **TypeScript (`*.object.ts`)** | The TS shown below — typically inside a forked [template](/docs/build/templates) |
 
 All three produce the same schema. The schema is canonical; everything

--- a/content/docs/build/packages.mdx
+++ b/content/docs/build/packages.mdx
@@ -51,7 +51,7 @@ pnpm dev
 
 ### From the UI
 
-**Packages → New Package** — name, id, version, namespace.
+**Studio → Packages → New Package** — name, id, version, namespace.
 
 ## Active package
 

--- a/content/docs/configure/index.mdx
+++ b/content/docs/configure/index.mdx
@@ -10,9 +10,24 @@ You manage people and their permissions day to day; the applications,
 objects, and permission sets themselves ship with the platform and the
 app packages you install.
 
-> **Permissions are designed in Studio, assigned in Setup.** Most
-> administration never leaves Setup — you enter Studio only to author
-> permission sets or to run the explain engine.
+## Setup and Studio
+
+**Permissions are designed in Studio, assigned in Setup.** That
+sentence is the canonical statement of a split that runs through the
+whole product, not a rule about permissions alone: Setup *operates* a
+running deployment, Studio *authors* the metadata that deployment runs.
+Both live inside the same UI at `/_console/`; neither is a surface of
+its own.
+
+| | Setup | Studio |
+|---|---|---|
+| Answers | Who is here, and what may they do? | What does this app consist of? |
+| Where | `/_console/apps/setup` | `/_console/studio` |
+| Gated by | `setup.access` | `studio.access` |
+| For | System administrators | Implementers and developers |
+
+Most administration never leaves Setup — you enter Studio only to
+author permission sets or to run the explain engine.
 
 ## The Setup app
 

--- a/content/docs/configure/permissions/index.mdx
+++ b/content/docs/configure/permissions/index.mdx
@@ -161,9 +161,9 @@ applies uniformly across REST, ObjectQL, and the UI.
 - The **explain engine** (`explain(principal, object, operation)`)
   reports the verdict of every layer in order — required permissions,
   object CRUD, field security, OWD baseline, sharing, row-level
-  security — with per-layer attribution. It surfaces as the
-  "Why can this user access?" panel. Explaining another user requires
-  the `manage_users` capability.
+  security — with per-layer attribution. Studio's **Access** pillar
+  surfaces it as the "Why can this user access?" panel. Explaining
+  another user requires the `manage_users` capability.
 - `/_console/` shows the effective permissions of any user as they're
   evaluated.
 - Audit log (`sys_audit_log`) records permission-sensitive changes —

--- a/content/docs/resources/glossary.mdx
+++ b/content/docs/resources/glossary.mdx
@@ -199,6 +199,19 @@ query time, compiled into row-level filters. A rule stored **without**
 criteria shares nothing — it is not a match-all. See
 [Record Access](/docs/configure/permissions/record-access#both-switches-fail-closed).
 
+### Studio
+
+The built-in metadata-authoring surface, at `/studio` inside the UI
+served at `/_console/`, gated by the `studio.access` permission.
+Where the metadata itself is *designed* — packages, objects, apps,
+flows and permission sets — one package at a time, across four pillars:
+Data, Automations, Interfaces, Access. Peer of **Setup**, not part of
+it: Setup operates a running deployment (its people, their grants, its
+configuration), Studio authors what that deployment runs — hence
+**permissions are designed in Studio, assigned in Setup**. Unlike
+Setup it is not an app under `/apps/`; the UI serves it as its own
+route subtree. See [Administration](/docs/configure#setup-and-studio).
+
 ### Surface
 
 One of the HTTP entry points a running ObjectOS exposes: `/` (REST API)


### PR DESCRIPTION
Fixes #102

Executes the 2026-08-20 maintainer ruling: **option 1 — `Studio` survives as the named metadata-authoring surface.** The product's named places are the unnamed end-user surface, **Setup** (administration) and **Studio** (authoring). All three ruled deliverables, and nothing else.

## What changed (6 files, +37/-9)

**1. `resources/glossary.mdx` gains a `Studio` entry** in alphabetical position, between `Sharing Rule` and `Surface`. It **defines** the surface — route, gate, what is authored there, how many pillars, and its relation to Setup — instead of describing it. The card's stop condition was explicit about this: a describing-without-deciding entry is how this corpus grew two mutually-referential `Console` entries (#89). The relation is stated in both directions ("Peer of Setup, not part of it"), so neither entry can be read without the other's boundary.

**2. `configure/index.mdx` promotes the split to a canonical statement.** "Permissions are designed in Studio, assigned in Setup" was a blockquote aside above the Setup section; it is now `## Setup and Studio`, a section whose body says the sentence is the canonical statement of a split that runs through the whole product, with a table giving both names' route, capability and audience side by side. The original aside's second sentence is kept verbatim underneath. The glossary entry deep-links to the new anchor.

**3. The four PR #100 rewrites now name the destination:**

| File | Was | Now |
|:--|:--|:--|
| `build/data/index.mdx:21` | `**Objects → New Object** → forms` | `**Studio → Objects → New Object** → forms` |
| `build/packages.mdx:54` | `**Packages → New Package**` | `**Studio → Packages → New Package**` |
| `build/agents.mdx:50` | `Or in the UI: **Agents → New Agent**.` | `Or in the UI: **Studio → Agents → New Agent**.` |
| `configure/permissions/index.mdx:164` | "It surfaces as the …" | "Studio's **Access** pillar surfaces it as the …" |

The last one is pillar-qualified because that is what the sibling page already says (`managing-access.mdx:84`, "Studio's **Access** pillar → **Explain access**") and because it is measurable: `PILLAR_FOR_SURFACE_TYPE` maps `permission` to the `access` pillar.

## Measured, not composed — including one correction to the dispatch's assumption

Every product fact asserted here was read off the sibling repos at `objectstack` `origin/main` `2866d5f97e` and `objectui` `origin/main` `6ff0eb1`.

**The dispatch assumed Studio is an app at `/apps/studio`, a syntactic peer of Setup's `/apps/setup`. It is not.** Studio is a dedicated route subtree of the console SPA at `/_console/studio` — `/studio`, `/studio/:packageId`, `/studio/:packageId/:tab` — declared in objectui `apps/console/src/App.tsx` via `studioRoutes`, and explicitly **outside** the `/apps/:appName/*` mount, as `studioEntry.ts` states in prose: "today the `/studio/*` routes sit OUTSIDE the only mount of it (`AppContent`, which covers `/apps/:appName/*`)". A `STUDIO_APP` metadata app does exist (`packages/platform-objects/src/apps/studio.app.ts`), but `packages/apps/studio/src/index.ts` records that it is **deliberately not default-loaded**: "the console ships a dedicated Studio surface at `/_console/studio/&lt;pkg&gt;/&lt;pillar&gt;`, so Studio no longer needs to exist as a navigable app tile in a stock boot" — and `packages/cli/src/commands/serve.ts:2470` and `packages/cli/src/adr-0048-app-split.test.ts:13` say the same thing independently.

**The consequence the dispatch was guarding against does not occur, which is why this did not stop.** The stop condition was that the `Surface` entry ("There are two, not three") would need a decision this card cannot make. It does not: `createConsoleStaticPlugin` serves one `/_console/*` catch-all and every Studio path is a route inside it, so Studio is **inside** the UI surface, not a third one. `Surface` is left untouched and stays true; the new `Studio` entry carries the relation instead ("inside the UI served at `/_console/`"). Had the entry been written as the assumed `/apps/studio`, the glossary would have shipped a route that does not resolve.

The rest of the measured basis: the entry gate is `studio.access` (`STUDIO_ENTRY_CAPABILITY`, objectui `studioEntry.ts:107`, an **entry**-level gate, fail-closed); the four pillars are `Data, Automations, Interfaces, Access` (`StudioDesignSurface.tsx:149`); the five metadata kinds Studio creates are package, app, object, flow and permission (`CreateItemDialog.tsx` header); and scope is one package at a time (`/studio/:packageId/:tab`).

## Sweep result — the dispatch's second assumption is falsified, and not fixed here

The dispatch assumed the four sites above are the only places PR #100 dropped the noun, and asked for a sweep. Answered by **diffing** PR #100 (`git show adbcafc -U0 -- 'content/docs'`) and classifying every removed `Console` occurrence, not by enumeration. Five more sites drop a **metadata-authoring** destination: `build/index.mdx:3`, `:13`, `:52`, and `build/automation/flows.mdx:9`, `:279`. `build/index.mdx:13` is the sharpest — the same "click-build" row as `build/data/index.mdx:21`, so after this PR one of the pair names Studio and the other does not.

All five are outside this card's declared six-file surface, so none is touched here. Filed as #148 with the full classification. Everything else PR #100 dropped is the end-user sense of the word and is correctly gone.

Separately filed as #150: `reference/cli.mdx:74` documents an `os studio` command that the CLI does not ship (oclif discovers commands from `packages/cli/src/commands/`; there is no studio command, and the upstream `packages/cli/README.md:45` carries the same stale claim). That line is cited in the card as evidence Studio is live; the ruling is unaffected, since it rests on `studio.access` and on the shipped `/_console/studio` surface, both measured above.

## Surface discipline

Exactly the six declared files are touched. `build/automation/approvals.mdx` (queued for #131), `configure/notifications.mdx` (in flight for #132), `build/interface/apps.mdx` and `configure/permissions/managing-access.mdx` (read as the vocabulary model, not rewritten) and every locale sibling are untouched — `git diff --name-only` is the six.

## Gates — all green on `46fc8b0`, the tree this PR pushes

| Gate | Result |
|:--|:--|
| `pnpm install --frozen-lockfile` | `Done in 9.1s` |
| `pnpm turbo run type-check --continue` | `Tasks: 1 successful, 1 total` — `cache miss, executing a4d54c7845f5b5ba` |
| `pnpm turbo run build` | `Tasks: 1 successful, 1 total` — `cache miss, executing cc6753e43e7379eb` |
| `pnpm turbo run test` | `Tasks: 1 successful, 1 total` — re-run with `--force` (`cache bypass, force executing`) after the first run replayed from the shared worktree cache |
| `check-node-floor.mjs --self-test` + check | exit 0; `Every declared floor clears what the dependency tree requires` |
| `check-translation-ownership.mjs` | exit 0; `This PR touches 0 translation artifact(s) and 6 other file(s)` |
| `check-translations.mjs` (freshness) | `✓ translations gate passed` — the six English edits report as locale staleness, non-blocking by design |
| `check-translation-output.mjs --self-test` + PR-scoped | `✓ translation output gate passed (138 pre-existing finding(s) reported)` — none in the changed files |

Both turbo tasks that consume `content/docs` report `cache miss`, so the greens were computed on this content rather than replayed from a sibling worktree's tree.

The glossary's `/docs/configure#setup-and-studio` link was verified against the **built output** rather than assumed: `id="setup-and-studio"` appears in `apps/docs/.next` for the configure page.

No changeset: this repo has no changeset flow. English only; locale siblings left alone per AGENTS.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V8AcCw8C1feB7b5kiaJd7b)_