### PR TITLE
docs(changelog): mirror the ratified 17.1.0 notes into Recent highlights

### DIFF
--- a/content/docs/resources/changelog.mdx
+++ b/content/docs/resources/changelog.mdx
@@ -54,6 +54,105 @@ Subscribe to releases on GitHub to get notified.
 
 ## Recent highlights
 
+### 17.1
+
+`@objectstack` **17.1.0** (released 2026-08-20) is the current release of
+the v17 line. Where 17.0 made the *authorable surface* loud, 17.1 makes
+the runtime's answers loud: a flag that promised to revoke access now
+revokes it, a read that failed stops being served as an empty one, a flow
+that never dispatched stops being reported as a run that failed, and a
+credential that was never meant to be readable stops being served. Full
+notes:
+[docs.objectstack.ai/docs/releases/v17](https://docs.objectstack.ai/docs/releases/v17).
+
+> **Warning:** 17.1.0 is a minor by version number, not by blast radius.
+> Several of its security corrections change who can read or write on an
+> existing deployment, with no migration step to notice. Work through the
+> 17.1.0 upgrade checklist in the full notes before rolling forward.
+
+What moved:
+
+- **Deactivating a permission set or a position now actually stops
+  granting access** (security) — both objects ship a Deactivate action
+  whose dialog promises that access stops, and nothing read the column: a
+  position seeded `active: false` still granted its permission sets, and
+  a permission set seeded `active: false` still returned a platform-admin
+  posture. A sharing rule reached users by a second road that never
+  passed that seam, so a rule sharing records with a deactivated position
+  kept sharing them — those shares are revoked on the next reconcile. A
+  row whose `active` column is absent or NULL is unaffected. On a
+  deployment that used the switch believing it was inert this is a real
+  revocation on live data, so audit your deactivated rows first. See
+  [Permission Sets](/docs/configure/permissions/permission-sets).
+- **The shipped admin sets no longer grant export on the `*` wildcard**
+  (breaking) — `admin_full_access`, `organization_admin` and the derived
+  `organization_admin_no_bypass` carried `objects['*'].allowExport: true`,
+  which made the 17.0 export axis undeniable: an application could
+  declare an object exportable by nobody and the platform exported it
+  anyway. Export is now granted per object, in an app's own permission
+  set; there is deliberately no automatic replacement. Read is untouched
+  — this narrows bulk egress only.
+- **Partial field masking** — `FieldSchema` declares `maskingRule`: the
+  closed preset enum `phone` / `id_card` / `bank_account` / `email` /
+  `name`, plus a `{ keepHead, keepTail }` escape hatch. A field declaring
+  a rule is served masked-but-recognizable (`138****5678`) to every
+  non-system caller, with the field's `requiredPermissions` as the unmask
+  gate. Masking rides the single runtime channel, so API callers, browser
+  users and the CSV/XLSX export route all see the same value; a masked
+  caller cannot filter, sort, group or aggregate on the field. See
+  [Field-Level Security](/docs/configure/permissions/field-level-security).
+- **`sys_audit_log` can answer "who viewed this record"** — the ledger
+  covered writes only; it gains a `read` action, its writer, and a
+  `record_views` list view. Record-detail reads only, per-object opt-in
+  with no global switch, batched off the request path, and **never any
+  field values** — read auditing runs ahead of field masking, so copying
+  values in would mint a plaintext copy of exactly what field-level
+  security withholds. See [Audit Logs](/docs/operate/audit-logs).
+- **Read-only approval visibility, per object, default off** — an object
+  can be named so that a user who can read a business record may also see
+  that record's approval requests and full action history. Omitted or
+  empty leaves visibility exactly as it is; on an object you do name it is
+  not a no-op — a supervisor who holds full read but never appears in the
+  approval used to get an empty list, and now sees the request row, every
+  actor and decision, the action's comment text (意见正文), and decision
+  attachments. The tier is read-only and introduces no new permission
+  concept: the service reads the record as the caller, so ordinary CRUD
+  and record access decide. See
+  [Approvals](/docs/build/automation/approvals).
+- **All three flow doors answer one honest status table** — a refused
+  dispatch stops being reported as a failed run: `404` not found, `409`
+  `FLOW_DISABLED`, `422` `FLOW_NO_START_NODE`, and `400` `FLOW_FAILED`
+  for a run that actually ran and was rejected. The automation `trigger`
+  routes, the actions door, and declared `type: 'flow'` endpoints now
+  read one shared definition instead of three private copies, and an
+  `outputMapping` is no longer applied to a failure. Callers should
+  branch on the HTTP status, not on an inner `success` flag. See
+  [Flows](/docs/build/automation/flows).
+- **`error.code` is a closed vocabulary at every door** — a thrown code
+  outside the platform's standard set no longer reaches `error.code`; it
+  rides the new optional `declaredCode` instead, so an application's own
+  spellings survive without widening the platform vocabulary.
+- **A failed read stops reading as an empty one** — a recurring class
+  closed across the metadata protocol, the roll-up summary index, and the
+  cascade-delete and registry probes: a read that *failed* used to be
+  indistinguishable from one that legitimately found nothing, so an
+  upsert pre-load turned every update into an insert and "what would
+  break if I delete this" answered "nothing". No `catch` is removed —
+  each is discriminated by error type, so an unprovisioned table stays
+  benign and everything else surfaces.
+- **Author-time gates reach the runtime publish door** — rules that only
+  `os build` / `os validate` ran now also judge a runtime write, so
+  Studio and the metadata API cannot land what the CLI refuses. Re-run
+  `os build` / `os validate` after upgrading: several new refusals can
+  fail a stack that built clean on 17.0, including an unknown top-level
+  stack key, a dashboard header `modal` action whose target is not a
+  declared page, and a list-view `sort` naming a formula field or no
+  field at all.
+- **Console (Studio)** — two objectui pin moves bring dashboard component
+  re-keying, the retirement of the structured `confirm` object on
+  actions, `I18nLabel` on metric widgets, and host-performed
+  `submitBehavior.url` redirects for consoles mounted at a sub-path.
+
 ### 17.0
 
 `@objectstack` **17.0.0** (released 2026-08-14) is a truth-telling


### PR DESCRIPTION
Fixes #142

`content/docs/resources/changelog.mdx` tells readers that `docs.objectstack.ai/docs/releases/v17` holds the authoritative release notes. That page now carries a full 17.1.0 treatment, so the mirror can follow. Adds a `### 17.1` entry above `### 17.0` under **Recent highlights** — "recent" is a claim about now, and it had been six days stale.

**This is a mirror, not a composition.** Every claim in the new entry is traceable to a ratified upstream section; nothing was summarized independently from the 69 generated `@objectstack/*` changelogs, which is what the card held this work back to avoid.

## What was mirrored, and from where

All sources are `objectstack` `origin/main`:

| New bullet | Upstream source |
|---|---|
| Opening paragraph (theme: the runtime's answers become loud) | `releases/v17.mdx:3341-3346`, the "practical theme is *honest refusals*" paragraph under `# What's new in 17.1.0` |
| The blast-radius Warning callout | `releases/v17.mdx:27-30` (release-status blockquote) and `:3336-3345` — upstream's own "minor by version number, not by blast radius" framing |
| Deactivating a permission set or a position | `## Security corrections in 17.1.0` (#8613, #8710) + `## Highlights — 17.1.0` bullet 1 |
| Shipped admin sets lose the `*` export wildcard | `## Security corrections in 17.1.0` (#8681) + Highlights bullet 2 |
| Partial field masking | `## New capabilities in 17.1.0` (#8993) + Highlights bullet 3 |
| `sys_audit_log` record-view auditing | `## New capabilities in 17.1.0` + Highlights bullet 4 |
| Read-only approval visibility, per object, default off | `## New capabilities in 17.1.0` (#8652); named as one of the three 17.1 adds in `releases/index.mdx` |
| All three flow doors, one status table | `### The flow doors answer real HTTP statuses` + Highlights bullet 5 |
| `error.code` closed vocabulary / `declaredCode` | `## Highlights — 17.1.0` bullet 6 (#9106) |
| A failed read stops reading as an empty one | `### A failed read stops reading as an empty one` |
| Author-time gates reach the runtime publish door | `### Author-time gates reach the runtime publish door` + the `### 17.1.0` upgrade checklist |
| Console (Studio) | `## Highlights — 17.1.0` bullet 7 |

The six-item spine of `releases/index.mdx`'s ratified v17 sentence — masking, record-view auditing, the read-only approval tier, deactivation actually revoking, the export-wildcard withdrawal, one flow status table — is covered in full.

## What was deliberately NOT touched

Eleven version-shaped claims across `content/docs` are facts about *when* a behaviour changed ("Since ObjectStack 17.0 …") and stay true forever. A bulk version bump would corrupt ten true sentences to fix one. That includes `changelog.mdx:26` on this very file (`engines.node … since 17.0`) — read and left alone.

The diff proves it mechanically: **99 insertions, 0 deletions, 1 file**. No existing line was modified.

No locale sibling was touched. `changelog.mdx` in fact has none yet — the translation worklist will create all six.

## Verification — all at `fd25dfb`, the final commit, on a clean tree

| Gate | Command | Verdict line |
|---|---|---|
| `build` / type-check | `pnpm turbo run type-check --filter=@objectos/docs --force` | `Tasks: 1 successful, 1 total` (`cache bypass, force executing`) |
| `build` / build | `pnpm turbo run build --filter=@objectos/docs --force` | `✓ Compiled successfully in 32.4s` · `✓ Generating static pages using 3 workers (740/740)` · `Tasks: 1 successful, 1 total` |
| `build` / test | `pnpm turbo run test --force` | `✓ 2 self-test(s) passed` · `Tasks: 1 successful, 1 total` |
| Node floor | `node .github/scripts/check-node-floor.mjs` | `✅ Every declared floor clears what the dependency tree requires, and the declarations agree.` |
| Ownership | `check-translation-ownership.mjs --actor os-zhuang --files (the diff list)` | `This PR touches 0 translation artifact(s) and 1 other file(s).` |
| Freshness | `node .github/scripts/check-translations.mjs` | `✓ translations gate passed` |

`--force` on the turbo tasks is deliberate: the turbo cache is shared across worktrees in this container, and this is a content-only change to a directory outside the package. Bypassing the cache removes the whole class of replayed-green false negatives that `turbo.json`'s `$TURBO_ROOT$/content/docs/**` input exists to prevent.

**Rendered-output check** (not just "it compiled") — from the prerendered `apps/docs/.next/server/app/en/docs/resources/changelog.html`. Angle brackets are spelled out below because GitHub's body sanitizer eats short tag-shaped fragments, backticks included:

- heading order under Recent highlights is **h3#171 → h3#170 → h3#160** — the new entry is first and the 17.0 entry survives intact;
- the Warning callout rendered as a real **blockquote** element carrying its full text;
- **10 list items** in the 17.1 section;
- the `意见正文` gloss and the `138****5678` masking example both render (the CJK gloss follows the `会签` precedent already on this page in the 16.0 entry).

## Out of scope, filed separately

- **#154** — `permission-sets.mdx:71-74` still promises `admin_full_access` and `organization_admin` carry `allowExport: true` for you. 17.1.0's #8681 withdrew exactly that wildcard, and nothing fails at parse time on upgrade. Found while checking link targets for this entry; out of scope for this PR: the card's file surface is this one file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFwZj1a84ZxFUcWAi5H8S5)_