### PR TITLE
refactor(docs): give the canonical host one definition in a leaf module

### DIFF
--- a/apps/docs/lib/seo.ts
+++ b/apps/docs/lib/seo.ts
@@ -1,24 +1,27 @@
 import { i18n } from '@/lib/i18n';
 import { source } from '@/lib/source';
+import { SITE_HOST } from '@/lib/site';
 
 /**
- * Canonical production host — the origin every absolute URL in this module is
+ * Canonical production origin — the origin every absolute URL in this module is
  * built on, and the `metadataBase` every relative metadata URL resolves against.
  *
- * `middleware.ts` spells the same host out a second time, and that duplication
- * is a decision rather than an oversight. It cannot import this constant: this
- * module imports `lib/source.ts`, so the import would drag the fumadocs loader
- * and every compiled MDX module into the edge runtime the middleware runs in.
- * Measured on this tree — middleware importing `SITE_URL` from here takes the
- * edge bundle from 149 KB to 14.7 MB of JavaScript, with `next build` still
- * exiting 0, so the cost surfaces at deploy rather than in CI.
+ * Derived from `SITE_HOST` in `lib/site.ts`, which `middleware.ts` imports for
+ * the canonical-domain redirect. That leaf module is now the single definition
+ * of the host; this is the `https://` origin built on it, the only form any
+ * node-runtime caller needs. Before it existed the host was spelled out twice,
+ * here and in `middleware.ts`, with nothing enforcing that the two agreed.
  *
- * The reason is recorded on both sides instead of a sync instruction, because
- * an instruction to a human is not a mechanism. Nothing here enforces that the
- * two agree; collapsing them properly needs a leaf module both runtimes can
- * import, which is a change to the file layout rather than to either file.
+ * `middleware.ts` still cannot import anything from THIS module, and the
+ * constraint has not softened — it has moved to `lib/site.ts`. Middleware runs
+ * in the edge runtime; this module imports `lib/source.ts`, which drags the
+ * fumadocs loader and every compiled MDX module into that bundle. Measured on
+ * this tree: 149,745 B of edge JavaScript becomes 17,375,914 B, roughly 116x,
+ * with `next build` still exiting 0 — so the cost surfaces at deploy on
+ * Cloudflare Workers rather than in CI. `lib/site.ts` is the import that is
+ * safe from both runtimes, and it stays safe only while it imports nothing.
  */
-export const SITE_URL = 'https://docs.objectos.ai';
+export const SITE_URL = `https://${SITE_HOST}`;
 
 /**
  * Absolute URL for a logical (locale-independent) path, hiding the locale

--- a/apps/docs/lib/site.ts
+++ b/apps/docs/lib/site.ts
@@ -1,0 +1,44 @@
+/**
+ * The canonical production host. One string, no imports, no dependents of its
+ * own — that is the entire contract of this file.
+ *
+ * ## Why it exists
+ *
+ * The host used to be written out twice. `SITE_URL` in `lib/seo.ts` builds every
+ * canonical tag, `og:url` and hreflang alternate the site renders; `middleware.ts`
+ * answers "which host is canonical" for every request before any page code runs.
+ * Nothing made the two agree, and nothing failed if they drifted — the redirect
+ * would have sent traffic to one host while the whole rendered surface named
+ * another, which is the specific failure the surrounding run of cards has been
+ * closing.
+ *
+ * ## Why it must import NOTHING
+ *
+ * `middleware.ts` runs in the **edge runtime**, and its bundle is whatever its
+ * import graph reaches. `lib/seo.ts` imports `lib/source.ts`, so reaching the
+ * host through that module pulls the fumadocs loader and every compiled MDX
+ * module into the edge bundle. Measured on this tree, one build apart:
+ * 149,745 B of edge JavaScript becomes 17,375,914 B — roughly 116x — and
+ * `next build` still exits 0, so no gate in CI reports it. This app deploys to
+ * Cloudflare Workers, so that cost arrives at deploy time on a change that read
+ * like an import cleanup.
+ *
+ * Both figures are the sum of the JS chunks the middleware entry names in
+ * `.next/server/middleware-manifest.json`, which is what actually ships to the
+ * edge. The route table `next build` prints reports no size for middleware, so
+ * there is nothing to read there instead — which is part of why this is easy to
+ * do by accident.
+ *
+ * This module is therefore a leaf by requirement, not by accident:
+ *
+ * - Never add an `import` here. Not `@/lib/source`, not `@/lib/i18n`, not
+ *   fumadocs, not anything that transitively reaches the MDX collection.
+ * - Never add a helper that would want one. `localeUrl`, the hreflang map and
+ *   everything else that needs `i18n.languages` belongs in `lib/seo.ts`, which
+ *   only the node runtime imports.
+ *
+ * The bare host is what the edge needs and it is the smaller of the two facts,
+ * so it is the one that lives here. The `https://` origin is derived from it in
+ * `lib/seo.ts`, the only place that needs that form.
+ */
+export const SITE_HOST = 'docs.objectos.ai';

