### PR TITLE
fix(docs): point an untranslated locale URL at the English page it serves

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -10,6 +10,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { LLMCopyButton, ViewOptions } from '@/components/ai/page-actions';
 import { gitConfig } from '@/lib/layout.shared';
 import { SITE_URL, languageAlternates, localeUrl, translatedLocales } from '@/lib/seo';
+import { i18n } from '@/lib/i18n';
 import type { InferPageType } from 'fumadocs-core/source';
 
 /**
@@ -45,6 +46,37 @@ function shareCardUrl(page: DocsPageData): string {
 }
 
 /**
+ * The locale a page's content actually lives in, as seen from `lang`.
+ *
+ * `lang` when that locale really has a translation of `slugs`; the default
+ * language otherwise, because fumadocs serves the English body under every
+ * unprefixed locale route (`fallbackLanguage` resolves to `defaultLanguage` —
+ * see `translatedLocales`). `/ja/docs/operate/backup` has no Japanese source,
+ * so the content sitting at that URL is the English page and every field that
+ * names where this content lives has to say so.
+ *
+ * `translated` is passed in rather than looked up so a caller that already
+ * needs the list — `generateMetadata` builds the hreflang cluster from it —
+ * computes it once.
+ */
+function canonicalLocale(lang: string, translated: readonly string[]): string {
+  return translated.includes(lang) ? lang : i18n.defaultLanguage;
+}
+
+/**
+ * Absolute URL of the page at `slugs` as seen from `lang`: its own locale URL
+ * when it is really translated there, the English URL when it is a fallback.
+ *
+ * Resolved per page, not once per request, because translation status is a
+ * property of the individual page. A translated page can sit under an
+ * untranslated ancestor and vice versa, so the breadcrumb trail has to ask
+ * about each crumb separately.
+ */
+function canonicalUrl(lang: string, slugs: string[]): string {
+  return localeUrl(canonicalLocale(lang, translatedLocales(slugs)), docsPath(slugs));
+}
+
+/**
  * Open Graph wants `language_TERRITORY`. Our locale tags carry no territory
  * (`en`, `zh-Hans`, `ja`, …), so the honest mapping is the tag with the
  * separator swapped — the same one the marketing site emits, which keeps
@@ -77,6 +109,11 @@ function jsonLdHtml(value: Record<string, unknown>): string {
  * prefix of its slugs. Each crumb is named by the page that actually sits at
  * that path so the name matches what a reader sees in the sidebar; a folder
  * with no index page falls back to its humanized segment.
+ *
+ * `item` is each crumb's own canonical URL, resolved crumb by crumb: a
+ * breadcrumb entry is a claim about where *that* page lives, and pointing it at
+ * a locale URL that only serves an English fallback is the same untruth the
+ * page's own canonical would be telling.
  */
 function breadcrumbListLd(lang: string, slugs: string[]): Record<string, unknown> {
   const trails = [[] as string[], ...slugs.map((_, i) => slugs.slice(0, i + 1))];
@@ -90,7 +127,7 @@ function breadcrumbListLd(lang: string, slugs: string[]): Record<string, unknown
       name:
         source.getPage(trail, lang)?.data.title ??
         humanizeSegment(trail[trail.length - 1] ?? 'docs'),
-      item: localeUrl(lang, docsPath(trail)),
+      item: canonicalUrl(lang, trail),
     })),
   };
 }
