### PR TITLE
fix(docs): correct os dev default port from 3002 to 3000

### DIFF
--- a/content/docs/reference/cli.mdx
+++ b/content/docs/reference/cli.mdx
@@ -67,9 +67,13 @@ Watches `objectstack.config.ts` and `src/`. Recompiles + reloads on
 save. Used as the npm `dev` script in scaffolded projects.
 
 ```bash
-os dev                         # port 3002 by default
-os dev -p 4002
+os dev                         # port 3000 by default
+os dev -p 4000
 ```
+
+Note `os dev` asks for the same port `os start` uses (3000). If that port
+is taken it binds the next free one and says so:
+`↪ server bound to port 3001 (requested 3000)`.
 
 ## Project commands
 


### PR DESCRIPTION
Fixes #229

## What changed

`content/docs/reference/cli.mdx:70` claimed `os dev` defaults to port **3002**. `content/docs/quickstart.mdx:200-203` (landed by #143 from a real boot transcript) already says the opposite: `os dev` asks for **3000**, the same port `os start` uses, and binds the next free port on collision. This PR brings line 70 into agreement with the measured, reviewed value.

```diff
-os dev                         # port 3002 by default
-os dev -p 4002
+os dev                         # port 3000 by default
+os dev -p 4000
+```
+
+Note `os dev` asks for the same port `os start` uses (3000). If that port
+is taken it binds the next free one and says so:
+`↪ server bound to port 3001 (requested 3000)`.
```

## The two calls the dispatch asked for

1. **How much belongs in the code-block comment.** Kept the inline comment terse (`# port 3000 by default`), matching this file's existing convention (`os start`'s block reads `# default port 3000`, `os serve`'s reads `# port 3000` — no comment in this file carries more than a few words). The collision/rebind behavior — the part that actually surprises someone running `os dev` next to `os start` — goes in a short note line under the block instead. That's not a new pattern for this file: `os start`'s block is immediately followed by an unfenced "HOME directory default:" note (lines 40-42) before the next heading, so a short prose line after a code block is already how this file handles "one more fact that doesn't fit in a comment." A two-sentence comment inside the `bash` fence would have broken the file's terse-comment convention for no reason the reader needs.
2. **`os dev -p 4002` → `4000`.** Took it. 4002 read as "3002 plus a bit"; now that the default is corrected, 4000 pairs the same way. Minor note: `os serve --port 4000 --no-ui` (three lines up) already uses 4000 as its example port, so this introduces a duplicate value in the same file — different flag spelling (`--port` vs `-p`) and different command, so I judged it not worth picking a different number just to avoid the repeat, but flagging it since the dispatch asked me to say which way I went and why.

## Premise check (dispatch's assumption, tested)

Confirmed 3000-with-next-free-port is still current behavior, checked against `@objectstack/cli` **17.2.0** (current `latest`) in `/home/user/objectstack`, not just the 17.1.0 the quickstart measurement used:

- `packages/cli/src/commands/dev.ts`: `const requestedPort = port ?? '3000';` — default is still 3000.
- `packages/cli/src/commands/serve.ts:680`: `port: Flags.string({ ..., default: readEnvWithDeprecation('OS_PORT', 'PORT', { silent: true }) ?? '3000' })` — same default on the child `serve` boots.
- The rebind message and `PORT_SEARCH_SPAN` collision-search logic in `serve.ts` are unchanged in shape; the most recent CLI commit touching this area (`4f9df8f`, 17.2.0, #13120) only changed *which number* the three announcement channels report (the actually-bound port via `IHttpServer.getPort()`, fixing a `--port 0` edge case) — it did not change the default or the collision behavior itself.

No re-arm of #141 needed; this stays the card it was filed as.

Also re-ran the issue's own re-check command on `origin/main`: `cli.mdx` was the only English file still carrying the 3002 claim; the seven `quickstart.<locale>.mdx` siblings still carry it (correctly, per scope — left untouched) and `quickstart.mdx` itself was already correct (also left untouched).

## Scope

Only `content/docs/reference/cli.mdx`, lines 70-71 plus the new note line. No locale siblings touched, `quickstart.mdx` untouched, no neighbouring sections tidied.

## Verification (all from repo root, per dispatch)

```
$ pnpm turbo run build --force
...
 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total

$ pnpm turbo run test --force
...
 Tasks:    1 successful, 1 total
Cached:    0 cached, 1 total

$ node .github/scripts/check-locale-surface.mjs
...
✓ every advertised URL has a source file and every source file is advertised; both `llms` bodies carry every en-only page title and none from the other locales; and no page slug in the content tree contains a dot
```

All three exit 0 with clean verdict lines (captured before any pipe). Also spot-checked the actual Next.js build output (`apps/docs/.next/server/app/llms.mdx/docs/reference/cli.body`) contains the corrected text, so this isn't just a source-file edit — it renders. No changeset needed (this repo has no changeset flow / no `packages/`).

This repo has no `skip-changeset` label mechanism (that's an `objectstack` convention) and no `packages/`, so nothing else to check there.

Verified at commit `58f660a` (current HEAD of this branch).


---
_Generated by [Claude Code](https://claude.ai/code/session_016TUrhcggSFrYctvp5dsV1A)_