### PR TITLE
fix(docs): make llms.txt crawlable and give it a real header

### DIFF
--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,13 +1,96 @@
+import type { Folder } from 'fumadocs-core/page-tree';
+import { llms } from 'fumadocs-core/source/llms';
+import { i18n } from '@/lib/i18n';
 import { source } from '@/lib/source';
 
 export const revalidate = false;
 
+/**
+ * The one place this site states what ObjectOS is.
+ *
+ * Taken verbatim from the marketing site's own `/llms.txt`
+ * (`www.objectos.ai`, `src/pages/llms.txt.ts`) — the current authoritative
+ * positioning string for the two products. It is deliberately NOT re-derived
+ * from `content/docs/index.mdx`: that page's framing is itself under review,
+ * and `llms.txt` must not become the place a second version of it appears.
+ *
+ * If the positioning changes, change this constant. Nothing else in this file
+ * encodes it.
+ */
+const SUMMARY =
+  'ObjectStack is the open target format and runtime for AI-written enterprise software; ObjectOS is the commercial production platform where teams build, review, deploy, and operate ObjectStack applications.';
+
+/** Title line: the product this documentation is for. */
+const TITLE = 'ObjectOS';
+
+/** Heading for the pages that sit at the tree root rather than in a section. */
+const ROOT_HEADING = 'Overview';
+
+/**
+ * English only, by `AGENTS.md` rule 1 — English is the single source of truth
+ * and every `*.<locale>.mdx` is a derived artifact. `source.getPages()` and
+ * `source.getPageTree()` list *every* language when called without one, which
+ * is how this file used to emit all 335 pages across 7 locales as one flat
+ * list. The locale URLs are announced at the end of the file instead.
+ */
+const LANG = i18n.defaultLanguage;
+
+const OTHER_LOCALES = i18n.languages.filter((lang) => lang !== LANG);
+
+function sectionHeading(folder: Folder): string {
+  const title = source.getNodeMeta(folder, LANG)?.data.title;
+  if (title) return title;
+  return typeof folder.name === 'string' ? folder.name : 'Documentation';
+}
+
 export async function GET() {
-  const lines: string[] = [];
-  lines.push('# Documentation');
-  lines.push('');
-  for (const page of source.getPages()) {
-    lines.push(`- [${page.data.title}](${page.url}): ${page.data.description}`);
+  const generator = llms(source);
+  const tree = source.getPageTree(LANG);
+
+  const lines: string[] = [
+    `# ${TITLE}`,
+    '',
+    `> ${SUMMARY}`,
+    '',
+    'This is the ObjectOS product and developer documentation, grouped by the ' +
+      'sections used in the site navigation. Every page below is also available ' +
+      'as Markdown by appending `.mdx` to its URL (for example ' +
+      '`/docs/quickstart.mdx`), and `/llms-full.txt` carries the full text of ' +
+      'every page in one file.',
+  ];
+
+  // Root-level pages (index, why, quickstart, ...) come before the section
+  // folders in the tree; collect them under one heading so the file opens with
+  // a section rather than a bare list.
+  const rootPages = tree.children.filter((node) => node.type === 'page');
+  if (rootPages.length > 0) {
+    lines.push('', `## ${ROOT_HEADING}`, '');
+    for (const node of rootPages) lines.push(generator.indexNode(node, LANG));
   }
+
+  for (const node of tree.children) {
+    if (node.type !== 'folder') continue;
+    lines.push('', `## ${sectionHeading(node)}`, '');
+    // The folder's own bullet is dropped: the heading already names it. Its
+    // index page and children are rendered at the top level of the section,
+    // so nested subfolders keep exactly one level of indentation.
+    if (node.index) lines.push(generator.indexNode(node.index, LANG));
+    for (const child of node.children) lines.push(generator.indexNode(child, LANG));
+  }
+
+  if (OTHER_LOCALES.length > 0) {
+    lines.push(
+      '',
+      '## Other Languages',
+      '',
+      `Every page above is also published under a locale prefix — for example ` +
+        `\`/${OTHER_LOCALES[0]}/docs/quickstart\`. Available locales: ` +
+        `${OTHER_LOCALES.map((lang) => `\`${lang}\``).join(', ')}. English is the ` +
+        `source of truth; a page with no translation yet falls back to English.`,
+    );
+  }
+
+  lines.push('');
+
   return new Response(lines.join('\n'));
 }

--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -9,8 +9,12 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      // Generated text endpoints duplicate page content; keep them out of the index.
-      disallow: ['/api/', '/llms.txt', '/llms-full.txt'],
+      // `/llms.txt` and `/llms-full.txt` are deliberately crawlable. They exist to be
+      // fetched by AI crawlers and answer engines, which is the audience a blanket
+      // `User-agent: *` disallow shuts out; and a plain-text endpoint does not compete
+      // with the HTML page for a position in a result list the way a duplicate HTML
+      // page would. `/api/` stays out: it serves the search index, not readable content.
+      disallow: ['/api/'],
     },
     sitemap: `${BASE}/sitemap.xml`,
     host: BASE,


### PR DESCRIPTION
Fixes #170

## What changed

**`apps/docs/app/robots.ts`** — `/llms.txt` and `/llms-full.txt` are no longer disallowed. `/api/` still is, and the comment now says why it is the one that stays out (it serves the search index, not readable content).

**`apps/docs/app/llms.txt/route.ts`** — the file now opens with `# ObjectOS` and a one-sentence blockquote summary, and the link list is grouped under the same section headings the site navigation uses.

The strongest argument for this change is the org's own written policy, in `www.objectos.ai`'s `AGENTS.md`:

> Keep machine-facing surfaces first-class: /llms.txt, /rss.xml, canonical URLs, structured data. Treat llms.txt as a curated map for LLM retrieval, not an afterthought.

A blanket `User-agent: *` disallow on the one file written for LLM retrieval is a straight violation of that.

## Where the summary wording comes from

Verbatim from the marketing site's own `/llms.txt` (`www.objectos.ai`, `src/pages/llms.txt.ts`) — the organization's current authoritative positioning string. No new positioning copy is authored here.

It is deliberately **not** re-derived from `content/docs/index.mdx`. That page's frontmatter frames ObjectOS as "the runtime for internal tools that stays in your network"; the marketing site frames ObjectStack as the open target format and ObjectOS as the commercial production platform on top of it. Decision card #171 exists because those two disagree. Sourcing from `index.mdx` would have baked the disputed version into `llms.txt`.

The string lives in one constant, `SUMMARY`, with a comment saying so. When #171 settles, that constant is the only edit. (Note that #171's outcome will also move the `[ObjectOS](/docs)` line under `## Overview` — that description is the page's own frontmatter, rendered from page data, not copy authored in this PR.)

## The grouping question, and a measurement that changes it

The card floated grouping by top-level section and left it to judgement, noting 79 English pages. Measuring first turned up something the card could not have seen:

`source.getPages()` and `source.getPageTree()` list **every language** when called without one — `fumadocs-core`'s indexer only filters by locale prefix when a locale is passed. So the old flat list was not 79 lines. It was **all 335 `.mdx` files across 7 locales**, with translated titles and translated descriptions interleaved, in file order.

That settles both halves at once:

- **Grouping: yes.** 79 pages across 8 sections is already past the point where a flat list is a wall rather than a map, and the nesting under `build/data`, `build/interface`, `build/automation` and `configure/permissions` is real structure that a flat list throws away.
- **Locale: default only.** `AGENTS.md` rule 1 — English is the single source of truth, every `*.locale.mdx` is a derived artifact. Grouping 335 mixed-locale entries by section would have interleaved 7 languages inside every heading, which is worse than the flat list it replaced. The locale URL scheme is announced in one `## Other Languages` line at the end instead of 256 link lines, so nothing becomes undiscoverable.

Rendering goes through `fumadocs-core`'s own `llms()` helper (`fumadocs-core/source/llms`) rather than a hand-rolled tree walk, so names, descriptions, link escaping and nesting come from the library. The folder's own bullet is dropped where the `##` heading already names it.

## Verification

Production build, then `next start` on a local port, fetched over HTTP — the two checks the card asks for.

`GET /robots.txt`:

```
User-Agent: *
Allow: /
Disallow: /api/

Host: https://docs.objectos.ai
Sitemap: https://docs.objectos.ai/sitemap.xml
```

`grep -c llms` on that body: `0`. `grep -c 'Disallow: /api/'`: `1`.

`GET /llms.txt` (`content-type: text/plain;charset=UTF-8`), first lines:

```
# ObjectOS

> ObjectStack is the open target format and runtime for AI-written enterprise software; ObjectOS is the commercial production platform where teams build, review, deploy, and operate ObjectStack applications.

This is the ObjectOS product and developer documentation, grouped by the sections used in the site navigation. Every page below is also available as Markdown by appending `.mdx` to its URL (for example `/docs/quickstart.mdx`), and `/llms-full.txt` carries the full text of every page in one file.

## Overview

- [ObjectOS](/docs): The runtime for internal tools that stays in your network. One command to start, your database, your auth, your data — never ours.
```

Counts on the served body: 116 lines, **79** link lines (matching the English page count the card states), 9 headings (`Overview`, `Use`, `Build`, `Configure`, `Deploy`, `Operate`, `Resources`, `Reference`, `Other Languages`), and **0** links to a non-default locale prefix.

Gates, all run on the final commit `eefef37` in a dedicated worktree:

| Gate | Result |
|---|---|
| `turbo run type-check --continue` | `Tasks: 1 successful, 1 total` |
| `turbo run build` | `Tasks: 1 successful, 1 total` |
| `turbo run test` (`--force`, see below) | `Tasks: 1 successful, 1 total` — `✓ 2 self-test(s) passed` |
| `node .github/scripts/check-node-floor.mjs` | exit 0 — `✅ Every declared floor clears what the dependency tree requires` |

`turbo run test` first came back as a cache hit whose replayed logs were stamped `/home/user/objectos-issue-169/tools/ci-scripts` — a **sibling worktree's** run, exactly the shared-cache replay `AGENTS.md` warns about. Its inputs (`tools/ci-scripts/**`, `.github/scripts/**`, `apps/docs/lib/i18n.ts`) are untouched by this PR so the hash match was legitimate, but the line above is from a forced re-execution in this worktree. `type-check` and `build` were genuine cache misses that executed here.

The `.mdx` claim in the header line was checked against the route it depends on: `next.config.mjs` rewrites `/docs/:path*.mdx` to `/llms.mdx/docs/:path*`, `app/llms.mdx/docs/[[...slug]]/route.ts` serves it as `text/markdown`, and `middleware.ts`'s matcher excludes dotted paths so it is not locale-redirected.

## Deliberate non-changes

- **`next.config.mjs` is untouched.** The `/docs/:path*.mdx` rewrite is unrelated to the robots rule and stays as-is. (It is at lines 44-51 on `main`, not 59-66 as the card says.)
- **Links stay site-relative.** Making them absolute would mean either a third copy of the base URL or importing `@/lib/seo` — and `seo.ts` is being edited concurrently on #169. Filed separately rather than coupling two PRs over a cosmetic improvement.
- **No changeset.** This repo has no changeset flow and no `.changeset/` directory.

## Filed out of scope

- #177 — `llms-full.txt` has the same missing-locale-argument defect and now serves 4.6 MB of all-seven-locales full text to crawlers this PR just let in. Not in this PR's file surface.
- #178 — both `llms` endpoints emit site-relative URLs (observation).

The seven-locales-per-page defect in `sitemap.ts` is already covered by #175 and #169, so no new card for it; measured here at 3892 `loc` entries for 574 distinct URLs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_