--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -1,29 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Negotiator from 'negotiator';
 import { i18n } from '@/lib/i18n';
+import { SITE_HOST } from '@/lib/site';
 
 const LOCALE_COOKIE = 'FD_LOCALE';
 
 /**
- * The canonical docs host, and the legacy host that redirects to it.
+ * The legacy docs host, which redirects permanently to the canonical one.
  *
- * `CANONICAL_HOST` holds the same value as `SITE_URL` in `lib/seo.ts`, written
- * out a second time on purpose. This file runs in the **edge runtime**, and
- * `lib/seo.ts` imports `lib/source.ts` — so importing the constant from there
- * would pull the fumadocs loader and all 413 compiled MDX modules into this
- * bundle. Measured on this tree: the edge bundle goes from 149 KB to 14.7 MB of
- * JavaScript, and `next build` still exits 0, so nothing in CI would say so.
+ * The canonical host is `SITE_HOST`, imported above from `lib/site.ts` — the
+ * same constant `lib/seo.ts` builds `SITE_URL` on. The redirect target and every
+ * canonical tag, `og:url` and hreflang alternate the site renders are therefore
+ * one definition, where they used to be two literals with nothing enforcing that
+ * they agreed. Drift would have pointed this redirect at one host while the
+ * whole rendered surface named another.
  *
- * Two copies of one hostname is the smaller cost, and the copy belongs on this
- * side: this redirect answers "which host is canonical" for every request
- * before any page code runs, and that answer should not depend on the module
- * graph that builds pages. Collapsing the two would take a leaf module both
- * runtimes can import — not an import from `lib/seo.ts`.
- *
- * Nothing enforces that the two agree. That is the residual cost of the
- * decision, stated here so it is visible rather than discovered.
+ * Import the host from `@/lib/site` and never from `@/lib/seo`. This file runs
+ * in the **edge runtime**, and its bundle is whatever its import graph reaches:
+ * `lib/seo.ts` imports `lib/source.ts`, so reaching the host through it pulls
+ * the fumadocs loader and every compiled MDX module in here. Measured on this
+ * tree, one build apart: 149,745 B of edge JavaScript becomes 17,375,914 B,
+ * roughly 116x, and `next build` exits 0 either way — so nothing in CI reports
+ * it and the cost lands at deploy time on Cloudflare Workers. `lib/site.ts`
+ * exists to be the one import that cannot do that; it imports nothing, and the
+ * comment at the top of it is what keeps it that way.
  */
