### PR TITLE
feat(docs): give docs pages an SEO title, Open Graph, and structured data

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -1,4 +1,4 @@
-import { source } from '@/lib/source';
+import { SITE_NAME, getPageImage, source } from '@/lib/source';
 import type { Metadata } from 'next';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
 import { notFound } from 'next/navigation';
@@ -9,7 +9,118 @@ import { File, Folder, Files } from 'fumadocs-ui/components/files';
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { LLMCopyButton, ViewOptions } from '@/components/ai/page-actions';
 import { gitConfig } from '@/lib/layout.shared';
-import { languageAlternates, localeUrl, translatedLocales } from '@/lib/seo';
+import { SITE_URL, languageAlternates, localeUrl, translatedLocales } from '@/lib/seo';
+import type { InferPageType } from 'fumadocs-core/source';
+
+/**
+ * The page type the loader actually produces, frontmatter schema included.
+ *
+ * Deliberately inferred rather than hand-written: a structural annotation like
+ * `{ data: { seoTitle?: string } }` would type-check whether or not the schema
+ * extension in `source.config.ts` ever reached the generated collection types,
+ * which is exactly the thing that has to be true for `seoTitle` to arrive.
+ * Inferring it means `tsc` fails if the field is not really there.
+ */
+type DocsPageData = InferPageType<typeof source>;
+
+/** Logical, locale-independent path of a docs page, e.g. `docs/build/interface/views`. */
+function docsPath(slugs: string[]): string {
+  return ['docs', ...slugs].join('/');
+}
+
+/**
+ * The string the `<title>` tag should carry. A page may declare `seoTitle` when
+ * its H1 noun is too short to match anything a reader would search for; most
+ * pages declare nothing and fall back to `title`, rendering byte-identically to
+ * before this field existed. `??` is safe rather than lax because the schema
+ * rejects an empty or whitespace-only `seoTitle` at build time.
+ */
+function seoTitleOf(page: DocsPageData): string {
+  return page.data.seoTitle ?? page.data.title;
+}
+
+/** Absolute URL of the generated 1200x630 share card for a page. */
+function shareCardUrl(page: DocsPageData): string {
+  return `${SITE_URL}${getPageImage(page).url}`;
+}
+
+/**
+ * Open Graph wants `language_TERRITORY`. Our locale tags carry no territory
+ * (`en`, `zh-Hans`, `ja`, …), so the honest mapping is the tag with the
+ * separator swapped — the same one the marketing site emits, which keeps
+ * og:locale consistent across the two properties.
+ */
+function ogLocale(lang: string): string {
+  return lang.replace('-', '_');
+}
+
+/** `record-access` -> `Record access`, for a path segment with no page to name it. */
+function humanizeSegment(segment: string): string {
+  const spaced = segment.replace(/-/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Serialize a JSON-LD node for injection into a `<script>` tag.
+ *
+ * Every `<` is rewritten to the six-character JSON escape backslash-u-0-0-3-c,
+ * which parses back to the same character but cannot be read as markup. Without
+ * it a closing script tag inside a title or description would end the block
+ * early and drop the rest of the JSON into the document as markup.
+ */
+function jsonLdHtml(value: Record<string, unknown>): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+/**
+ * `BreadcrumbList` over the page's own ancestry: the docs root, then every
+ * prefix of its slugs. Each crumb is named by the page that actually sits at
+ * that path so the name matches what a reader sees in the sidebar; a folder
+ * with no index page falls back to its humanized segment.
+ */
+function breadcrumbListLd(lang: string, slugs: string[]): Record<string, unknown> {
+  const trails = [[] as string[], ...slugs.map((_, i) => slugs.slice(0, i + 1))];
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: trails.map((trail, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name:
+        source.getPage(trail, lang)?.data.title ??
+        humanizeSegment(trail[trail.length - 1] ?? 'docs'),
+      item: localeUrl(lang, docsPath(trail)),
+    })),
+  };
+}
+
+/**
+ * `TechArticle` for a docs page.
+ *
+ * Deliberately carries no `publisher`/`author`: those are entity-level claims
+ * about the organization, and which entity this site speaks for is the open
+ * question on the positioning card. A TechArticle without them is valid; a
+ * TechArticle asserting the wrong entity would have to be retracted.
+ */
+function techArticleLd(args: {
+  lang: string;
+  title: string;
+  description?: string;
+  url: string;
+  image: string;
+}): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: args.title,
+    ...(args.description ? { description: args.description } : {}),
+    url: args.url,
+    image: args.image,
+    inLanguage: args.lang,
+    isAccessibleForFree: true,
+  };
+}
 
 export default async function Page(props: {
   params: Promise<{ lang: string; slug?: string[] }>;
@@ -20,33 +131,58 @@ export default async function Page(props: {
 
   const MDX = page.data.body;
 
+  // Structured data. Emitted from the page rather than from `generateMetadata`,
+  // which can only produce meta/link elements — the Metadata API has no channel
+  // for a JSON-LD script. Google reads `application/ld+json` from either the
+  // head or the body, so rendering it here is a supported placement, not a
+  // workaround.
+  const jsonLd = [
+    breadcrumbListLd(params.lang, page.slugs),
+    techArticleLd({
+      lang: params.lang,
+      title: seoTitleOf(page),
+      description: page.data.description,
+      url: localeUrl(params.lang, docsPath(page.slugs)),
+      image: shareCardUrl(page),
+    }),
+  ];
+
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
-      <DocsTitle>{page.data.title}</DocsTitle>
-      <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
-      <div className="flex flex-row gap-2 items-center border-b pb-6">
-        <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
-        <ViewOptions
-          markdownUrl={`${page.url}.mdx`}
-          githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
+    <>
+      {jsonLd.map((item) => (
+        <script
+          key={item['@type'] as string}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLdHtml(item) }}
         />
-      </div>
-      <DocsBody>
-        <MDX
-          components={getMDXComponents({
-            a: createRelativeLink(source, page),
-            Step,
-            Steps,
-            File,
-            Folder,
-            Files,
-            FileTree: Files,
-            Tab,
-            Tabs,
-          })}
-        />
-      </DocsBody>
-    </DocsPage>
+      ))}
+      <DocsPage toc={page.data.toc} full={page.data.full}>
+        <DocsTitle>{page.data.title}</DocsTitle>
+        <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
+        <div className="flex flex-row gap-2 items-center border-b pb-6">
+          <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
+          <ViewOptions
+            markdownUrl={`${page.url}.mdx`}
+            githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
+          />
+        </div>
+        <DocsBody>
+          <MDX
+            components={getMDXComponents({
+              a: createRelativeLink(source, page),
+              Step,
+              Steps,
+              File,
+              Folder,
+              Files,
+              FileTree: Files,
+              Tab,
+              Tabs,
+            })}
+          />
+        </DocsBody>
+      </DocsPage>
+    </>
   );
 }
 