@@ -131,6 +168,13 @@ export default async function Page(props: {
 
   const MDX = page.data.body;
 
+  // The locale this page's content really lives in — `params.lang` for a real
+  // translation, English for a fumadocs fallback. `url` and `inLanguage` are
+  // properties of one `TechArticle` node, so they resolve together: a node that
+  // named the English URL while claiming `inLanguage: "ja"` would assert that
+  // the English page is Japanese.
+  const contentLang = canonicalLocale(params.lang, translatedLocales(page.slugs));
+
   // Structured data. Emitted from the page rather than from `generateMetadata`,
   // which can only produce meta/link elements — the Metadata API has no channel
   // for a JSON-LD script. Google reads `application/ld+json` from either the
@@ -139,10 +183,10 @@ export default async function Page(props: {
   const jsonLd = [
     breadcrumbListLd(params.lang, page.slugs),
     techArticleLd({
-      lang: params.lang,
+      lang: contentLang,
       title: seoTitleOf(page),
       description: page.data.description,
-      url: localeUrl(params.lang, docsPath(page.slugs)),
+      url: localeUrl(contentLang, docsPath(page.slugs)),
       image: shareCardUrl(page),
     }),
   ];
@@ -199,7 +243,12 @@ export async function generateMetadata(props: {
 
   // Logical path is locale-independent; reconstruct each locale URL from slugs.
   const path = docsPath(page.slugs);
-  const canonical = localeUrl(params.lang, path);
+  const translated = translatedLocales(page.slugs);
+  // Where this content lives. An untranslated locale route serves the English
+  // body (fumadocs falls back), so it points at the English URL instead of
+  // declaring itself canonical — the fallback copy is not a separate page.
+  const contentLang = canonicalLocale(params.lang, translated);
+  const canonical = localeUrl(contentLang, path);
   const title = seoTitleOf(page);
   const description = page.data.description;
   const image = shareCardUrl(page);
@@ -211,11 +260,16 @@ export async function generateMetadata(props: {
       canonical,
       // Only the locales that really have this page. The cluster is keyed by
       // the logical path, not by params.lang, so every page in it advertises
-      // the same reciprocal set.
-      languages: languageAlternates(path, translatedLocales(page.slugs)),
+      // the same reciprocal set. Untouched by the fallback rule above: an
+      // untranslated locale is already absent from it, which is #169's settled
+      // shape and stays correct whatever `canonical` points at.
+      languages: languageAlternates(path, translated),
     },
     openGraph: {
       type: 'article',
+      // og:url is Open Graph's permanent id for the object, so it tracks
+      // `canonical` — an object identified by the English URL and by this
+      // locale's URL at the same time is two objects.
       url: canonical,
       siteName: SITE_NAME,
       // Set explicitly rather than inherited: the root layout's `%s | ObjectOS`
@@ -224,7 +278,11 @@ export async function generateMetadata(props: {
       // "Views | ObjectOS — ObjectOS" in a share preview.
       title,
       description,
-      locale: ogLocale(params.lang),
+      // The locale of the object og:url names, which is the English page when
+      // this route is a fallback. Not the same claim as `<html lang>`: that one
+      // describes the document being served, chrome included, and #181 settled
+      // it on the route segment.
+      locale: ogLocale(contentLang),
       images: [{ url: image, width: 1200, height: 630, alt: title }],
     },
     twitter: {


### PR DESCRIPTION
Fixes #174

Option A, per the adjudication comment on the card: when the current locale has no real translation of a page, every field that asserts where this content lives names the English URL instead of this locale's URL.

`/ja/docs/operate/backup` has no Japanese source. fumadocs falls back to the default language and serves the English body, so the URL was a second copy of the English page that declared itself canonical. #169 took it out of the sitemap and out of every hreflang cluster, but "no longer advertised" is not "no longer indexable" — the in-page language switcher links to it from every translated page.

The predicate is `translatedLocales(slugs)`, which landed with #169 and already computes exactly this. No second implementation.

## The set of URL-asserting fields, and what each one now emits

#166 landed after the card was written and put `openGraph`, `twitter` and two JSON-LD blocks into the same function, so the set is larger than the card describes. Enumerated so it can be checked rather than trusted. Example is `/ja/docs/operate/backup` (English-only page under a non-English prefix); "unchanged" means byte-identical to `23a976b`.

| Field | Asserts | Before | Now |
|---|---|---|---|
| `alternates.canonical` | where this page lives | `…/ja/docs/operate/backup` | `…/docs/operate/backup` |
| `openGraph.url` (`og:url`) | Open Graph's permanent id for the object | `…/ja/docs/operate/backup` | `…/docs/operate/backup` |
| `TechArticle.url` | where this article lives | `…/ja/docs/operate/backup` | `…/docs/operate/backup` |
| `BreadcrumbList` `item`, per crumb | where *that* crumb's page lives | `…/ja/docs`, `…/ja/docs/operate`, `…/ja/docs/operate/backup` | `…/ja/docs`, `…/docs/operate`, `…/docs/operate/backup` |
| `alternates.languages` (hreflang + x-default) | which locales really have this page | en + x-default only | **unchanged** — settled by #169; an untranslated locale is already absent |
| `openGraph.images` / `twitter.images` (`og:image`) | where the share card lives | `…/og/docs/operate/backup/image.png` | **unchanged** — locale-independent by construction (`getPageImage` takes no lang); that is #185's card, deliberately untouched |
| `TechArticle.image` | same share card | as above | **unchanged**, same reason |
| `LLMCopyButton` `markdownUrl`, `ViewOptions` `githubUrl` | in-page UI affordances | `/ja/docs/…mdx`, GitHub blob URL | **unchanged** — reading-experience links, not metadata claims. The GitHub URL already resolves to the English source, because `page.path` keeps the authored filename. |

Breadcrumb `item` resolves **crumb by crumb**, not once per request: a translated page can sit under an untranslated ancestor. `/ja/docs/configure/permissions/positions` is that case — the page and `configure/permissions` are both translated into Japanese, `configure` is not, so only the middle crumb moves to the English URL.

### Two fields that assert a language, not a URL, and why they moved anyway

`og:locale` and `TechArticle.inLanguage` sit on the same object as a URL that changed. Leaving them would have *introduced* an incoherence rather than found one: a `TechArticle` node naming the English URL while claiming `inLanguage: "ja"` asserts that the English page is Japanese. Both now describe the object their URL names — `en` on a fallback route, unchanged everywhere else.

`html lang` is a different claim — it describes the document being served, translated chrome included — and #181 settled it on the route segment. Untouched.

## Verification

Read out of the prerendered HTML in `.next/server/app`, not out of the source. Two production builds of the same tree, one at `23a976b` and one at `ea353af`, compared file by file.

**The three cases from the card.**

1. English-only page under a non-English prefix, `ja/docs/operate/backup.html` — `canonical`, `og:url`, `TechArticle.url` and the page's own crumb all moved to `https://docs.objectos.ai/docs/operate/backup`; `og:locale` and `inLanguage` moved `ja` to `en`; hreflang, both image URLs and `html lang` unchanged.
2. Fully translated page under a non-English prefix, `ja/docs/configure/permissions/positions.html` — `canonical` still self-referential and unchanged, as are `og:url`, `TechArticle.url`, `og:locale`, `inLanguage`, hreflang and the images. Only the `configure` crumb moved, which is the ancestor case above.
3. English page, `en/docs/operate/backup.html` — unchanged. All **81** English routes are byte-identical across every extracted field.

**Scale, against an independent oracle.** 218 of the 553 docs routes change `canonical`. The count of untranslated locale/page pairs, computed straight from `content/docs/` without going through the app code, is **also 218** (zh-Hans 17, ja 40, de 41, es 40, fr 40, ko 40). The number is equal, not merely bounded.

**No regression anywhere else.** Whole-document byte comparison of all 577 prerendered HTML files, normalizing only Next's per-build random `buildId` and the content-hashed asset names:

- 370 documents differ, 207 are byte-identical.
- 370 is again the oracle's number: a document differs iff some page in its ancestry is untranslated in its locale. Per locale — zh-Hans 30, ja 68, de 68, es 68, fr 68, ko 68 — matching the oracle exactly.
- Zero `en/` routes differ. Zero non-docs routes differ (locale home pages, privacy, terms, `_not-found`).
- Blanking absolute site URLs and the two language values makes the **rendered markup of all 370 byte-identical**. So every relative navigation href, the visible breadcrumb, and all body text are untouched — #169's constraint that the reading experience must not change holds.

**One residual difference, run down rather than waved past.** 47 documents also differ inside the RSC flight payload after that normalization. It is not build nondeterminism: two builds of the identical tree are byte-identical in all 577 files. It is React moving where it outlines a subtree into a lazy chunk, because the shortened URL strings shift every later write position. Concretely, on `de/docs/build/automation/approvals.html`, chunk `1d` goes from `["$","td",null,{"children":["$","strong",null,{"children":"Approver"}]}]` to `["$","strong",null,{"children":"Approver"}]` with the `td` inlined into the row — the same `td` containing the same `strong` containing the same text, with the chunk boundary one level lower. Checked mechanically across all 370: same element tags, same text leaves, zero documents with a genuinely different tree.

**Gates**, all on `ea353af`, exit codes captured before any pipe:

- `pnpm turbo run type-check --continue` — `Tasks: 1 successful, 1 total`, `Cached: 0 cached, 1 total` (executed, not replayed)
- `pnpm turbo run build` — `Tasks: 1 successful, 1 total`, `Cached: 0 cached, 1 total`, 47.9s
- `pnpm turbo run test --force` — `Tasks: 1 successful, 1 total`, `cache bypass, force executing`
- `node .github/scripts/check-node-floor.mjs` — "Every declared floor clears what the dependency tree requires, and the declarations agree."
- `node .github/scripts/check-translations.mjs` — "translations gate passed"
- `node .github/scripts/check-translation-ownership.mjs --actor … --files …` — "This PR touches 0 translation artifact(s) and 1 other file(s)."

`tsc --noEmit --listFiles` confirms `page.tsx` is genuinely in the type-check program, so the green covers the edited file rather than merely excluding it.

## Scope

One file: `apps/docs/app/[lang]/docs/[[...slug]]/page.tsx`. `lib/seo.ts` is read, not edited — `translatedLocales` is used as it landed. `lib/source.ts` and the OG route are untouched (#185). No changeset flow in this repo, no `packages/`.

Filed while implementing, not fixed here: #187 — `BreadcrumbList` advertises `/docs/reference` and `/docs/resources` as crumb items on 98 prerendered pages, and neither path has a page in any locale. Pre-existing since #166; this PR changes which dead URL is emitted, not the fact that it is dead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_