### PR TITLE
fix(ci): keep derived locales off the translation worklist

### DIFF
--- a/.github/scripts/check-translation-output.mjs
+++ b/.github/scripts/check-translation-output.mjs
@@ -101,6 +101,7 @@ import { readFileSync, writeFileSync, readdirSync, existsSync, mkdtempSync, rmSy
 import { join, dirname, relative, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
+import { DERIVED_FROM } from './lib/derived-locales.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '../..');
@@ -159,9 +160,12 @@ function walk(dir, out = []) {
 const localeOf = (f) => LOCALES.find((l) => f.endsWith(`.${l}.mdx`)) ?? null;
 const englishOf = (f, l) => `${f.slice(0, -`.${l}.mdx`.length)}.mdx`;
 
-/**
- * Locales DERIVED FROM ANOTHER LOCALE rather than translated from English, and
- * the locale each one is derived from.
+/* ------------------------------------------------------- derived locales --
+ * `DERIVED_FROM` — which locales are generated from another locale rather than
+ * translated from English — is imported from `./lib/derived-locales.mjs`, the
+ * one definition `check-translations.mjs` also reads. That module carries the
+ * reasoning for why this particular fact is shared while the small readers
+ * around it stay duplicated. What follows is why it matters HERE.
  *
  * Every rule below asks "is this file faithful to the thing it was produced
  * from?", and until `zh-Hant` shipped that thing was always the English
@@ -188,7 +192,6 @@ const englishOf = (f, l) => `${f.slice(0, -`.${l}.mdx`.length)}.mdx`;
  * `unsafe` is untouched by any of this — it needs no sibling, runs over the
  * whole corpus, and is the one rule that is never scoped.
  */
-const DERIVED_FROM = { 'zh-Hant': 'zh-Hans' };
 
 /**
  * The file a locale file must be faithful to: its source-locale sibling for a

--- a/.github/scripts/check-translations.mjs
+++ b/.github/scripts/check-translations.mjs
@@ -37,6 +37,34 @@
  * to also produce six translations is the cost this design exists to remove.
  * Translations catch up in a separate pass — see `docs/TRANSLATION.md`.
  *
+ * ## Derived locales are not translation work
+ *
+ * `zh-Hant` is generated from its `zh-Hans` sibling by
+ * `apps/docs/scripts/gen-zh-hant.mjs` and committed — never translated from
+ * English, never hand-written (`DERIVED_FROM` in `./lib/derived-locales.mjs`).
+ *
+ * Every verdict above except `unstamped` and `orphan` describes TRANSLATION
+ * work: a page a pass should produce or refresh. None of them can describe a
+ * derived locale, because no pass may write one. So `stale`, `missing` and
+ * `guide-stale` are scoped to translated locales, and with them the
+ * `--worklist` that is built from those three buckets — `docs/TRANSLATION.md`
+ * calls the worklist "the entire input to a pass", and an item on it is an
+ * instruction to translate. Emitting `en → zh-Hant` items asked the pass for a
+ * second, divergent Chinese voice on a page that already has one: output the
+ * generator overwrites and `gen-zh-hant.mjs --check` rejects in the meantime.
+ *
+ * `unstamped` and `orphan` deliberately stay in scope for derived locales.
+ * They are not work items, they are defects in a file that exists: a Traditional
+ * page whose English source was retired is unreachable and must be pruned, and
+ * one with no `translation:` block has unknown provenance. Both are the
+ * generator's failure to prune or stamp, and both still block. Scoping them out
+ * along with the work verdicts would have been the quiet half of this bug.
+ *
+ * The freshness of the CONVERSION itself — that the Traditional bytes match
+ * what the converter produces from the current Simplified page — is not this
+ * script's question at all. `gen-zh-hant.mjs --check` owns it in CI and answers
+ * it byte for byte, which is strictly stronger than anything a stamp can say.
+ *
  * ## Usage
  *
  *   node .github/scripts/check-translations.mjs                  # PR gate + report
@@ -44,16 +72,19 @@
  *   node .github/scripts/check-translations.mjs --worklist       # JSON work items
  *   node .github/scripts/check-translations.mjs --stamp <file>   # stamp one translation
  *   node .github/scripts/check-translations.mjs --baseline       # one-time backfill
+ *   node .github/scripts/check-translations.mjs --self-test      # prove the scoping can fail
  *
  * No dependencies, no network, no credentials — it must be runnable on a fork
  * PR and by anyone with a checkout.
  */
-import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { existsSync } from 'node:fs';
 import { join, dirname, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { DERIVED_FROM, isDerived } from './lib/derived-locales.mjs';
 
 /**
  * Bump when a change to `docs/TRANSLATION.md` invalidates existing output
@@ -86,6 +117,15 @@ function locales() {
 }
 
 const LOCALES = locales();
+
+/**
+ * Locales a translation pass may write. Derived locales (`DERIVED_FROM`) are
+ * generated from another locale, so they are excluded from every verdict that
+ * describes work — see the header. `LOCALES` stays whole: `localeOf()` must
+ * still RECOGNISE a derived file, or its orphan and unstamped defects become
+ * invisible instead of merely unactionable.
+ */
+const TRANSLATED_LOCALES = LOCALES.filter((l) => !isDerived(l));
 
 function walk(dir, out = []) {
   for (const e of readdirSync(dir, { withFileTypes: true })) {
@@ -151,8 +191,16 @@ function provenanceFromGit(localeFile, enFile) {
   }
 }
 
-function survey() {
-  const all = walk(DOCS);
+/**
+ * `docs` and `derived` are injectable so the self-test can drive this against a
+ * fixture tree, and — the point of the red fixture — against an EMPTY derived
+ * map, which is what this script did before the scoping existed. A rule that
+ * has never been seen to fail is not known to work.
+ */
+function survey({ docs = DOCS, derived = DERIVED_FROM } = {}) {
+  /** Locales a pass may actually write. See `TRANSLATED_LOCALES`. */
+  const workLocales = LOCALES.filter((l) => !isDerived(l, derived));
+  const all = walk(docs);
   const english = all.filter((f) => !localeOf(f)).sort();
   const translated = all.filter((f) => localeOf(f)).sort();
 
@@ -174,6 +222,14 @@ function survey() {
       unstamped.push({ file: rel(t), locale: l });
       continue;
     }
+    /**
+     * A derived locale stops here. `orphan` and `unstamped` above are defects
+     * in a file that exists and still block; `stale` and `guide-stale` below
+     * are work verdicts, and no pass may write this file — the generator does.
+     * Whether the CONVERSION is current is `gen-zh-hant.mjs --check`'s
+     * question, answered byte for byte rather than by a carried-over stamp.
+     */
+    if (isDerived(l, derived)) continue;
     const current = shaOf(en);
     if (stamp.source_sha !== current) {
       stale.push({ en: rel(en), out: rel(t), locale: l, mode: stamp.mode ?? 'auto' });
@@ -183,14 +239,45 @@ function survey() {
   }
 
   for (const en of english) {
-    for (const l of LOCALES) {
+    // `workLocales`, not `LOCALES`: a Traditional page is never missing in a
+    // way anyone can act on. It appears when the generator is run over a
+    // Simplified sibling that exists, so the actionable row is the zh-Hans one.
+    for (const l of workLocales) {
       if (!existsSync(siblingOf(en, l))) {
         missing.push({ en: rel(en), out: rel(siblingOf(en, l)), locale: l, mode: 'auto' });
       }
     }
   }
 
-  return { english, translated, unstamped, orphan, stale, guideStale, missing };
+  return { english, translated, unstamped, orphan, stale, guideStale, missing, workLocales };
+}
+
+/**
+ * The entire input to a translation pass (`docs/TRANSLATION.md`). Built from
+ * the three work buckets, which `survey()` has already scoped to translated
+ * locales — one exclusion point, so the worklist and the report columns can
+ * never disagree about what a pass is allowed to write.
+ */
+const worklistOf = (s) =>
+  [...s.stale, ...s.missing, ...s.guideStale].filter((w) => w.mode !== 'reviewed');
+
+/**
+ * Why `--gate=release --require=zh-Hant` is an ERROR and not a no-op: a derived
+ * locale carries no `stale` or `missing` rows by construction, so requiring one
+ * would pass VACUOUSLY. A release gate that cannot go red is worse than no gate
+ * at all, because someone is relying on it. Returns the message, or `null`.
+ */
+function derivedRequireError(required, derived = DERIVED_FROM) {
+  const named = required.filter((l) => isDerived(l, derived));
+  if (!named.length) return null;
+  const sources = [...new Set(named.map((l) => derived[l]))];
+  return (
+    `--require names derived locale(s): ${named
+      .map((l) => `${l} (generated from ${derived[l]})`)
+      .join(', ')} — these carry no stale/missing rows, so requiring them would ` +
+    `pass vacuously. Require ${sources.join(', ')} instead; the generated output ` +
+    'is gated separately by `gen-zh-hant.mjs --check`.'
+  );
 }
 
 function countByLocale(items) {
@@ -206,8 +293,27 @@ function report(s) {
   const st = countByLocale(s.stale);
   const mi = countByLocale(s.missing);
   const gs = countByLocale(s.guideStale);
-  for (const l of LOCALES) lines.push(`| ${l} | ${st[l]} | ${mi[l]} | ${gs[l]} |`);
+  /**
+   * Derived locales get dashes, not zeroes, and are not dropped from the table.
+   * A zero would read as "nothing to do here", which is true by accident and
+   * would become a lie the moment the generator stopped being run; an absent
+   * row would hide that the locale ships at all. A dash says the question does
+   * not apply, and the footnote says which gate does ask it.
+   */
+  for (const l of LOCALES) {
+    lines.push(isDerived(l) ? `| ${l} | — | — | — |` : `| ${l} | ${st[l]} | ${mi[l]} | ${gs[l]} |`);
+  }
   lines.push('');
+  const derivedRows = LOCALES.filter((l) => isDerived(l));
+  if (derivedRows.length) {
+    lines.push(
+      `— = generated, not translated: ${derivedRows
+        .map((l) => `\`${l}\` from \`${DERIVED_FROM[l]}\``)
+        .join(', ')}. No pass writes these; ` +
+        '`apps/docs/scripts/gen-zh-hant.mjs --check` gates them byte for byte in CI.',
+      '',
+    );
+  }
   if (s.unstamped.length) {
     lines.push(`### ⛔ Unstamped (${s.unstamped.length})`, '');
     lines.push('Provenance unknown — freshness cannot be judged. Run `--baseline`.', '');
@@ -233,6 +339,9 @@ function main() {
   const argv = process.argv.slice(2);
   const arg = (name) => argv.find((a) => a.startsWith(`--${name}=`))?.split('=').slice(1).join('=');
   const has = (name) => argv.some((a) => a === `--${name}` || a.startsWith(`--${name}=`));
+
+  // Before any corpus work: the self-test drives fixture trees, never `DOCS`.
+  if (has('self-test')) return selfTest();
 
   if (has('stamp')) {
     const target = arg('stamp') ?? argv[argv.indexOf('--stamp') + 1];
@@ -269,8 +378,7 @@ function main() {
   const s = survey();
 
   if (has('worklist')) {
-    const work = [...s.stale, ...s.missing, ...s.guideStale].filter((w) => w.mode !== 'reviewed');
-    console.log(JSON.stringify(work, null, 2));
+    console.log(JSON.stringify(worklistOf(s), null, 2));
     return;
   }
 
@@ -284,6 +392,8 @@ function main() {
     const required = (arg('require') ?? '').split(',').map((x) => x.trim()).filter(Boolean);
     const unknown = required.filter((l) => !LOCALES.includes(l));
     if (unknown.length) throw new Error(`--require names unknown locale(s): ${unknown.join(', ')}`);
+    const derivedProblem = derivedRequireError(required);
+    if (derivedProblem) throw new Error(derivedProblem);
     for (const l of required) {
       const st = s.stale.filter((x) => x.locale === l).length;
       const mi = s.missing.filter((x) => x.locale === l).length;
@@ -296,6 +406,175 @@ function main() {
     process.exit(1);
   }
   console.error('\n✓ translations gate passed');
+}
+
+/* ------------------------------------------------------------- self-test --
+ * 裁决: a validator observed only green is indistinguishable from one that
+ * cannot go red.
+ *
+ * The rule under test is a NEGATIVE — "no derived-locale item reaches the
+ * worklist" — and a negative is the easy kind to pass by accident: a fixture
+ * with no derived files at all, a typo in `DERIVED_FROM` that disables nothing,
+ * a `walk()` that never reached the tree, all read as success. So every case
+ * below is asserted against the SAME fixture tree surveyed twice: once with
+ * `DERIVED_FROM`, and once with an empty map, which is exactly what this script
+ * did before the scoping existed.
+ *
+ * That second run is the red fixture. It must EMIT the items the first run must
+ * not, and the self-test fails if it does not — so a fixture that lost its
+ * derived pages, or a scoping that silently stopped applying, cannot pass here.
+ */
+
+/** A 64-hex sha that matches no real file: makes a stamp deliberately stale. */
+const NEVER_SHA = '1'.repeat(64);
+
+const fixtureEnglish = (title) => `---\ntitle: ${title}\n---\n\nEnglish prose for ${title}.\n`;
+
+const fixtureStamped = (title, sha, mode = 'auto') =>
+  `---\ntitle: ${title}\ntranslation:\n  source_sha: ${sha}\n  guide_rev: ${GUIDE_REV}\n  mode: ${mode}\n---\n\nTranslated prose for ${title}.\n`;
+
+const fixtureUnstamped = (title) => `---\ntitle: ${title}\n---\n\nTranslated prose for ${title}.\n`;
+
+/**
+ * A tree exercising every verdict on both a translated and a derived locale.
+ * Written with the real `zh-Hant`/`zh-Hans` pair rather than invented tags so
+ * that a `DERIVED_FROM` typo cannot make this pass while the corpus stays wrong.
+ */
+function buildFixture(dir) {
+  const derivedLocale = Object.keys(DERIVED_FROM)[0];
+  const sourceLocale = DERIVED_FROM[derivedLocale];
+  const w = (name, body) => writeFileSync(join(dir, name), body);
+
+  // Stale in both the source locale and the derived one: the derived page
+  // carries the same carried-over stamp, which is what makes it LOOK like work.
+  w('stale.mdx', fixtureEnglish('stale'));
+  w(`stale.${sourceLocale}.mdx`, fixtureStamped('stale', NEVER_SHA));
+  w(`stale.${derivedLocale}.mdx`, fixtureStamped('stale', NEVER_SHA));
+
+  // English with no siblings at all: `missing` in every locale.
+  w('uncovered.mdx', fixtureEnglish('uncovered'));
+
+  // Derived file whose English source is gone: `orphan`, and still blocking.
+  w(`gone.${derivedLocale}.mdx`, fixtureStamped('gone', NEVER_SHA));
+
+  // Derived file with no `translation:` block: `unstamped`, still blocking.
+  w('bare.mdx', fixtureEnglish('bare'));
+  w(`bare.${sourceLocale}.mdx`, fixtureStamped('bare', shaOf(join(dir, 'bare.mdx'))));
+  w(`bare.${derivedLocale}.mdx`, fixtureUnstamped('bare'));
+
+  return { derivedLocale, sourceLocale };
+}
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'check-translations-'));
+  let failed = 0;
+  const check = (name, ok, detail = '') => {
+    console.log(`${ok ? '✓' : '✗'} ${name.padEnd(64)}${detail}`);
+    if (!ok) failed += 1;
+  };
+
+  try {
+    const { derivedLocale, sourceLocale } = buildFixture(dir);
+
+    // The map itself. A `DERIVED_FROM` entry naming a locale `i18n.ts` does not
+    // declare is a typo that disables the exclusion without any other symptom.
+    for (const [derived, from] of Object.entries(DERIVED_FROM)) {
+      check(
+        `DERIVED_FROM: "${derived}" and its source "${from}" are declared in i18n.ts`,
+        LOCALES.includes(derived) && LOCALES.includes(from),
+      );
+      check(
+        `DERIVED_FROM: "${derived}" is excluded from TRANSLATED_LOCALES`,
+        !TRANSLATED_LOCALES.includes(derived) && TRANSLATED_LOCALES.includes(from),
+      );
+    }
+
+    const scoped = survey({ docs: dir });
+    const unscoped = survey({ docs: dir, derived: {} });
+    const workOf = (s, l) => worklistOf(s).filter((w) => w.locale === l);
+
+    // ---- the red fixture: without the scoping, these items ARE emitted ----
+    const wouldEmit = workOf(unscoped, derivedLocale);
+    check(
+      `red fixture: without DERIVED_FROM the tree emits ${derivedLocale} work`,
+      wouldEmit.length > 0,
+      `emitted ${wouldEmit.length}`,
+    );
+    check(
+      `red fixture: and they are the stale and missing items, not noise`,
+      wouldEmit.some((w) => w.out.endsWith(`stale.${derivedLocale}.mdx`)) &&
+        wouldEmit.some((w) => w.out.endsWith(`uncovered.${derivedLocale}.mdx`)),
+    );
+
+    // ---- the rule ----
+    const emitted = workOf(scoped, derivedLocale);
+    check(
+      `worklist emits no ${derivedLocale} items`,
+      emitted.length === 0,
+      emitted.length ? `emitted ${JSON.stringify(emitted.map((w) => w.out))}` : '',
+    );
+    check(
+      `${derivedLocale} absent from stale, missing and guide-stale`,
+      ![...scoped.stale, ...scoped.missing, ...scoped.guideStale].some(
+        (x) => x.locale === derivedLocale,
+      ),
+    );
+
+    // ---- the exclusion did not over-reach ----
+    check(
+      `translated locale ${sourceLocale} is unaffected by the scoping`,
+      JSON.stringify(workOf(scoped, sourceLocale)) ===
+        JSON.stringify(workOf(unscoped, sourceLocale)) &&
+        workOf(scoped, sourceLocale).length > 0,
+    );
+    check(
+      'every other translated locale is unaffected too',
+      TRANSLATED_LOCALES.every(
+        (l) => JSON.stringify(workOf(scoped, l)) === JSON.stringify(workOf(unscoped, l)),
+      ),
+    );
+    check(
+      `a ${derivedLocale} orphan still BLOCKS`,
+      scoped.orphan.some((o) => o.locale === derivedLocale && o.file.endsWith(`gone.${derivedLocale}.mdx`)),
+    );
+    check(
+      `an unstamped ${derivedLocale} file still BLOCKS`,
+      scoped.unstamped.some(
+        (u) => u.locale === derivedLocale && u.file.endsWith(`bare.${derivedLocale}.mdx`),
+      ),
+    );
+
+    // ---- the release gate cannot pass vacuously on a derived locale ----
+    check(
+      `--require=${derivedLocale} is rejected rather than passing vacuously`,
+      (derivedRequireError([derivedLocale]) ?? '').includes(derivedLocale),
+    );
+    check(
+      `--require=${sourceLocale} is still accepted`,
+      derivedRequireError([sourceLocale]) === null,
+    );
+
+    // ---- the report tells the reader why the row is blank ----
+    const table = report(scoped);
+    check(
+      `report shows ${derivedLocale} as generated, not as zero work`,
+      table.includes(`| ${derivedLocale} | — | — | — |`) &&
+        table.includes('generated, not translated'),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  console.log('');
+  if (failed) {
+    console.error(`✗ self-test: ${failed} case(s) did not behave as declared`);
+    process.exit(1);
+  }
+  console.log(
+    `✓ self-test: derived-locale scoping holds for ${Object.keys(DERIVED_FROM).length} derived ` +
+      `locale(s) over ${TRANSLATED_LOCALES.length} translated locale(s) — proven able to fail by ` +
+      'surveying the same fixture tree with the exclusion removed',
+  );
 }
 
 main();

--- a/.github/scripts/lib/derived-locales.mjs
+++ b/.github/scripts/lib/derived-locales.mjs
@@ -1,0 +1,49 @@
+/**
+ * Which locales are GENERATED FROM ANOTHER LOCALE rather than translated from
+ * English, and the locale each one is generated from.
+ *
+ * `zh-Hant` is produced from the `zh-Hans` page by
+ * `apps/docs/scripts/gen-zh-hant.mjs` (OpenCC `s2twp`) and committed. It is
+ * never translated from English and never hand-written, and CI gates it with
+ * `gen-zh-hant.mjs --check` on every PR.
+ *
+ * ## Why this one fact is SHARED, when the readers around it are duplicated
+ *
+ * `check-translations.mjs` and `check-translation-output.mjs` deliberately
+ * carry their own copies of the small things they read — `locales()`, `walk()`,
+ * `localeOf()`, frontmatter parsing. That duplication is not laziness and it is
+ * not this module's business to undo. It is the same principle
+ * `check-locale-surface.mjs` states over its `SITE_URL` re-declaration: a check
+ * that shares a constant with the thing it checks cannot catch that constant
+ * being wrong. Two independent PARSERS of one tree genuinely cross-check each
+ * other, and that convention holds because a mismatch between them is LOUD —
+ * `SITE_URL` drifting lands every URL in both `unexpected-url` and
+ * `missing-url` at once.
+ *
+ * Neither property holds for this map, which is why it lives here instead:
+ *
+ *   1. It is not a reader, it is a FACT about the content pipeline — that
+ *      Traditional is generated from Simplified. Neither script audits the
+ *      other, so two copies of that fact cross-check nothing. There is no
+ *      oracle, only two places to be wrong independently.
+ *   2. A drift between two copies would be SILENT, which is the exact inverse
+ *      of the property that makes re-declaring `SITE_URL` safe. One script
+ *      skipping Traditional in its worklist while the other still compares it
+ *      against English produces no finding anywhere: the failure surfaces as a
+ *      wasted translation pass, days later, in a place that does not point
+ *      back here.
+ *
+ * So: one definition, imported by both. A locale added here changes the
+ * worklist and the fidelity comparison in the same commit, or neither.
+ *
+ * Both consumers assert this map against `apps/docs/lib/i18n.ts` in their
+ * `--self-test`: an entry naming a locale that is not declared there is a typo
+ * that would otherwise silently disable the exclusion it was meant to add.
+ */
+export const DERIVED_FROM = { 'zh-Hant': 'zh-Hans' };
+
+/** Is this locale generated from another locale rather than translated? */
+export const isDerived = (locale, map = DERIVED_FROM) => Object.hasOwn(map, locale);
+
+/** The locale this one is generated from, or `null` if it is translated. */
+export const derivedFrom = (locale, map = DERIVED_FROM) => map[locale] ?? null;

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -31,7 +31,8 @@ node .github/scripts/check-translations.mjs --worklist  # JSON work items
 
 The worklist is the entire input to a pass — it lists every page that is stale,
 missing, or produced under an older revision of this guide, and it excludes
-pages a human has marked `mode: reviewed`. Work it item by item:
+pages a human has marked `mode: reviewed` and locales that are generated rather
+than translated (see [Derived locales](#derived-locales)). Work it item by item:
 
 ```bash
 # translate <en> into <locale>, write it to <out>, then:
@@ -210,9 +211,15 @@ and gated in CI by `gen-zh-hant.mjs --check`.
 - `check-translation-output.mjs` compares a derived locale against its SOURCE
   locale, not against English (`DERIVED_FROM` there) — for `zh-Hant` the rules
   are a check on the converter.
-- ⚠️ `--worklist` does not know about this yet: it still emits
-  `en → zh-Hant` items alongside the `zh-Hans` ones. Skip them. Acting on one
-  produces a page the generator overwrites and `--check` rejects.
+- `--worklist` never emits a `zh-Hant` item: a derived locale is not this
+  pass's work, so it is excluded from the `stale`, `missing` and `guide-stale`
+  verdicts the worklist is built from. The status table shows `—` in those
+  columns for the same reason, and `--gate=release --require=zh-Hant` is
+  rejected rather than passing vacuously — require `zh-Hans` instead.
+- What still applies to a derived page is anything wrong with the FILE rather
+  than its content: an orphaned `zh-Hant` page whose English source was retired,
+  or one with no `translation:` stamp, both still block the gate. The fix is to
+  re-run the generator, which prunes and re-stamps.
 
 ## Adding a locale
 

--- a/tools/ci-scripts/run-self-tests.mjs
+++ b/tools/ci-scripts/run-self-tests.mjs
@@ -40,11 +40,18 @@
  *     not listed → failure, naming the file. A new self-test joins the CI step
  *     by being written, not by someone remembering this list.
  *
- * Deliberately NOT run here: `check-translations.mjs` and
- * `check-translation-ownership.mjs`. Neither declares a self-test mode, and
- * running them for real would make the required `build` job fail on the
- * corpus's translation debt — which is the `Translations` workflow's job, and
- * reported-not-blocking there by design.
+ * Deliberately NOT run here: the GATE mode of `check-translations.mjs`, and
+ * `check-translation-ownership.mjs` entirely. Running either for real would
+ * make the required `build` job fail on the corpus's translation debt — which
+ * is the `Translations` workflow's job, and reported-not-blocking there by
+ * design. `check-translation-ownership.mjs` declares no self-test at all.
+ *
+ * `check-translations.mjs` is listed for its `--self-test` only, on the same
+ * footing as `check-locale-surface.mjs` below: the fixtures run against
+ * temporary trees and never read `content/docs/`, so they cost milliseconds and
+ * cannot fail on corpus debt. What they prove is that its derived-locale
+ * scoping — the rule keeping generated `zh-Hant` pages off a translation
+ * worklist — is still able to go red.
  *
  * ## Self-test here, gate in the workflow
  *
@@ -68,6 +75,7 @@ const SCRIPTS = join(ROOT, '.github/scripts');
 /** Scripts whose `--self-test` mode this step runs. Never let this go empty. */
 const SELF_TESTED = [
   'check-translation-output.mjs',
+  'check-translations.mjs',
   'check-node-floor.mjs',
   'check-locale-surface.mjs',
 ];
@@ -83,6 +91,13 @@ const SELF_TESTED = [
  * goes unnoticed here. This check narrows the gap, it does not close it — the
  * guarantee that this step never silently executes nothing is the empty-list
  * check above, not this one.
+ *
+ * The scan is also TOP LEVEL only — `readdirSync` without `recursive`, plus an
+ * `isFile()` filter — so `.github/scripts/lib/` is outside it by construction.
+ * That is what lets shared leaf modules live there without tripping this rule,
+ * and it is the reason a self-test belonging to one of them has to be reached
+ * through the script that imports it rather than added to `SELF_TESTED` on its
+ * own: a `lib/` entry here would run, but nothing would notice if it stopped.
  */
 const DISPATCH = /(['"`])(?:--)?self-test\1/;
 


### PR DESCRIPTION
Fixes #216

`zh-Hant` is generated from its `zh-Hans` sibling by `apps/docs/scripts/gen-zh-hant.mjs` and committed — never translated from English. `check-translations.mjs` derived its locale list from `apps/docs/lib/i18n.ts` and treated every non-default locale identically, so `--worklist` emitted 65 `en` to `zh-Hant` items. `docs/TRANSLATION.md` calls the worklist "the entire input to a pass", so those items were instructions to translate English into Traditional Chinese: a second, divergent Chinese voice on a page that already has one.

## Structure: the shared leaf module, and why the duplication convention does not cover this

Adjudicated in the dispatch as the shared route; I checked it against the tree and **the tree supports it**, for a reason worth recording rather than just concurring with.

The re-declaration convention is documented once, over `SITE_URL` in `check-locale-surface.mjs:142`:

> Deliberately re-declared rather than imported: this file is the independent check, and a check that shares a constant with the thing it checks cannot catch that constant being wrong. **A mismatch shows up as every URL landing in both `unexpected-url` and `missing-url`, which is loud and unambiguous.**

That rationale carries two preconditions, and `DERIVED_FROM` satisfies neither:

1. **It applies to a checker and the thing it checks.** `check-locale-surface.mjs` audits the app's sitemap; `SITE_URL` is a value the audited system produces, so an independent copy is a genuine oracle. Neither translation script audits the other — they are two consumers of one fact about the content pipeline. Two copies cross-check nothing.
2. **It requires the mismatch to be loud.** `SITE_URL` drift lands every URL in two rule buckets at once. `DERIVED_FROM` drift is silent by construction: one script skipping Traditional in its worklist while the other still compares it against English produces no finding anywhere. It surfaces as a wasted translation pass, days later, somewhere that does not point back at either file.

So the shared module holds the **fact**; the small readers (`locales()`, `walk()`, `localeOf()`, frontmatter parsing) stay duplicated, untouched. `.github/scripts/lib/derived-locales.mjs` carries this reasoning inline so the next person does not have to re-derive it.

**Self-test hazard verified by measurement, not by reading.** `tools/ci-scripts/run-self-tests.mjs` scans with `readdirSync` without `recursive`, plus an `isFile()` filter. I wrote a throwaway `.github/scripts/lib/__probe.mjs` containing the literal `'--self-test'`, ran the runner, and it was **not** flagged while the top-level script was; the probe was then removed. `lib/` is outside the scan by construction.

## `Missing` / `Stale`: excluded, with the vacuous-pass hole closed

The card called these "arguably" wrong. **I excluded them**, after looking at both consumers:

- **The report table** goes to `$GITHUB_STEP_SUMMARY` (`translations.yml`) — a human-read status surface. The `zh-Hant` row was structurally identical to `zh-Hans` (48/17 against 48/17), because a derived page carries its source's stamp. It is a duplicate row presented as a to-do list.
- **`--gate=release --require=LOCALE`** is the one place these numbers *block*.

That second consumer is why exclusion alone was not enough. Removing the rows would make `--require=zh-Hant` pass **vacuously** — a release gate that cannot go red, which is worse than no gate because someone is relying on it. So it now errors and names the locale carrying the real answer:

```
--require names derived locale(s): zh-Hant (generated from zh-Hans) — these carry no
stale/missing rows, so requiring them would pass vacuously. Require zh-Hans instead;
the generated output is gated separately by `gen-zh-hant.mjs --check`.
```

The derived row is rendered as `—` rather than dropped or zeroed: a zero reads as "nothing to do here", true by accident and a lie the moment the generator stops being run; an absent row hides that the locale ships at all. A footnote names the gate that does ask the question.

**`unstamped` and `orphan` deliberately still cover derived locales.** They are defects in a file that exists — an unreachable Traditional page whose English source was retired, or one with no provenance — not work items, and both still block. Scoping them out alongside the work verdicts would have been the quiet half of this bug.

## Numbers

| | before | after |
|:--|--:|--:|
| worklist entries | 505 | **440** |
| worklist `zh-Hant` | 65 | **0** |
| `Stale` total | 270 | **222** |
| `Missing` total | 235 | **218** |
| self-tests run by `turbo run test` | 3 | **4** |

Per-locale after: `{de:75, es:75, fr:75, ja:75, ko:75, zh-Hans:65}` — verified programmatically that **no other locale moved**. The two column deltas are exactly the removed `zh-Hant` rows (48 stale + 17 missing = the 65 worklist items).

## The red fixture

`check-translations.mjs` gains a `--self-test` (13 cases). The rule under test is a *negative* — "no derived-locale item reaches the worklist" — which is the easy kind to pass by accident: a fixture with no derived pages, a `DERIVED_FROM` typo disabling nothing, a `walk()` that never reached the tree all read as success.

So every case is asserted against the **same fixture tree surveyed twice**: once with `DERIVED_FROM`, once with an empty map — exactly what this script did before. The second run **must emit** what the first must not, and the self-test fails if it does not.

Ablation confirming both exclusion points are load-bearing, each mutation confirmed on disk by anchor count before reading any result, restore proven by blob hash against the HEAD blob plus an empty `git diff HEAD`:

| mutation | self-test exit |
|:--|:--|
| remove `if (isDerived(l, derived)) continue;` | **1** — `stale.zh-Hant.mdx` emitted |
| widen the `missing` loop back to `LOCALES` | **1** — `uncovered.zh-Hant.mdx` emitted |

## Declared deviations from the stated file surface

Two, both reported rather than done silently:

1. **`docs/TRANSLATION.md`** — its interim warning ("`--worklist` does not know about this yet: it still emits `en → zh-Hant` items … Skip them") is made **false** by this change, so per the dispatch it had to go. Replaced with what is now enforced, plus a note that orphan/unstamped still block. The worklist definition at the top of the file was also incomplete and now names the exclusion.
2. **`tools/ci-scripts/run-self-tests.mjs`** — **mechanically forced, not chosen.** The moment `check-translations.mjs` declares `--self-test`, the runner's own guard fails the build: `declares --self-test but is not listed in SELF_TESTED`. Listing it follows the `check-locale-surface.mjs` precedent — self-test here, gate in the workflow — and its docblock's claim that the script "declares no self-test mode" is now false and was corrected. I also recorded that the scan is top-level only, so the next shared module does not have to rediscover it.

## Gates

All on the final commit `6d14f6a`, working tree clean:

| gate | verdict line |
|:--|:--|
| `pnpm turbo run type-check` | `Tasks: 1 successful, 1 total` (exit 0) |
| `pnpm turbo run build` | `Tasks: 1 successful, 1 total` (exit 0) |
| `pnpm turbo run test --force` | `✓ 4 self-test(s) passed` (exit 0) |
| `check-locale-surface.mjs` | `✓ every advertised URL has a source file …` (exit 0) |
| `check-translations.mjs` | `✓ translations gate passed` (exit 0) |
| `gen-zh-hant.mjs --check` | `✓ zh-Hant: 73 generated file(s) match … byte for byte.` (exit 0) |

`check-translation-output.mjs --files` — exit 0, `✓ translation output gate passed (138 pre-existing finding(s) reported)`, the same 138 `main` reports. Measured against a comparison worktree at `d454ccb`: **stdout and stderr are byte-identical** (`diff` exit 0), which is the strongest available evidence that moving `DERIVED_FROM` to the shared module changed nothing there.

Exit codes were captured before any pipe throughout, and each verdict above is the line the gate printed rather than a `$?` reading.

## Filed, not fixed

- #221 — `.github/workflows/translations.yml` filters on `.github/scripts/check-translation*.mjs`, which does not match `.github/scripts/lib/`, so a future PR editing only the shared module skips the corpus gates. Bounded: `ci.yml` has no path filter and `turbo.json` already declares `$TURBO_ROOT$/.github/scripts/**` for `test`, so both self-tests still run. This PR edits both `check-translation*.mjs` files, so the workflow runs here normally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_