### PR TITLE
fix(docs): serve llms-full.txt in the default locale only

### DIFF
--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -1,9 +1,22 @@
+import { i18n } from '@/lib/i18n';
 import { getLLMText, source } from '@/lib/source';
 
 export const revalidate = false;
 
+/**
+ * English only, by `AGENTS.md` rule 1 — English is the single source of truth
+ * and every `*.<locale>.mdx` is a derived artifact. This is the same pin
+ * `llms.txt` carries, for the same reason: `source.getPages()` filters by
+ * locale **only when a language is passed** — called bare it returns every
+ * language's page set concatenated, so this route used to emit all 335 pages
+ * across 7 locales (4.6 MB, the same page appearing up to seven times) instead
+ * of the 79 English ones. The locale text stays reachable per page through the
+ * `.mdx` rewrite and the locale URLs announced at the end of `llms.txt`.
+ */
+const LANG = i18n.defaultLanguage;
+
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source.getPages(LANG).map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join('\n\n'));


### PR DESCRIPTION
Fixes #177

`source.getPages()` filters by locale **only when a language is passed** — called bare it returns every language's page set concatenated. `apps/docs/app/llms-full.txt/route.ts` called it bare, so `/llms-full.txt` served the full processed text of all 335 pages across 7 locales instead of the 79 English ones.

## The fix

One line, plus the comment that keeps it from being undone:

```ts
const LANG = i18n.defaultLanguage;
// ...
const scan = source.getPages(LANG).map(getLLMText);
```

This is deliberately the **same shape `llms.txt` was given in #179**, for the same reason: English is the single source of truth (`AGENTS.md` rule 1) and every locale `.mdx` is a derived artifact. Consistency between the two endpoints is the point — the two routes now pin the locale identically, so a reader who understands one understands the other.

Not changed: `revalidate`, the response headers, the join separator. Locale text stays reachable per page through the `.mdx` rewrite and the locale URLs `llms.txt` announces at the end of its own body.

## Measured

Over HTTP from a **production build**, not from source: `pnpm --filter @objectos/docs build` then `next start`, `GET /llms-full.txt`. Before is `origin/main` @ `9c29df6`; after is this branch @ `2ed6449` (working tree byte-identical to the commit — `git status` and `git diff HEAD` both empty at build time).

| | before (`9c29df6`) | after (`2ed6449`) |
|---|---|---|
| bytes on the wire | **4,608,768** | **671,413** |
| `# ` lines | 641 | 93 |
| CJK/Kana/Hangul occurrences | 170,658 | 24 |

85.4% smaller — a 6.9x reduction. The 4,608,768 / 641 figures reproduce the measurement in the issue exactly.

### Locale composition

Per locale: how many of that locale's frontmatter titles appear as a `# ` line in the served body. `exclusive` counts only titles no other locale shares, which is the number that actually settles whether a locale's pages are in the payload.

| locale | files | titles present before | titles present after | exclusive before | exclusive after |
|---|---|---|---|---|---|
| en | 79 | 79 | **79** | 63 | **63** |
| zh-Hans | 62 | 62 | 9 | 53 | **0** |
| ja | 39 | 39 | 7 | 31 | **0** |
| de | 38 | 38 | 13 | 25 | **0** |
| es | 39 | 39 | 7 | 32 | **0** |
| fr | 39 | 39 | 11 | 28 | **0** |
| ko | 39 | 39 | 7 | 31 | **0** |

Every English page is still served; **no locale-exclusive title from any of the six non-default locales survives**. The residual per-locale "titles present" counts are titles that are identical to their English original (proper nouns, `ObjectOS`, untranslated headings) — which is why their exclusive count is zero.

The 24 remaining CJK occurrences are English-source content, not locale pages: Chinese vendor names in the embedding-provider table (`阿里通义 DashScope`, `智谱 GLM`, `硅基流动 SiliconFlow`, `火山 Doubao`) and two glossed approval terms (`意见正文`, `会签`). They are present in the English `.mdx` on `main`.

One correction to the issue: it estimated English-only at "roughly a quarter". It is closer to **one seventh** (14.6%) — 256 of the 335 files are translations, and the CJK ones cost ~3 bytes per character.

## PM assumptions, tested

1. **"Root cause identical to `llms.txt`'s — a missing locale argument, not a second defect."** Confirmed. The single missing argument accounts for the whole delta; nothing else in the route was locale-aware.
2. **"No consumer depends on `llms-full.txt` carrying every locale."** Confirmed by grep. Only two references exist in the repo: the comment in `app/robots.ts`, and the sentence in `llms.txt` telling readers that `/llms-full.txt` carries the full text of every page — which describes the pages `llms.txt` itself lists (English), so it reads *more* accurately after this change, not less. The marketing site (`www.objectos.ai`) has its own separate `/llms.txt` and does not consume this endpoint.

## Gates

`type-check` (`fumadocs-mdx && next typegen && tsc --noEmit`) green; `build` green; `check-node-floor.mjs` green; `check-translations.mjs` green; `check-translation-ownership.mjs` green (0 translation artifacts, 1 other file). `turbo run test` is a no-op — no package in this repo implements a `test` task.

Scope: one file, `apps/docs/app/llms-full.txt/route.ts`. `apps/docs/lib/source.ts` was read but not edited (#166 owns it); no change inside it was needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_