### PR TITLE
fix(docs): derive the sitemap and hreflang locale surface from real translations

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -9,7 +9,7 @@ import { File, Folder, Files } from 'fumadocs-ui/components/files';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { LLMCopyButton, ViewOptions } from '@/components/ai/page-actions';
 import { gitConfig } from '@/lib/layout.shared';
-import { languageAlternates, localeUrl } from '@/lib/seo';
+import { languageAlternates, localeUrl, translatedLocales } from '@/lib/seo';
 
 export default async function Page(props: {
   params: Promise<{ lang: string; slug?: string[] }>;
@@ -69,7 +69,10 @@ export async function generateMetadata(props: {
     description: page.data.description,
     alternates: {
       canonical: localeUrl(params.lang, path),
-      languages: languageAlternates(path),
+      // Only the locales that really have this page. The cluster is keyed by
+      // the logical path, not by params.lang, so every page in it advertises
+      // the same reciprocal set.
+      languages: languageAlternates(path, translatedLocales(page.slugs)),
     },
   };
 }

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,29 +1,48 @@
 import type { MetadataRoute } from 'next';
 import { source } from '@/lib/source';
 import { i18n } from '@/lib/i18n';
-import { languageAlternates, localeUrl } from '@/lib/seo';
+import { languageAlternates, localeUrl, translatedLocales } from '@/lib/seo';
 
 export const revalidate = false;
+
+/**
+ * Locales in which `privacy` and `terms` are actually written. Those two pages
+ * carry their copy in a `content` record inside their own route component
+ * (`app/[lang]/privacy/page.tsx`, `app/[lang]/terms/page.tsx`), which falls back
+ * to English (`content[lang] ?? content.en`) for anything not listed there —
+ * the same fallback-shaped defect the docs pages have. Keep this in sync with
+ * those two records.
+ */
+const STATIC_PAGE_LOCALES = ['en', 'zh-Hans'];
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const entries: MetadataRoute.Sitemap = [];
 
   // Top-level static pages (paths are locale-independent slugs).
-  const staticPaths: Array<{ path: string; priority: number }> = [
-    { path: '', priority: 1 },
-    { path: 'privacy', priority: 0.3 },
-    { path: 'terms', priority: 0.3 },
+  const staticPaths: Array<{ path: string; priority: number; locales: readonly string[] }> = [
+    // The root exists in every locale: it is a language dispatch page that
+    // redirects to that locale's /docs.
+    { path: '', priority: 1, locales: i18n.languages },
+    { path: 'privacy', priority: 0.3, locales: STATIC_PAGE_LOCALES },
+    { path: 'terms', priority: 0.3, locales: STATIC_PAGE_LOCALES },
   ];
 
-  // Documentation pages, enumerated from the Fumadocs source. Slugs are the
-  // same across locales, so we reconstruct each locale URL from page.slugs.
-  const docPaths = source
-    .getPages()
-    .map((page) => ({ path: ['docs', ...page.slugs].join('/'), priority: 0.8 }));
+  // Documentation pages. `source.getPages()` with no argument returns every
+  // locale's page set concatenated — the same logical page once per language —
+  // so it must be pinned to the default language to enumerate pages rather than
+  // page/locale pairs. Slugs are the same across locales, so we reconstruct
+  // each locale URL from page.slugs.
+  const docPaths = source.getPages(i18n.defaultLanguage).map((page) => ({
+    path: ['docs', ...page.slugs].join('/'),
+    priority: 0.8,
+    locales: translatedLocales(page.slugs),
+  }));
 
-  for (const { path, priority } of [...staticPaths, ...docPaths]) {
-    const languages = languageAlternates(path);
-    for (const lang of i18n.languages) {
+  for (const { path, priority, locales } of [...staticPaths, ...docPaths]) {
+    // One reciprocal hreflang cluster per logical path, listing only the
+    // locales that really have this page, and shared by every entry in it.
+    const languages = languageAlternates(path, locales);
+    for (const lang of locales) {
       entries.push({
         url: localeUrl(lang, path),
         changeFrequency: 'weekly',

--- a/apps/docs/lib/seo.ts
+++ b/apps/docs/lib/seo.ts
@@ -1,4 +1,5 @@
 import { i18n } from '@/lib/i18n';
+import { source } from '@/lib/source';
 
 // Canonical production host. Keep in sync with middleware's domain redirect.
 export const SITE_URL = 'https://docs.objectos.ai';
@@ -16,14 +17,62 @@ export function localeUrl(lang: string, path: string): string {
 }
 
 /**
- * hreflang alternates map for a logical path: every supported locale plus an
- * x-default pointing at the English (canonical) URL. Shape matches the
- * `alternates.languages` field of Next.js Metadata and MetadataRoute.Sitemap.
+ * The locales that have a *real* translated source file for `slugs`.
+ *
+ * Why this cannot be read off the loader's own per-language APIs: `defineI18n`
+ * leaves `fallbackLanguage` unset, which fumadocs resolves to `defaultLanguage`
+ * — so every non-English locale's in-memory file system is constructed by
+ * copying the English files in and letting real translations overwrite them.
+ * The consequences, measured against fumadocs-core 16.8.12 with this repo's
+ * content:
+ *
+ * - `source.getPages(lang)` and `source.getLanguages()` report 79 pages for
+ *   *all seven* locales — they cannot tell a translation from a fallback.
+ * - `source.getPages()` with no argument returns every locale's page set
+ *   concatenated (553), not the default-language set.
+ *
+ * What does survive the copy is the file identity: `page.path` keeps the
+ * ORIGINAL locale-suffixed filename it was authored under. A real Japanese page
+ * is `operate/backup.ja.mdx`; an inherited fallback is the English
+ * `operate/backup.mdx` under a `ja` lookup. Comparing against the English
+ * page's path is therefore the discriminator, and it needs no filesystem access
+ * at request time.
+ *
+ * English is the authored source (AGENTS.md: "English is the single source of
+ * truth"), so it is present for every real page — and absent here only for a
+ * translation-only file, which AGENTS.md forbids and which this function
+ * correctly reports as having no English URL to advertise.
  */
-export function languageAlternates(path: string): Record<string, string> {
+export function translatedLocales(slugs: string[]): string[] {
+  const englishPath = source.getPage(slugs, i18n.defaultLanguage)?.path;
+
+  return i18n.languages.filter((lang) => {
+    const page = source.getPage(slugs, lang);
+    if (!page) return false;
+    return lang === i18n.defaultLanguage || page.path !== englishPath;
+  });
+}
+
+/**
+ * hreflang alternates map for a logical path, over the locales that actually
+ * have a translation of it, plus an x-default pointing at the English
+ * (canonical) URL. Shape matches the `alternates.languages` field of Next.js
+ * Metadata and MetadataRoute.Sitemap.
+ *
+ * `locales` is required on purpose. It used to be implicit — every caller got
+ * all seven — and that is the defect this signature removes; a default value
+ * would let a future call site silently reproduce it.
+ */
+export function languageAlternates(
+  path: string,
+  locales: Iterable<string>,
+): Record<string, string> {
+  const available = new Set(locales);
   const languages: Record<string, string> = {};
+  // Iterate i18n.languages rather than `locales` so the map order is the
+  // declared locale order regardless of what the caller passes.
   for (const lang of i18n.languages) {
-    languages[lang] = localeUrl(lang, path);
+    if (available.has(lang)) languages[lang] = localeUrl(lang, path);
   }
   languages['x-default'] = localeUrl(i18n.defaultLanguage, path);
   return languages;


### PR DESCRIPTION
Fixes #169

All numbers below are measured on this branch at `587d9a4`, through `pnpm turbo run build --filter=@objectos/docs --force`, read out of the generated `apps/docs/.next/server/app/sitemap.xml.body`.

## The card's premise held, but two of its mechanism assumptions did not

**Confirmed — the fallback is real, so the duplicate-content reading of the card stands.** `defineI18n` leaves `fallbackLanguage` unset, and fumadocs-core 16.8.12 resolves that to `defaultLanguage` rather than to "no fallback" (`fallbackLanguage !== null ? fallbackLanguage ?? defaultLanguage : null` — only an explicit `null` disables it). `source.getPage(['operate','backup'], 'ja')` returns the English page with url `/ja/docs/operate/backup`. Those URLs serve English; they do not 404. No correction needed to the card on this point.

**Falsified — `source.getPages()` does not return the default-language set.** It returns every locale's page set concatenated. Its own doc comment says so: *"do not filter by language if `lang` is not specified"*. Against this repo's 335 MDX files it returns **553** pages — the same 79 logical slugs, once per language.

That makes the defect substantially larger than the card estimated. The card projected "roughly 553 URLs". The real pre-fix output, built from `origin/main`'s three files through this same pipeline:

| | pre-fix (`origin/main`) | this branch |
|---|---|---|
| sitemap entries | 3892 | 346 |
| distinct URLs among them | 574 | 346 |
| duplicate entries | 3318 | 0 |
| hreflang alternate elements | 31136 | 2410 |

So every URL was being submitted seven times over, on top of the locale problem the card describes.

**Falsified — the suggested route does not work.** `source.getLanguages()` and `source.getPages(lang)` look like the clean way to enumerate per-locale pages, and they cannot do this job: each locale's in-memory file system is built as `new FileSystem(inherit)`, which *copies* the English files in before the real translations overwrite them. Measured, every one of the seven locales reports 79 pages. Those APIs cannot tell a translation from a fallback.

## What this changes

What survives the copy is file identity: `page.path` keeps the original locale-suffixed filename it was authored under. A real Japanese page is `configure/permissions/positions.ja.mdx`; an inherited fallback under a `ja` lookup is the English `operate/backup.mdx`. Comparing against the English page's path is the discriminator, and it needs no filesystem access — which matters because this app builds through OpenNext for Cloudflare.

- `lib/seo.ts` gains `translatedLocales(slugs)`, the single derivation both surfaces now share.
- `languageAlternates(path, locales)` takes the locale set as a **required** argument. It used to be implicit — every caller got all seven — and that implicitness is the defect; a default value would let a future call site reproduce it silently. `x-default` still points at the English URL, and English is still emitted for every page.
- `app/sitemap.ts` pins the enumeration to `source.getPages(i18n.defaultLanguage)`, which is what removes the 3318 duplicates.
- `generateMetadata` builds its hreflang cluster from the same derivation. `canonical` is byte-identical to what is on main — see "left alone" below.

`i18n.languages`, routing, middleware and the reading experience are untouched. An untranslated locale URL behaves exactly as it does today; it is simply no longer advertised.

## Beyond the docs pages: `privacy` and `terms`

`sitemap.ts` also emits the two legal pages, and they had the same defect from a different source. `app/[lang]/privacy/page.tsx` and `app/[lang]/terms/page.tsx` keep their copy in a module-private `content` record with exactly two keys, `en` and `zh-Hans`, and render `content[lang] ?? content.en` for the other five locales — the same English-under-a-foreign-prefix shape. Under the card's adjudicated rule those five locale URLs each are not real, so this branch trims both pages to `en` + `zh-Hans` (10 bogus entries removed).

Those two route files are outside this card's declared file surface, so the pair is restated as a constant in `sitemap.ts` rather than read from them. That is correct today and will drift the day someone adds a third key. Filed as #173 to make it derived.

The redirecting root (`path: ''`) is deliberately unchanged at all seven locales and `priority: 1`: it dispatches to that locale's `/docs` in every locale, so it is real in all seven under this card's rule. Whether it belongs in the sitemap at all is #171's question, and this branch leaves it exactly as found.

## Verification — the card's three steps

**1. Entry count matches the files on disk.** Docs entries per locale, counted from the built sitemap against `find content/docs -name '*.LOCALE.mdx' | wc -l`:

| locale | files on disk | sitemap entries |
|---|---|---|
| en | 79 | 79 |
| zh-Hans | 62 | 62 |
| ja | 39 | 39 |
| de | 38 | 38 |
| es | 39 | 39 |
| fr | 39 | 39 |
| ko | 39 | 39 |
| **total** | **335** | **335** |

Plus 7 root + 2 privacy + 2 terms = 346, with 346 distinct URLs. The 41-of-79 headline in the card reproduces exactly: 41 English pages are missing at least one locale.

**2. An English-only page lists only English and x-default.** Rendered head of `/docs/operate/backup`, from `.next/server/app/en/docs/operate/backup.html`:

```
link rel="canonical"  href="https://docs.objectos.ai/docs/operate/backup"
link rel="alternate"  hrefLang="en"        href="https://docs.objectos.ai/docs/operate/backup"
link rel="alternate"  hrefLang="x-default" href="https://docs.objectos.ai/docs/operate/backup"
```

`https://docs.objectos.ai/ja/docs/operate/backup` is absent from the sitemap entirely.

**3. A fully translated page keeps all seven, reciprocally.** `/docs/configure/permissions/positions` and `/ja/docs/configure/permissions/positions` emit the identical eight-element cluster (seven locales + x-default), because the cluster is keyed by the logical path rather than by the rendering locale.

A partially translated page behaves in between: `/docs/use/approvals` and `/ko/docs/use/approvals` both list `en`, `zh-Hans`, `x-default` — those being the two files that exist.

(React serializes the attribute as `hrefLang`. HTML attribute names are ASCII case-insensitive, so crawlers read it as `hreflang`; this is unchanged from main.)

## Reverse verification

Both legs were run from the committed state, with the mutation proven on disk by blob hash and the restore proven by an empty `git diff HEAD` / `git status --porcelain`.

- **Can the new contract go red?** Dropping the second argument at one call site: `app/sitemap.ts(44,23): error TS2554: Expected 2 arguments, but got 1.` — `Tasks: 0 successful, 1 total`. The required parameter is enforced, and `type-check` demonstrably reads these files.
- **Is the 346 caused by this change?** The three files were checked out at `ee74379` and rebuilt through the same command: 3892 entries / 574 distinct. Restored and rebuilt: 346 / 346. This build-measured baseline agrees exactly with an independent measurement taken by driving the installed `loader()` directly over the real content tree.

## Gates, all on `587d9a4`

| gate | verdict line |
|---|---|
| `node check-node-floor.mjs --self-test` | `✓ self-test: 17 rule case(s) … every rule demonstrated able to fail` |
| `node check-node-floor.mjs` | `✅ Every declared floor clears what the dependency tree requires` |
| `turbo run type-check --continue --force` | `Tasks: 1 successful, 1 total` |
| `turbo run build --force` | `Tasks: 1 successful, 1 total` |
| `turbo run test --force` | `✓ 2 self-test(s) passed` · `Tasks: 1 successful, 1 total` |

Every run used `--force`, so none of these is a replayed cache entry from a sibling agent's worktree. The `Translations` workflow does not fire on this PR: its path filter is `content/docs/**`, `apps/docs/lib/i18n.ts` and `.github/scripts/check-translation*.mjs`, and this diff touches none of them. No changeset — this repo has no changeset flow.

## Deliberately left alone

- **`canonical` on fallback URLs.** `/ja/docs/operate/backup` still declares itself canonical while serving English. It is now out of the sitemap and out of every cluster, so it is no longer advertised, but a crawler arriving by another route can still index it. Pointing `canonical` at the English URL is the textbook fix and is not adjudicated on this card — the adjudication covers sitemap entries and hreflang alternates and requires the reading experience to be unchanged. Filed as #174 with the options priced.
- **No regression gate.** Nothing in the repo asserts anything about the generated sitemap; `type-check`, `build` and `test` are green on the 3892-entry tree and on this one alike. Filed as #175. Adding one would mean a new `.github/scripts/` file, outside this card's file surface and a new gate surface.

## Notes for #166

This branch changes the signature `generateMetadata` calls but not its shape: it still returns the same four fields, and the `alternates.languages` value now comes from `languageAlternates(path, translatedLocales(page.slugs))`. Nothing #166 adds — the SEO-title frontmatter field, `openGraph`/`twitter`, JSON-LD, the OG `site=` string — interacts with it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_