### PR TITLE
fix(docs): stop advertising breadcrumb crumbs for paths that have no page

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -86,12 +86,6 @@ function ogLocale(lang: string): string {
   return lang.replace('-', '_');
 }
 
-/** `record-access` -> `Record access`, for a path segment with no page to name it. */
-function humanizeSegment(segment: string): string {
-  const spaced = segment.replace(/-/g, ' ');
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
-
 /**
  * Serialize a JSON-LD node for injection into a `<script>` tag.
  *
@@ -106,27 +100,55 @@ function jsonLdHtml(value: Record<string, unknown>): string {
 
 /**
  * `BreadcrumbList` over the page's own ancestry: the docs root, then every
- * prefix of its slugs. Each crumb is named by the page that actually sits at
- * that path so the name matches what a reader sees in the sidebar; a folder
- * with no index page falls back to its humanized segment.
+ * prefix of its slugs *that has a page of its own*. Each crumb is named by the
+ * page sitting at that path, so the name matches what a reader sees in the
+ * sidebar.
  *
- * `item` is each crumb's own canonical URL, resolved crumb by crumb: a
- * breadcrumb entry is a claim about where *that* page lives, and pointing it at
- * a locale URL that only serves an English fallback is the same untruth the
- * page's own canonical would be telling.
+ * A prefix with no page is not emitted at all. `content/docs/meta.json`
+ * declares `reference` and `resources` as sidebar folders and neither has an
+ * `index.mdx`, so a trail through them was advertising a path that 404s in
+ * every locale. `item` is defined as the URL of the page the crumb names, so a
+ * crumb whose URL resolves to nothing is not a weaker claim than a good one but
+ * a false one — and a consumer may drop the whole trail rather than the single
+ * entry. Keeping the step and omitting only its `item` is schema.org-legal, but
+ * it trades a false URL for a `ListItem` missing a field that is expected on
+ * every entry except the last, so the crumb goes rather than the URL.
+ *
+ * Positions are assigned after the drop, so a trail that lost a middle crumb is
+ * numbered 1..n with no hole. `position` is an ordinal within this list — 1
+ * signifies the beginning of the trail — not an index into the folder
+ * hierarchy: a gap would assert an element the consumer was not sent, which is
+ * the same false claim moved into a different field.
+ *
+ * The check costs nothing at request time. `source.getPage()` is the in-memory
+ * resolver this function already called to name each crumb; it is now called
+ * once per crumb and answers both questions. Because fumadocs seeds every
+ * locale's file system from English and lets real translations overwrite it
+ * (see `translatedLocales`), it resolves whenever *any* locale has the page —
+ * so a crumb is dropped only where the path has no page anywhere, and the
+ * surviving trail is identical across the seven locales. Give those two folders
+ * an `index.mdx` later and their crumbs reappear with no change here.
+ *
+ * Existence and translation are separate questions, asked in that order. A
+ * crumb that survives is then pointed at its own canonical URL crumb by crumb:
+ * a breadcrumb entry is a claim about where *that* page lives, so it names this
+ * locale's URL when the locale really has that page and the English URL when it
+ * would only be serving the English fallback.
  */
 function breadcrumbListLd(lang: string, slugs: string[]): Record<string, unknown> {
   const trails = [[] as string[], ...slugs.map((_, i) => slugs.slice(0, i + 1))];
+  const crumbs = trails.flatMap((trail) => {
+    const page = source.getPage(trail, lang);
+    return page ? [{ trail, page }] : [];
+  });
 
   return {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
-    itemListElement: trails.map((trail, index) => ({
+    itemListElement: crumbs.map(({ trail, page }, index) => ({
       '@type': 'ListItem',
       position: index + 1,
-      name:
-        source.getPage(trail, lang)?.data.title ??
-        humanizeSegment(trail[trail.length - 1] ?? 'docs'),
+      name: page.data.title,
       item: canonicalUrl(lang, trail),
     })),
   };


### PR DESCRIPTION
Fixes #187

`breadcrumbListLd` built one `ListItem` per slug prefix unconditionally, so a folder with no `index.mdx` was advertised in JSON-LD as a page that exists. `content/docs/reference/` and `content/docs/resources/` are the only two sections without one, which put a dead `item` URL on 98 prerendered pages — the only two dead URLs on the site's structured data.

Each prefix is now resolved through `source.getPage()` and a crumb with no page behind it is not emitted. Per the adjudication on the card, this is the code fix only: `content/docs/**` is not in the diff, and index pages for those two folders remain a separate content decision waiting on #171. If they are ever added, their crumbs reappear with no change here — the resolver simply starts returning a page.

## What happens to a dropped middle crumb

**The crumb goes, not just its `item`, and the survivors renumber to stay contiguous.** Both halves of that are deliberate.

*Why drop the whole crumb.* `ListItem` does permit `name` without `item`, and that is the smaller diff. But `item` is expected on every entry in a breadcrumb trail except the last, so a middle entry carrying only a name trades a false URL for a structurally incomplete entry — the same risk of the consumer discarding the whole trail that the dead URL created. Dropping the crumb leaves every remaining entry complete and every remaining claim true. It also reads correctly against the definition: a `BreadcrumbList` describes a navigation path, and a step no reader can navigate to is not part of any path.

*Why renumber rather than leave a gap.* `position` is an ordinal within this list — position 1 signifies the beginning of the trail — not an index into the folder hierarchy. A trail numbered 1, 3 asserts that a second element exists and was not delivered, which re-states in the `position` field exactly the claim the fix removed from `item`. So positions are assigned after the drop and the trail is numbered 1..n. Nothing else needs to stay in sync: the node carries no `numberOfItems`.

## Interaction with #174

`5602623` made each crumb resolve its own URL, pointing an untranslated crumb at the English page it actually serves. That rule and this one both act per crumb, so they are ordered rather than combined: **existence first, translation second.** A crumb is emitted only if a page resolves at that path; only then is it asked which locale's URL it should name.

This makes the both-untranslated-and-nonexistent case a single decision instead of two competing ones. Before, `/ja/docs/reference/cli` emitted a `reference` crumb pointed at `https://docs.objectos.ai/docs/reference` — #174's fallback rule firing on a path with no translation anywhere, and producing the English form of a URL that 404s. Now the crumb is gone before that rule is consulted:

```
ja/docs/reference/cli.html
  before                                  after
  1  ObjectOS      /ja/docs               1  ObjectOS      /ja/docs
  2  Reference     /docs/reference        …  (dropped)
  3  CLI Reference /docs/reference/cli    2  CLI Reference /docs/reference/cli
```

Position 1 still carries the Japanese URL (the docs index is translated) and position 2 still carries the English URL (`reference/cli` is not) — #174's behaviour intact on both, on either side of the crumb that was removed.

One property worth naming: because fumadocs seeds every locale's file system from English and lets real translations overwrite it, `source.getPage()` resolves whenever *any* locale has the page. So the existence check is locale-invariant — the set of crumbs is the same in all seven locales and only their URLs differ. That is why the 14 affected English pages map to exactly 98 prerendered ones.

## Verification

Read from the prerendered HTML of a full production build, not from the source: `.next/server/app/**/*.html`, then every `application/ld+json` block, then the `BreadcrumbList` node. Before = `5602623` (this branch's base), after = `bc166ca` (this branch's head, rebuilt clean after the commit). The oracle is computed straight from `content/docs/` — walking the `.mdx` files, deriving slugs and locale tags, and asking which ancestry prefixes have no file in any locale — with no app code, no fumadocs and no build output involved.

| | |
|---|---|
| Pages emitting a `BreadcrumbList` | 553 before, 553 after (no page lost its node) |
| Oracle: pages carrying a dead crumb | **98** |
| Measured: pages whose trail changed | **98** |
| Set equality, not a bound | **PASS** — the two sets are identical, page for page |
| Total crumbs | 1701 before, 1603 after, exactly 98 removed |
| Pages byte-identical before/after | 455 ( = 553 − 98 ) |
| Dead `item` URLs remaining | 0 |

Distinct dead prefixes found by the oracle: `reference` (9 English pages) and `resources` (5) — 14 × 7 locales = 98, matching the card's count exactly.

Three further assertions, each over all 553 pages:

- **After == before minus the dead crumbs, renumbered.** For every page, the emitted trail equals the baseline trail with dead entries filtered out and positions reassigned 1..n. No surviving crumb's `name` or `item` moved. **PASS**
- **No page with an already-valid trail lost a crumb.** The 455 pages whose oracle trail was fully live are byte-identical to baseline; the changed set contains only pages the oracle marks. **PASS**
- **#174's rule recomputed independently.** For all 1603 crumbs in the new build, the expected `item` was recomputed from the filesystem — this locale's URL when a real translated file exists for that path, the English URL otherwise — and compared against what was actually emitted. **PASS**, no mismatches. (The first run of this check reported 553 failures, all of them a trailing-slash bug in the oracle's own root-path join, not in the app; fixed in the oracle and re-run.)

Gates run locally at `bc166ca`, matching what CI's `build` job runs:

- `pnpm type-check` (`fumadocs-mdx`, `next typegen`, `tsc --noEmit`) — exit 0, captured before any pipe. Confirmed the edited file is genuinely in the compilation with `tsc --listFiles` (1 hit), rather than assuming it.
- `pnpm build` — `✓ Compiled successfully in 32.8s`, 553 docs pages prerendered.
- `pnpm turbo run test --force` — 2 self-tests passed, `0 cached` (the cached replay was rejected and re-run, per the turbo-cache warning in AGENTS.md).

## Notes

- One file changed: `apps/docs/app/[lang]/docs/[[...slug]]/page.tsx`. No `content/docs/**`, no `lib/source.ts`, no OG route — #185 is queued behind this card on those.
- `humanizeSegment` is removed. Its only caller was the crumb name's `??` fallback, which fired exactly when a prefix had no page; now no such crumb is emitted, so the branch is unreachable. A page's `title` is required by `pageSchema`, so a resolved crumb always has a name. Leaving the helper would have left a documented fallback for a case the new invariant forbids.
- No changeset: this repo has no changeset flow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_