@@ -62,17 +198,40 @@ export async function generateMetadata(props: {
   if (!page) notFound();
 
   // Logical path is locale-independent; reconstruct each locale URL from slugs.
-  const path = ['docs', ...page.slugs].join('/');
+  const path = docsPath(page.slugs);
+  const canonical = localeUrl(params.lang, path);
+  const title = seoTitleOf(page);
+  const description = page.data.description;
+  const image = shareCardUrl(page);
 
   return {
-    title: page.data.title,
-    description: page.data.description,
+    title,
+    description,
     alternates: {
-      canonical: localeUrl(params.lang, path),
+      canonical,
       // Only the locales that really have this page. The cluster is keyed by
       // the logical path, not by params.lang, so every page in it advertises
       // the same reciprocal set.
       languages: languageAlternates(path, translatedLocales(page.slugs)),
+    },
+    openGraph: {
+      type: 'article',
+      url: canonical,
+      siteName: SITE_NAME,
+      // Set explicitly rather than inherited: the root layout's `%s | ObjectOS`
+      // template belongs on the title tag, where the brand suffix helps. Here
+      // `siteName` already carries the brand, so repeating it would render
+      // "Views | ObjectOS — ObjectOS" in a share preview.
+      title,
+      description,
+      locale: ogLocale(params.lang),
+      images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [image],
     },
   };
 }

--- a/apps/docs/app/og/docs/[...slug]/route.tsx
+++ b/apps/docs/app/og/docs/[...slug]/route.tsx
@@ -1,4 +1,4 @@
-import { getPageImage, source } from '@/lib/source';
+import { SITE_NAME, getPageImage, source } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { ImageResponse } from 'next/og';
 import { generate as DefaultImage } from 'fumadocs-ui/og';
@@ -17,7 +17,7 @@ export async function GET(
     <DefaultImage
       title={page.data.title}
       description={page.data.description}
-      site="ObjectStack Protocol"
+      site={SITE_NAME}
     />,
     {
       width: 1200,

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -10,6 +10,20 @@ export const source = loader({
   plugins: [lucideIconsPlugin()],
 });
 
+/**
+ * The product name, as it should appear to a reader — in `og:site_name`, on the
+ * generated share card, anywhere the brand is spelled out.
+ *
+ * It is a constant rather than a literal at each use site because the two use
+ * sites had already drifted: the share-card generator was passing "ObjectStack
+ * Protocol", a different product, while the metadata said "ObjectOS". One
+ * exported string is what stops the next consumer from inventing a fourth
+ * spelling. It lives here, next to `getPageImage`, because `lib/seo.ts` — the
+ * other plausible home — imports this module, and putting it there would make
+ * the dependency circular.
+ */
+export const SITE_NAME = 'ObjectOS';
+
 export function getPageImage(page: InferPageType<typeof source>) {
   const segments = [...page.slugs, 'image.png'];
 

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -5,7 +5,36 @@ import path from 'node:path';
 export const docs = defineDocs({
   dir: path.resolve(process.cwd(), '../../content/docs'),
   docs: {
-    schema: pageSchema,
+    schema: pageSchema.extend({
+      /**
+       * Optional SEO title: what the `<title>` tag should say, when that is not
+       * what the H1 and the sidebar should say.
+       *
+       * `title` stays the short navigational noun ("Views") because it is what
+       * renders in the sidebar, the breadcrumb and the H1. That same noun makes
+       * a title tag carrying no query term at all, so a page may declare a
+       * longer, keyword-bearing `seoTitle` here and `generateMetadata` prefers
+       * it. Declaring nothing is the norm: the fallback is `title`, so a page
+       * that says nothing renders exactly what it rendered before.
+       *
+       * Extending is not optional bookkeeping — the base `pageSchema` is a Zod
+       * object with the default "strip" behaviour, so a `seoTitle:` in
+       * frontmatter that is not declared here is silently dropped at parse time
+       * rather than reaching `page.data`.
+       *
+       * Built from `pageSchema.shape.title` rather than a fresh `z.string()`
+       * because `zod` is a *peer* dependency of fumadocs-core and is not
+       * resolvable from this workspace — `require.resolve('zod')` fails in
+       * `apps/docs`. Reusing the shape keeps the field's type identical to
+       * `title`'s without adding a dependency to declare it.
+       *
+       * `.trim().min(1)` is deliberate: an empty or whitespace-only `seoTitle`
+       * is an authoring mistake, and rejecting it at build time is what lets
+       * the consumer use a plain `??` fallback instead of a tolerant one that
+       * would quietly paper over the empty string.
+       */
+      seoTitle: pageSchema.shape.title.trim().min(1).optional(),
+    }),
     postprocess: {
       includeProcessedMarkdown: true,
     },


### PR DESCRIPTION
Fixes #166

`generateMetadata` returned four fields, so all 79 English pages and every translation shipped a title tag built from the short navigational noun, no share card, and no structured data. This adds the mechanism for all three. It authors no content.

## What changed

**An optional `seoTitle` frontmatter field** (`apps/docs/source.config.ts`). `generateMetadata` prefers it and falls back to `title`, so the sidebar, breadcrumb and H1 keep the short noun while the title tag can carry query terms. `DocsTitle` still renders `page.data.title` and is untouched.

**Open Graph and Twitter** (`page.tsx`), pointed at the 1200x630 card that `app/og/docs/[...slug]/route.tsx` was already generating for every page and that nothing referenced. Uses the existing `getPageImage()` helper and the per-locale canonical URL already computed in `generateMetadata`.

**JSON-LD**: `BreadcrumbList` from the slug segments and `TechArticle` per page. Those two only.

**The share card's `site=` string**, which said "ObjectStack Protocol" — a different product. It now reads one exported `SITE_NAME` constant, so the two use sites cannot drift into a fourth spelling of the brand.

## Three decisions worth a reviewer's eye

**The schema extension imports no zod.** `pageSchema` is a Zod object, so `.extend()` is the right mechanism — but `zod` is a *peer* dependency of fumadocs-core and is not resolvable from `apps/docs` (`require.resolve('zod')` fails there). Adding it would have meant touching `package.json` and the lockfile, outside this card's file surface. The field is therefore built from `pageSchema.shape.title`, which is already the exact string schema wanted:

```
seoTitle: pageSchema.shape.title.trim().min(1).optional(),
```

`.trim().min(1)` is deliberate. An empty or whitespace-only `seoTitle` is rejected at build time, which is what lets the consumer use a plain `??` fallback instead of a tolerant one that would quietly paper over the empty string.

**JSON-LD renders in the body, not the head.** The Metadata API has no channel for a script element — it emits meta and link only — so the two blocks are rendered from the page component. Google reads `application/ld+json` from either the head or the body, and this is the placement Next.js documents. Flagging it because the card's Verification section asks for the document head specifically; the blocks are present and valid, one level down from where that sentence reads.

**`TechArticle` carries no `publisher` or `author`.** Those are entity-level claims about the organization, and which entity this site speaks for is the open question on #171. A `TechArticle` without them is valid; one asserting the wrong entity would have to be retracted.

## Verification

Gates run at `2d8e409`, the final commit on this branch:

| gate | result |
|---|---|
| `pnpm --filter @objectos/docs run type-check` | `VERDICT command-exit 0` |
| `pnpm --filter @objectos/docs run build` | `VERDICT command-exit 0` |
| `pnpm turbo run test` | `VERDICT command-exit 0` |
| `node .github/scripts/check-node-floor.mjs` | exit 0, "Every declared floor clears what the dependency tree requires" |
| `node .github/scripts/check-translations.mjs` | exit 0, "translations gate passed" |

Read out of the prerendered HTML rather than the source, per the card.

**Nested page** — `.next/server/app/en/docs/build/interface/views.html`:

```
title           Views | ObjectOS
og:title        Views
og:image        https://docs.objectos.ai/og/docs/build/interface/views/image.png
og:url          https://docs.objectos.ai/docs/build/interface/views
og:type         article
og:site_name    ObjectOS
og:locale       en
twitter:card    summary_large_image
```

Both JSON-LD blocks present and parsing as valid JSON, with breadcrumb names resolved from the real pages at each path:

```
1 | ObjectOS  | https://docs.objectos.ai/docs
2 | Build     | https://docs.objectos.ai/docs/build
3 | Interface | https://docs.objectos.ai/docs/build/interface
4 | Views     | https://docs.objectos.ai/docs/build/interface/views
```

**Index pages** — `/docs/build/interface` gives a 3-item trail and a `TechArticle` headline of "Interface"; the docs root `/docs` gives a 1-item trail. Both carry both blocks, both valid.

**Per-locale**: `/ja/...` emits `og:locale ja` and a `TechArticle` `inLanguage: ja` with the `/ja/` URL; `zh-Hans` maps to `zh_Hans`.

**No page regresses.** Across all 79 built English pages, the title tag equals the frontmatter title followed by ` | ObjectOS` — 79 of 79 matched, 0 mismatched. Nothing declares a `seoTitle` yet, so nothing changed.

**The declared path works.** No content page declares `seoTitle` (that is #167, and this card authors no content), so the distinct-title path was verified with a temporary mutation that was measured and reverted, not committed. Adding a `seoTitle` to one page and rebuilding:

```
title tag             Kanban, List and Calendar Views for Self-Hosted Internal Tools | ObjectOS
og:title              Kanban, List and Calendar Views for Self-Hosted Internal Tools
TechArticle headline  Kanban, List and Calendar Views for Self-Hosted Internal Tools
last breadcrumb crumb Views
rendered H1           Views
```

The title tag, `og:title` and the article headline follow the declared value while the H1 and the breadcrumb keep the short noun — the separation this card exists to create. The file was then restored and proven byte-identical to its HEAD blob, with `git status -- content/docs` empty.

**Reverse verification of the schema wiring.** Removing the `seoTitle` extension from `source.config.ts` and re-running `type-check` goes red, naming the field:

```
error TS2339: Property 'seoTitle' does not exist on type 'DocCollectionEntry<"docs",
{ title: string; description?: string | undefined; ... }>'
```

The error prints the schema-derived frontmatter type without the field, which is direct evidence that `page.data.seoTitle` resolves against the generated collection type rather than a permissive `any`. The mutation was confirmed on disk by hash before the run, and the restore confirmed against the HEAD blob after it. The page helpers take the inferred `InferPageType` for this reason — a hand-written structural annotation would have type-checked whether or not the extension ever reached the generated types.

**The OG route still builds for every page**: `/og/docs/[...slug]` prerendered 79 paths.

## Scope

Untouched on purpose: `alternates.canonical` and `alternates.languages`, both settled by #176; `languageAlternates()`, at its final signature; `content/docs/**`, which is #167's job. #174 is not addressed here and remains open. Entity-level `Organization` / `SoftwareApplication` markup is left out pending #171.

Filed while here and left for triage, deliberately untouched by this branch: #185 — every locale's `og:image` resolves to the same English card, because the card URL carries no language and the route resolves the page without one. Dormant before this PR since nothing emitted `og:image`; visible now.

Files changed are the four in this card's declared surface, no more.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_