-const CANONICAL_HOST = 'docs.objectos.ai';
 const LEGACY_HOST = 'www.objectos.app';
 
 /**
@@ -256,7 +257,7 @@ export default function middleware(request: NextRequest) {
   if (host === LEGACY_HOST) {
     const target = new URL(request.url);
     target.protocol = 'https:';
-    target.host = CANONICAL_HOST;
+    target.host = SITE_HOST;
     target.port = '';
     return NextResponse.redirect(target, 308);
   }


### PR DESCRIPTION
Fixes #205

`SITE_URL` in `lib/seo.ts` and `CANONICAL_HOST` in `middleware.ts` were two literals for one value. `apps/docs/lib/site.ts` now holds the host and nothing else; `lib/seo.ts` derives the origin from it, `middleware.ts` redirects to it. `app/layout.tsx` needed no change — it takes `SITE_URL` from `lib/seo.ts`, which is still exported from there, just no longer written out there.

All measurements below are at `98ecc0e`, the branch head.

## The size, which is the acceptance criterion

Edge runtime JS = the sum of the JS chunks the middleware entry names in `.next/server/middleware-manifest.json`. The route table `next build` prints reports no size for middleware, so there is nothing to read there instead.

| tree | edge runtime JS | `next build` |
|---|---:|---|
| baseline, `0c4351f` | **149,745 B** | exit 0 |
| baseline rebuilt, no source change (control) | 149,745 B | exit 0 |
| **this branch, `98ecc0e`** | **149,745 B** | exit 0 |
| ablation: `middleware.ts` importing `@/lib/seo` | **17,375,914 B** | exit 0 |

Zero growth — and stronger than equal totals: the three chunk files are byte-for-byte identical to the baseline, same content-hashed names, same sizes (`[root-of-the-server]__07_86ae._.js` at 139,218 B in both). The import adds no module-wrapper overhead at all; the bundler inlines the constant exactly as it inlined the local one.

The baseline was re-measured rather than assumed. #205 recorded 149,491 B; the current figure is 149,745 B, 254 B higher, consistent with #223 and #225 having landed since.

The control row is the noise floor. Two builds of unmodified source produced the identical byte count, so the 0 B delta on this branch is a measurement and not a coincidence.

**The ablation row was measured on this tree, not quoted.** #205 carried 14,849,913 B from #204's run; on today's content, with zh-Hant shipped, pointing `middleware.ts` at `@/lib/seo` produces **17,375,914 B** — 116x, not 99x, and growing with the collection. `next build` exited 0, as advertised. The mutation was confirmed on disk before the build (grep counts on both the injected and the removed text) and the restore was verified by `git hash-object` against the HEAD blob, with `git diff HEAD` empty afterwards.

`apps/docs/lib/site.ts` imports nothing. It is one exported string and a comment explaining why it must stay that way.

## Rendered metadata unchanged

#204's method: every URL-bearing `link`/`meta` tag in the head of all 659 prerendered HTML files, plus every absolute URL in `robots.txt`, `sitemap.xml`, `llms.txt` and `llms-full.txt` — 12,696 rows, sorted, diffed.

```
baseline vs branch:   diff exit 0, 0 lines
control vs baseline:  diff exit 0, 0 lines     (proves the extraction is build-salt-insensitive)
```

No byte diff of `.next` was attempted; Next salts every build, so that comparison says nothing.

## The domain redirect

Six cases against `next start` on the branch build, plus four controls for what #223 and #225 established. Server killed by explicit PID after confirming its cwd was inside this worktree.

| case | request Host | path | result |
|---|---|---|---|
| 1 | `www.objectos.app` | `/docs/quickstart` | 308 `https://docs.objectos.ai/docs/quickstart` |
| 2 | `www.objectos.app` | `/docs/quickstart?utm_source=x&q=a%20b` | 308 `https://docs.objectos.ai/docs/quickstart?utm_source=x&q=a+b` |
| 3 | `www.objectos.app` | `/` | 308 `https://docs.objectos.ai/` |
| 4 | `docs.objectos.ai` | `/docs/quickstart` | 200 |
| 5 | local | `/cn/docs/quickstart` | 308 `/zh-Hans/docs/quickstart` |
| 6 | `www.objectos.app` | `/cn/docs/quickstart` | 308 `https://docs.objectos.ai/cn/docs/quickstart` |
| 7 | local | `/zh-Hant/docs/quickstart` | 200 |
| 8 | local | `/zh-hant/docs/quickstart` | 308 `/zh-Hant/docs/quickstart` |
| 9 | local | `/en/docs/quickstart` | 307 `/docs/quickstart` |

Case 2 preserves the query. Case 6 is the ordering control: the domain rule runs before the legacy-locale rule, so the host is corrected first and `/cn/` is handled on the next hop. Cases 7 to 9 are #225's folded-index behaviour, untouched.

## One definition is now an enforced definition

The card was filed because nothing failed if the two values drifted. They can no longer drift — there is one of them — and moving that one is caught by a gate that already exists.

`.github/scripts/check-locale-surface.mjs` keeps its own copy of the host on purpose, documented in place as the independent oracle: "a check that shares a constant with the thing it checks cannot catch that constant being wrong." It compares the built `sitemap.xml` against URLs it constructs from its own literal. `sitemap.ts` builds its URLs through `lib/seo.ts`, which now derives from `SITE_HOST` — so the gate transitively pins the middleware's redirect host as well, which it could not do before.

Measured, not asserted. Setting `SITE_HOST` to `docs.objectos.invalid` and rebuilding:

```
check-locale-surface.mjs   exit 1
✗ locale surface: 818 finding(s)
```

Restored and verified by hash against the HEAD blob. As a side observation, that run put the edge bundle at 149,750 B — exactly 5 B more, the length difference between the two hostnames. The host string is inlined into the edge chunk and the size tracks it byte for byte, which is independent confirmation that nothing but the string crosses the import.

## Gates

All at `98ecc0e`, all with `--force` because the turbo cache is shared across worktrees in this container, and all with the exit code captured before any pipe.

| command | exit |
|---|---|
| `turbo run build --force --filter=@objectos/docs` | 0, 1140/1140 pages |
| `turbo run type-check --force --filter=@objectos/docs` | 0 |
| `turbo run test --force` | 0 |
| `node .github/scripts/check-locale-surface.mjs` | 0, `sitemap.xml` 409 URLs, 0 unexpected, 0 missing |

No changeset: this repo has no `.changeset` directory and no changeset workflow.

## Out of scope, filed

- #226 — the legacy-host redirect compares the raw Host header, so `www.objectos.app:8080` skips the canonical redirect while the same block clears the port on the target side. Found while running the table above. Low severity and possibly zero in production; filed unassigned for triage, not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_