### PR TITLE
fix(docs): compare hostname, not authority, in legacy-host redirect

### DIFF
--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -253,8 +253,18 @@ function getPreferredLanguage(request: NextRequest): string {
  */
 export default function middleware(request: NextRequest) {
   // Canonical domain redirect: legacy docs host -> canonical host (permanent).
+  //
+  // The Host header carries the authority, `host[:port]` (RFC 9110 §7.2), not
+  // just the hostname. Comparing it whole tested only the bare-host shape:
+  // `www.objectos.app:8080` is not `=== LEGACY_HOST`, so a ported request fell
+  // through to locale negotiation and got served (200) under the legacy host
+  // instead of redirected (308) off it — while three lines below, the target
+  // side already strips its port (`target.port = ''`). The port was accounted
+  // for on the way out and not on the way in (#226); comparing the hostname on
+  // both sides closes that gap without changing the target normalisation.
   const host = request.headers.get('host');
-  if (host === LEGACY_HOST) {
+  const hostname = host?.split(':')[0];
+  if (hostname === LEGACY_HOST) {
     const target = new URL(request.url);
     target.protocol = 'https:';
     target.host = SITE_HOST;


### PR DESCRIPTION
Fixes #226

## The change

`middleware.ts`'s legacy-host redirect compared the raw `Host` header
(`host[:port]`, the authority) against a bare hostname literal, so
`www.objectos.app:8080` was never `===` `LEGACY_HOST` and fell through to
locale negotiation — served (200) under the legacy host instead of
redirected (308) off it. Three lines below, the same block already strips
the port from the *target* (`target.port = ''`), so the port was accounted
for on the way out and not on the way in.

Fix: compare the hostname (`host?.split(':')[0]`), not the authority, one
line. No change to the target-side normalisation.

## Verification

`next build` + `next start`, curl with an explicit `Host` header, PID killed
by explicit PID after each run (never `pkill -f`). The redirect table
reused from #204 / #223 / #225 / #227, plus the new row this card adds:

| # | Host header | path | before | after |
|---|---|---|---|---|
| 1 | `www.objectos.app` | `/docs/quickstart` | 308 → `https://docs.objectos.ai/docs/quickstart` | unchanged |
| 2 | `www.objectos.app` | `/docs/quickstart?utm=x&ref=y` | 308, query preserved | unchanged |
| 3 | `docs.objectos.ai` | `/docs/quickstart` | 200 (passthrough) | unchanged |
| 4 | `docs.objectos.ai` | `/zh-Hant/docs/quickstart` | 200 | unchanged |
| 5 | `docs.objectos.ai` | `/zh-hant/docs/quickstart` | 308 → `/zh-Hant/docs/quickstart` | unchanged |
| 6 (ordering control) | `www.objectos.app` | `/cn/docs/quickstart` | 308 → `https://docs.objectos.ai/cn/docs/quickstart` (domain rule wins; `/cn/` handled next hop) | unchanged |
| **7 (new)** | `www.objectos.app:8080` | `/docs/quickstart` | **200**, served under the legacy host (the bug) | **308** → `https://docs.objectos.ai/docs/quickstart`, no port on target |
| **guard** | `docs.objectos.ai:3000` | `/docs/quickstart` | 200 | **200, unchanged** — proves the fix compares against `LEGACY_HOST` specifically, not "strip the port from every Host and compare," which would have wrongly caught this row too |

#225's controls, re-checked on this tree: `/en/docs/quickstart` → 307
(default-locale strip). Matches expectations.

Row 7's "before" was reproduced empirically, not inferred: the pre-fix file
was rebuilt and started on its own port and returned 200 for the ported
legacy host, confirming the bug before restoring the fix and rebuilding
again for the final table above.

Gates, all fresh (`--force`, no turbo cache reuse), exit codes captured
before any pipe:

```
pnpm turbo run type-check --filter=@objectos/docs --force   EXIT=0
pnpm turbo run build --filter=@objectos/docs --force        EXIT=0
pnpm turbo run test --force                                 EXIT=0
node .github/scripts/check-locale-surface.mjs (repo root)   EXIT=0, 409/409 URLs, 0 unexpected/missing/duplicated
```

No `.changeset/` entry — this repo has no changeset tooling (confirmed: no
`.changeset/` directory, no changeset references in any `package.json` or
CI workflow); the site is a private, unpublished app.

File surface: `apps/docs/middleware.ts` only, as scoped — `git diff --stat`
confirms.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G5zjYc2BoFV2NjKBBapC7C)_