### PR TITLE
fix(docs): delete the os studio CLI reference section

### DIFF
--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -71,10 +71,6 @@ os dev                         # port 3002 by default
 os dev -p 4002
 ```
 
-### `os studio` — dev server with the UI enabled
-
-Same as `os dev` but with the UI explicitly enabled.
-
 ## Project commands
 
 ### `os init` — scaffold a new project


### PR DESCRIPTION
Fixes #150

## What

Deletes the `### \`os studio\` — dev server with the UI enabled` section
(`content/docs/reference/cli.mdx:74-77`, four lines: heading, blank, the
single sentence, blank). Nothing else in the file changes — line 70's
stale `# port 3002 by default` comment is left untouched; it belongs to
#229, filed separately.

## Why deletion, not correction

Triage adjudicated this on 2026-08-23 and it is not re-litigable: delete,
do not replace with corrected instructions. `os dev` is documented
directly above the deleted section, and the glossary already carries the
`/_console/studio` route, so a correction would only duplicate content
that already exists elsewhere.

## Premise re-verified at implementation time

The dispatching card measured "no `studio` command" on `objectstack` at
a sha that was already stale by dispatch time. Re-verified just now on
current `objectstack` `origin/main` (`e452ad5`):

- `packages/cli/src/commands/` (via `git ls-tree`) has no `studio.ts` /
  `studio/` entry.
- Case-insensitive `git grep -il studio` under that directory hits only
  `i18n/extract.ts`, `lint.ts`, a migrate integration test, and a serve
  test — never a command definition. Control probe: the same grep style
  does find `dev.ts` under that directory, so the pattern is not
  silently matching nothing.
- `packages/cli/package.json`'s `oclif.commands` still uses
  `"strategy": "pattern"` against `./dist/commands` with no alias map,
  so the shipped command set is exactly the files on disk — confirmed
  unchanged from the dispatching card's measurement.

`os studio` still does not exist. The deletion stands.

## Blast radius

`git grep 'reference/cli#'` across `content/docs` returns zero anchor
links into any section of this file (control-probed: plain
`/docs/reference/cli` page links do exist in the corpus, e.g.
`build/ai-builder.mdx`, so the zero is a real absence and not a dead
probe). No other mention of "os studio" exists anywhere under
`content/docs`.

## Out of scope (left alone on purpose)

- Line 70 (`os dev  # port 3002 by default`) — wrong (measured default
  is 3000; `quickstart.mdx:200-203` already says so), and it's #229,
  filed specifically so it wouldn't ride along here.
- `objectstack packages/cli/README.md:45`'s stale row — filed as its own
  card in the framework repo by triage; not widened into this PR.
- Locale siblings — untouched; translations are never a dev agent's
  output in this repo.

## Verification

Run from the repo root, on worktree `objectos-issue-150` at commit
`a1fdc91`:

- `pnpm turbo run build --force` — `Tasks: 1 successful, 1 total`.
- `pnpm turbo run test --force` — `Tasks: 1 successful, 1 total`; the
  `check-locale-surface.mjs` self-tests inside it all pass.
- `node .github/scripts/check-locale-surface.mjs` (run directly, from
  repo root, after the build above) — verdict line: *"every advertised
  URL has a source file and every source file is advertised; both
  `llms` bodies carry every en-only page title and none from the other
  locales; and no page slug in the content tree contains a dot"*. This
  is the gate that would notice if deleting a heading moved the
  advertised `llms.txt` / `llms-full.txt` surface — it does not, since
  those track page titles, not sub-headings.

`git diff --stat`: `content/docs/reference/cli.mdx | 4 ----`, one file,
four deletions, nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TUrhcggSFrYctvp5dsV1A)_