### PR TITLE
fix(ci): widen translations.yml path filters to match job inputs

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -6,12 +6,24 @@ on:
     paths:
       - 'content/docs/**'
       - 'apps/docs/lib/i18n.ts'
-      - '.github/scripts/check-translation*.mjs'
+      # Was 'check-translation*.mjs' — a `*` never crosses `/`, so it missed
+      # '.github/scripts/lib/derived-locales.mjs', imported by both
+      # check-translations.mjs and check-translation-output.mjs (#221). Widened
+      # to the whole directory to match what turbo.json already declares as
+      # the `test` task's input for this tree, and to cover any future script
+      # (or nested lib/) the two checks below start importing.
+      - '.github/scripts/**'
       - '.github/workflows/translations.yml'
   push:
     branches: [main]
     paths:
+      # Freshness / self-test / Output run on push too (only the Ownership
+      # step is pull_request-only, see the `if:` below) and read the same
+      # i18n.ts + scripts as the pull_request job — so this needs the same
+      # two entries, not just the corpus path.
       - 'content/docs/**'
+      - 'apps/docs/lib/i18n.ts'
+      - '.github/scripts/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Fixes #221

Notation: this repo's issue/PR-body sanitizer strips angle brackets and decodes HTML numeric character references, even inside code fences, so this body avoids angle brackets and writes wildcards as plain `*`/`**` instead.

## What changed

Widened `.github/workflows/translations.yml`'s `paths:` filters so the `Ownership & freshness` job's trigger actually covers what the job reads. `.github/scripts/check-translation*.mjs` cannot cross a path separator, so it never matched `.github/scripts/lib/derived-locales.mjs` even though `check-translations.mjs` and `check-translation-output.mjs` both import it — a PR editing only that shared module skipped the whole job (no freshness report, no corpus-wide output gate). Fixed by widening to `.github/scripts/**`, matching what `turbo.json` already declares as the `test` task's input for this directory.

Per the card's framing ("a path filter that is narrower than the task's declared inputs is a class, not an instance"), I went through every `paths:` filter in `.github/workflows/` rather than just this one line.

## Full comparison

| Workflow / trigger | Filter (as of `main`) | What it matches | What the job(s) behind it actually read | Gap? | Action |
|---|---|---|---|---|---|
| `ci.yml` (push / pull_request / merge_group) | *(no `paths:` at all)* | everything | `node-floor` job: root `package.json`, `apps/docs/package.json`, `tools/ci-scripts/package.json`, `.node-version`, `pnpm-lock.yaml`. `build` job: `gen-zh-hant.mjs --check`, `turbo run type-check` (inputs: `$TURBO_DEFAULT$` + `content/docs/**`), `turbo run build` (same), `check-locale-surface.mjs` (reads the built `.next` sitemap + `content/docs/**` + `apps/docs/lib/i18n.ts`), `turbo run test` (inputs: `$TURBO_DEFAULT$` + `.github/scripts/**` + `apps/docs/lib/i18n.ts`) | No — nothing is excluded, since nothing is filtered | none, deliberate. The two jobs' combined inputs span nearly every top-level directory (root, `apps/docs`, `content/docs`, `.github/scripts`, `tools/ci-scripts`); a filter that actually matched that footprint would be indistinguishable from no filter. Leaving it off is the correct shape, not an oversight. |
| `translations.yml` `pull_request` | `content/docs/**`, `apps/docs/lib/i18n.ts`, `.github/scripts/check-translation*.mjs`, `.github/workflows/translations.yml` | the 3 `check-translation*.mjs` files by basename, nothing under `lib/` | `content/docs/**` (corpus), `apps/docs/lib/i18n.ts` (locale list — read by all 3 check-translation* scripts), `check-translation-ownership.mjs`, `check-translations.mjs`, `check-translation-output.mjs`, and — transitively — `.github/scripts/lib/derived-locales.mjs`, imported by 2 of those 3 | **Yes** (#221's own finding) | Widened `.github/scripts/check-translation*.mjs` to `.github/scripts/**` |
| `translations.yml` `push` | `content/docs/**` only | content docs only | Same as above minus the `Ownership` step, which is gated `if: github.event_name == 'pull_request'`. `Freshness`, `Output validator self-test`, and `Output` have no such gate and run on push too — reading `apps/docs/lib/i18n.ts` and all 3 `check-translation*` scripts (plus `derived-locales.mjs`) exactly as on `pull_request` | **Yes** — same defect shape on the push side, not called out in #221 but found while doing the "every filter" pass it asked for | Added `apps/docs/lib/i18n.ts` and `.github/scripts/**` to the push filter |
| `deploy-docs.yml` `push` | `apps/docs/**`, `content/docs/**`, `pnpm-lock.yaml`, `.github/workflows/deploy-docs.yml` | apps/docs tree, docs content, lockfile, self | `opennextjs-cloudflare build && opennextjs-cloudflare deploy`, run from `apps/docs/`. Checked every config file it touches (`next.config.mjs`, `wrangler.jsonc`, `open-next.config.ts`, `source.config.ts`, `middleware.ts`, `mdx-components.tsx`) — all live under `apps/docs/**`. `apps/docs/tsconfig.json` has no `extends`, so it does not pull in root `tsconfig.base.json`. No dependency on anything in `.github/scripts/**` | No gap found | none |
| `deploy-docs.yml` (trigger scope) | no `pull_request` trigger at all | — | — | not a gap — deliberate: this is the deploy job, it should not fire from an unmerged branch. Standard push-only CD pattern. | none |

## Proof the widened filter matches by pattern, not by eye

GitHub's `paths:` filter rule: `*` never crosses `/`; `**` matches any characters including `/`. Rather than eyeball it, I ran the actual candidate paths through `minimatch` (globstar-enabled, matches GitHub's documented semantics) as an oracle:

```
OLD: .github/scripts/check-translation*.mjs
  MATCH     .github/scripts/check-translations.mjs
  MATCH     .github/scripts/check-translation-output.mjs
  MATCH     .github/scripts/check-translation-ownership.mjs
  no match  .github/scripts/lib/derived-locales.mjs      (the bug)
  no match  .github/scripts/check-node-floor.mjs
  no match  .github/scripts/check-locale-surface.mjs

NEW: .github/scripts/**
  MATCH     .github/scripts/check-translations.mjs
  MATCH     .github/scripts/check-translation-output.mjs
  MATCH     .github/scripts/check-translation-ownership.mjs
  MATCH     .github/scripts/lib/derived-locales.mjs      (fixed)
  MATCH     .github/scripts/check-node-floor.mjs
  MATCH     .github/scripts/check-locale-surface.mjs
  MATCH     .github/scripts/build-update-manifest.mjs
  no match  apps/docs/lib/i18n.ts
  no match  content/docs/foo.mdx
  no match  .github/workflows/translations.yml
```

## Newly-triggered paths — confirmed intended

`translations.yml`'s `pull_request` trigger will now also fire on edits to `check-node-floor.mjs`, `check-locale-surface.mjs`, and `build-update-manifest.mjs` (previously excluded — none of these are consumed by this workflow's job). Its `push` trigger will now also fire on `apps/docs/lib/i18n.ts`-only and `.github/scripts/**`-only pushes (previously the push filter only matched `content/docs/**`).

Both are intended, not scope creep: they match the precedent `turbo.json` already set (`$TURBO_ROOT$/.github/scripts/**` as the `test` task's input, i.e. the whole directory is already treated as one hash unit repo-wide), and they close this exact defect class for any future script `lib/` gains. The job itself is one lightweight job (checkout, node setup, 4 script invocations, no build step), so the CI-minutes cost of an occasional unrelated trigger is small.

One thing I looked at and did **not** wire in: `build-update-manifest.mjs` is not referenced by any workflow at all (no `paths:` filter names it, no `run:` step invokes it — its own header comment documents manual usage, invoked with an artifacts-directory argument and a tag argument). There is nothing to compare it against, so it is outside this audit's scope rather than a gap; noted here rather than silently left out.

## Verification

- `pnpm turbo run type-check --force`: exit 0
- `pnpm turbo run build --force`: exit 0 (1140 static pages generated)
- `pnpm turbo run test --force`: exit 0 (both `.github/scripts/*.mjs --self-test` suites pass, derived-locale fixtures included)
- `node .github/scripts/check-locale-surface.mjs`: exit 0, "every advertised URL has a source file and every source file is advertised"
- `node .github/scripts/check-translations.mjs`: exit 0, "translations gate passed"
- `node .github/scripts/check-translation-output.mjs --self-test`: exit 0
- `node .github/scripts/check-node-floor.mjs --self-test`: exit 0

All run `--force` (or, for the direct script invocations, freshly after a forced build) because the turbo cache is shared across this container's worktrees and a plain run replayed a cache hit from a sibling worktree (`objectos-issue-217`) on the first `type-check` attempt — caught and re-run before trusting the result. Exit codes were captured immediately after each command, from output redirected to a file, before any `tail` was read — never off the pipeline's own status.

Diff is limited to `.github/workflows/translations.yml` path filters and their explanatory comments — no job restructuring, no check weakened or removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_