### PR TITLE
fix(docs): reject a non-locale first segment at the route level

### DIFF
--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -20,13 +20,13 @@ const LANGUAGE_NAMES: Record<string, string> = {
  * locale is used verbatim — `zh-Hans` in particular is the correct tag and is
  * deliberately not rewritten to `zh-CN`.
  *
- * The `[lang]` segment is dynamic, so it is not guaranteed to hold one of them.
- * `middleware.ts` normalises every path it sees, but its matcher skips paths
- * containing a dot, so `/foo.bar/privacy` reaches this layout with `lang` set to
- * a string that is not a locale — and that route answers 200, it does not 404.
- * An arbitrary URL segment must not become the document's declared language, so
- * unsupported segments fall back to the default locale, which is the locale
- * `middleware.ts` would have chosen for that request anyway.
+ * `dynamicParams = false` below now means only an enumerated locale ever
+ * reaches this layout, so the fallback is unreachable in practice. It stays
+ * because this function has to be total over `string` — `lang` is typed as one
+ * — and because a language attribute is the wrong place to learn that a
+ * routing invariant broke. The default locale is what `middleware.ts` would
+ * have negotiated for such a request anyway, so the fallback is the quiet
+ * answer rather than a guess.
  */
 function documentLanguage(lang: string): string {
   return (i18n.languages as readonly string[]).includes(lang)
@@ -60,6 +60,49 @@ export default async function LanguageLayout({
   );
 }
 
+/**
+ * Only the locales `generateStaticParams` enumerates are servable under this
+ * segment; every other first segment is answered by the prerendered
+ * `/_not-found` route.
+ *
+ * `middleware.ts` is supposed to put a locale on every path, but its matcher
+ * exempts `.*\..*` — unanchored, so it skips any path containing a dot
+ * anywhere, not just an asset. A request whose *first* segment carries a dot
+ * therefore reaches these routes with `lang` set to something that is not a
+ * locale. Measured on the tree before this flag: `/foo.bar/privacy` and
+ * `/foo.bar/terms` rendered a full page and answered **200**, `/foo.bar`
+ * answered 307 to `/foo.bar/docs`, and `/favicon.ico` answered 307 to
+ * `/favicon.ico/docs`. An unbounded family of soft 404s — any dotted first
+ * segment produces another one — which for a docs site is a crawl-budget and
+ * duplicate-URL hole.
+ *
+ * The fix is here rather than in that matcher on purpose. The dot exemption is
+ * load-bearing for real **routes**, not only assets: `/llms.txt`,
+ * `/llms-full.txt`, `/sitemap.xml`, `/robots.txt` and every `.mdx` page route
+ * (`page.url` plus `.mdx`, which the copy button links to) all contain dots and
+ * are all exempted by it today. Tightening it would send those through locale
+ * negotiation, and `check-locale-surface.mjs` reads build output rather than a
+ * running server, so nothing in CI would report it. Rejecting the segment here
+ * also fixes strictly more, because it does not care how a bad segment arrived.
+ *
+ * **It has to be this flag and not `notFound()` in the layout.** That was
+ * measured, not assumed: with a `notFound()` guard here instead,
+ * `/foo.bar/privacy` answers 404 with a 594-byte empty error shell carrying no
+ * 404 copy at all, because `notFound()` raised while a request is rendered
+ * *dynamically* escapes both the RSC and the SSR render (#182 established this,
+ * and these URLs are dynamically rendered by construction — they are in no
+ * prerendered param set). The status would have looked correct and the body
+ * would have been blank. `dynamicParams = false` instead removes the dynamic
+ * render, routing the request to `/_not-found`, an ordinary prerendered page:
+ * the served document is byte-identical to the one `/no-such-page` has always
+ * returned.
+ *
+ * The behavioural cost, stated plainly: a locale that is not in `i18n.languages`
+ * needs a rebuild to appear. `lib/i18n.ts` is a checked-in constant and AGENTS.md
+ * names it the authority for the locale list, so that is already true in
+ * practice. `app/[lang]/docs/[[...slug]]/page.tsx` and `app/og/docs/[...slug]`
+ * set the same flag for the same reason.
+ */
 export const dynamicParams = false;
 
 export async function generateStaticParams() {

--- a/apps/docs/app/[lang]/layout.tsx
+++ b/apps/docs/app/[lang]/layout.tsx
@@ -60,6 +60,8 @@ export default async function LanguageLayout({
   );
 }
 
+export const dynamicParams = false;
+
 export async function generateStaticParams() {
   return i18n.languages.map((lang) => ({ lang }));
 }


### PR DESCRIPTION
Fixes #180

(Angle-bracket markup omitted throughout — this repo's sanitizer strips it, including inside code fences.)

One line ships: `export const dynamicParams = false` on `apps/docs/app/[lang]/layout.tsx`, direction 2 as adjudicated. All readings below are from `b61f04e`, the head of this branch, taken against `next start` on a production build — never read off the source.

## Read this first: half the card's premise is already dead

The card reports `/foo.bar/docs` returning **500** out of the Fumadocs page-tree lookup. It was filed against `ee74379`. **That half is already fixed** — #192 (`6653744`) set `dynamicParams = false` on `app/[lang]/docs/[[...slug]]/page.tsx` hours later for a different reason, and it incidentally routes an unknown `lang` on the docs route to `/_not-found` before any tree lookup happens.

Measured on unmodified `main` at `3433803`, before touching anything:

| request | card says | `main` at `3433803` actually does |
|---|---|---|
| `/foo.bar/docs` | 500 | **404**, real 404 copy in server markup |
| `/foo.bar/privacy` | 200 | **200** — live |
| `/foo.bar/terms` | 200 | **200** — live |
| `/foo.bar` | not reported | **307 to `/foo.bar/docs`** — live, and undercounted by the card |
| `/favicon.ico` | not reported | **307 to `/favicon.ico/docs`** — live, and undercounted by the card |

So the 500 is gone and the soft-404 family is not. That is the more SEO-relevant half by the PM's own adjudication, and it is what this PR fixes. There was no reproducible 500 left to fix.

## The change

`generateStaticParams` on this layout already enumerated the seven locales; nothing consumed that as a constraint. The flag makes it one, so a first segment that is not a locale is answered by the prerendered `/_not-found` route instead of rendering a page under a bogus locale.

## The mechanism was measured, not assumed

The PM flagged `notFound()` in the layout as the shape that *looks* right and fails silently, per #182. Built both ways and probed:

| `/foo.bar/privacy` | status | stripped body bytes | 404 copy present |
|---|---|---:|---|
| `main` (no fix) | 200 | 9,325 | no — it is a whole privacy page |
| `notFound()` guard in the layout | **404** | **594** | **no — empty error shell** |
| `dynamicParams = false` (this branch) | **404** | 1,518 | **yes** |

The middle row is the trap, and it is not hypothetical: a status-code-only check scores it as a fix. `notFound()` raised in a dynamically rendered request escapes both the RSC and SSR renders, and these URLs are dynamically rendered by construction — they are in no prerendered param set, which is exactly the condition #182 documented.

The probe was reverted; its restore is proven by blob identity against `HEAD` (`2175018…`), not by an exit code.

## Verification

**The defect, and the strongest form of the evidence.** Not just "404 and the copy is there" — the served document is **byte-identical** to the one `/no-such-page` has always returned. sha256 of the response with script bodies stripped:

```
/no-such-page      fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/foo.bar/privacy   fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/foo.bar/terms     fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/foo.bar/docs      fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/foo.bar           fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/favicon.ico       fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc
/1.2.3/privacy     fa59d702c28d07c8484083371fbd3a451c01a6963273f7f8fad7878434132ffc

/privacy           e3969814557ea22e081abd282df1a5f3db3771c9347a5474f65b85cd780eb61d  (control)
/docs/architecture accd8e8122687cf5d09f7f902dded9ae0beb574b48f476ca734bb097276b4e65  (control)
```

**The naive command still lies, and the strip is still what makes the reading real.** #192's warning reproduces exactly on this tree — raw `grep` reports the 404 copy present on a perfectly healthy 200 page, because it is in the RSC payload either way:

```
                        raw grep   stripped
/foo.bar/privacy           1           1
/no-such-page              1           1
/docs/architecture         1           0     -- healthy page the naive command scores as a 404
/privacy                   1           0     -- ditto
```

**Controls, all against the running server. Every row identical before and after.**

| request | `main` | this branch |
|---|---|---|
| `/docs/architecture` | 200, `lang=en` | unchanged |
| `/zh-Hans/docs/architecture` | 200, `lang=zh-Hans` | unchanged |
| `/ja/docs/architecture` | 200, `lang=ja` | unchanged |
| `/privacy`, `/terms`, `/zh-Hans/privacy` | 200 | unchanged |
| `/docs`, `/` | 200, 307 to `/docs` | unchanged |
| `/no-such-page` | 404 with body | unchanged — #168 preserved |
| `/docs/no-such-page`, `/zh-Hans/docs/no-such-page` | 404 with body | unchanged — #192 preserved |
| `/cn/docs/architecture` | 308 to `/zh-Hans/docs/architecture` | unchanged |
| `/cn/privacy` | 308 to `/zh-Hans/privacy` | unchanged |
| `Accept-Language: zh-CN` on `/docs/architecture` | 307 to `/zh-Hans/...` | unchanged |
| `Accept-Language: ja` on `/docs/architecture` | 307 to `/ja/...` | unchanged |

**The six-case host table from #204, re-run:**

| request | result |
|---|---|
| `Host: www.objectos.app` `/docs/architecture` | 308 to `https://docs.objectos.ai/docs/architecture` |
| `Host: www.objectos.app` `/` | 308 to `https://docs.objectos.ai/` |
| `Host: www.objectos.app` `/docs/architecture?q=1` | 308, query kept |
| `Host: www.objectos.app` `/zh-Hans/docs/architecture` | 308, prefix kept |
| `Host: docs.objectos.ai` `/docs/architecture` | 200 |
| `Host: docs.objectos.ai` `/cn/docs/architecture` | 308 to `/zh-Hans/docs/architecture` |

**The direction-1 hazard, confirmed untouched.** Every dotted machine-facing route still 200, still no locale prefix, still no redirect at all:

| route | status | redirect | bytes | first line |
|---|---|---|---:|---|
| `/llms.txt` | 200 | none | 14,557 | `# ObjectOS` |
| `/llms-full.txt` | 200 | none | 685,243 | `# ObjectOS` |
| `/sitemap.xml` | 200 | none | 299,145 | the XML declaration |
| `/robots.txt` | 200 | none | 117 | `User-Agent: *` |
| `/docs/architecture.mdx` | 200 | none | 12,488 | `# Architecture` |

**Nothing left the enumeration.** Prerender count `996/996` on both sides; 577 prerendered HTML files, matching the figure #192 and #204 recorded.

**Gates**, all at `b61f04e`, exit code captured before any pipe, each read from the command's own verdict line:

| gate | result |
|---|---|
| `pnpm turbo run type-check --continue --force` | `Tasks: 1 successful, 1 total` (script echoed: `fumadocs-mdx && next typegen && tsc --noEmit`) |
| `pnpm turbo run build --force` | `Compiled successfully in 39.3s`, `Generating static pages (996/996)` |
| `pnpm turbo run test --force` | `Tasks: 1 successful, 1 total` — `16 case(s) over 9 rule(s) and 3 artifact(s)`, `3 self-test(s) passed` |
| `node .github/scripts/check-locale-surface.mjs` | exit 0 — 346/346 sitemap URLs, 0 unexpected, 0 missing; both `llms` bodies 60/60 |
| `node .github/scripts/check-node-floor.mjs` | exit 0 — "Every declared floor clears what the dependency tree requires" |

`--force` on all three turbo tasks: the cache is shared across worktrees in this container and would otherwise replay a sibling's green.

## A note on `/favicon.ico`

Not in the card, and it changes: 307 to `/favicon.ico/docs` before, a clean 404 now. `apps/docs/public/` holds only `logo.svg`, and the root metadata declares `icon: '/logo.svg'`, so there is no `favicon.ico` to serve either way — the request was redirecting into a 404 and now answers one directly. Strictly an improvement, called out because it is a behaviour change the card did not predict.

## Scope

One file, exactly the granted surface. `middleware.ts` was read and not touched. No changeset (this repo has no changeset flow), and the diff is app code, so `skip-changeset` does not apply — that label is not a mechanism in this repo.

## Filed, not fixed here

Two findings from the running-server sweep, both unassigned:

- **#207** — the `.mdx` copy/view links 404 on all six non-default locales, because `next.config.mjs` rewrites only the unprefixed `/docs/:path*.mdx`. Live, roughly 400 dead links, and unrelated to this card's surface. #207 is not addressed here.
- **#208** — observation-class: a docs page whose *slug* contains a dot would 404 at its public URL while answering 200 at the internal `/en/...` route. Latent — zero such pages exist today — but measured with a temporary probe page rather than reasoned. #208 remains open.

**On the matcher.** The PM asked to hear it if I came out convinced direction 1 is also needed. Measured answer: after this fix, the unanchored `.*\..*` exemption has no *live* consequence I could produce — #208 is the only remaining one and it has zero instances. So it is recorded as a finding with its measurement, not fixed here, and the adjudication that the matcher's blast radius is not worth this card's risk holds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_