### PR TITLE
docs(operate): correct audit-logs missing-notification diagnostic

### DIFF
--- a/content/docs/operate/audit-logs.mdx
+++ b/content/docs/operate/audit-logs.mdx
@@ -99,10 +99,10 @@ and `Created At`.
 
 The `dedup_key` collapses duplicate emits, and `payload` carries the raw event
 context that templates render from. Because this log sits *upstream* of routing,
-a row here with no matching inbox message usually means a subscription or
-preference filtered the event out — check
-[Notifications](/docs/configure/notifications) when a user reports a missing
-alert.
+a row here with no matching inbox message usually means the audience did not
+resolve to that user, or their preference muted the topic on that channel —
+check [Notifications](/docs/configure/notifications) when a user reports a
+missing alert.
 
 Downstream, each event is materialized into per-user inbox messages
 (`sys_inbox_message`) — the recipient's view lives under


### PR DESCRIPTION
Fixes #146

## What

`content/docs/operate/audit-logs.mdx:102` told admins that a missing inbox
message "usually means a subscription or preference filtered the event out."
The subscription half is false — the subscription-to-recipient expansion is
not wired, so a `sys_notification_subscription` row cannot filter a delivery.
This drops "a subscription or" and names the two real causes: the audience
did not resolve to that user, or their preference muted the topic on that
channel. The preference half was already true and is unchanged in substance.

## Basis (re-verified at dispatch, `objectstack` `origin/main` @ `e452ad5`, up from the `2866d5f97e` the card was filed against)

- `AudienceSpec` (`packages/services/service-messaging/src/messaging-service.ts`)
  is `string | { ownerOf: {...} }` — no `'subscribers'` member;
  `EmitInput.audience` is required.
- `RecipientResolver.resolveOne()` (`recipient-resolver.ts`) branches on
  `user:` / `role:` / `team:` / `owner_of:` / email / bare id — no branch
  reads `sys_notification_subscription`.
- The object's own header carries `⚠️ [#9807] ... NOT WIRED in this repo`.
- `MessagingService.emit()` does call `PreferenceResolver.filter()` on the
  resolved recipients and logs `suppressed for all recipients by preference`
  when it empties — that half of the original sentence is real.

## Scope

One sentence, one file (`content/docs/operate/audit-logs.mdx`), per the
issue's declared surface and the 2026-08-23 triage adjudication (not
re-litigated here). No locale siblings exist for this page. The same false
claim on `content/docs/configure/notifications.mdx` is issue #147's surface
and is not touched here. The `cloud`-repo leg stays the issue's declared,
unmeasured narrowing.

## Tests

Run from the repo root (`objectos` has no changeset flow and no `packages/`):

- `pnpm turbo run build --force` → `Tasks: 1 successful, 1 total`
- `pnpm turbo run test --force` → `Tasks: 1 successful, 1 total` (includes
  the `check-locale-surface.mjs` self-tests)
- `node .github/scripts/check-locale-surface.mjs` (exit 0) →
  `✓ every advertised URL has a source file and every source file is
  advertised; both llms bodies carry every en-only page title and none from
  the other locales; and no page slug in the content tree contains a dot`

Verified at commit `4515729`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016TUrhcggSFrYctvp5dsV1A)_