### PR TITLE
docs(configure): say which channels render a Notification Template

### DIFF
--- a/content/docs/configure/notifications.mdx
+++ b/content/docs/configure/notifications.mdx
@@ -25,8 +25,10 @@ emit() + explicit audience  →  Notification Event  →  recipients, filtered b
    read it.
 3. **Routing** — For each event, ObjectOS expands the audience the producer
    passed into recipients, checks whether each recipient allows that topic on
-   that channel (**Preferences**), and renders the message for the recipient's
-   channel and locale (**Templates**).
+   that channel (**Preferences**), and hands each accepted delivery to its
+   channel, which renders it. What a channel renders *from* differs by channel:
+   email and SMS render **Notification Templates**; the in-app inbox does not
+   (see [What each channel renders](#what-each-channel-renders)).
 4. **Inbox Message** (`sys_inbox_message`) — The materialized, per-user result
    the recipient actually sees in their inbox.
 
@@ -41,7 +43,7 @@ For a single event, these are the inputs that decide who gets what:
 |---|---|
 | The audience passed to `emit()` | *Who receives this?* — the producer names the recipients, and this is the only input that puts anyone on the list |
 | Notification Preference | *Does this recipient allow it here?* — the per-user mute/allow for the topic and channel, applied to every (recipient × channel) pair |
-| Notification Template | *How is it written?* — the subject and body to render for the recipient's channel and locale |
+| Notification Template | *How is it written?* — the subject and body rendered on the **email** and **SMS** channels. The in-app inbox does not read these rows; see [What each channel renders](#what-each-channel-renders) |
 | Notification Subscription | *Who declared standing interest?* — admin-authored rows, **not consulted when an event is routed** |
 
 A recipient reaches the inbox when the producer's audience resolves to them and
@@ -154,9 +156,10 @@ value first.
 
 At **Setup → Configuration → Notification Templates** (`sys_notification_template`).
 
-A per **(topic × channel × locale)** render template. Templates turn an event
-payload into the subject and body a recipient reads, in their locale and for
-their channel.
+A per **(topic × channel × locale)** render template, read by the **email** and
+**SMS** channels: a template turns an event payload into the subject and body
+those channels send. The in-app inbox does not read these rows — see
+[What each channel renders](#what-each-channel-renders).
 
 | Field | Purpose |
 |---|---|
@@ -173,6 +176,23 @@ These objects are **system-managed**: rows are seeded by the platform and the
 capabilities you run, so most of your work is editing template content or
 toggling `is_active`, `enabled`, and preference defaults rather than creating
 records from scratch.
+
+### What each channel renders
+
+Rendering happens per channel, and only two channels read the rows above:
+
+| Channel | Renders from |
+|---|---|
+| **Email** | The Notification Template matching (topic, `email`, locale). With no matching active row, the notification's own title and body are sent as-is |
+| **SMS** | The Notification Template matching (topic, `sms`, locale), with the same fallback |
+| **In-app inbox** | **Not a Notification Template.** The inbox row is written from the notification's own title and body — the topic, when the producer set no title. When the notification names an email template instead, the inbox renders that one: a `sys_email_template` row resolved by (name, locale) through the email service, which [Email](/docs/configure/email#templates) documents. Without an email service able to render it, that delivery fails rather than falling back |
+
+> **Warning:** `inbox` is the **default** channel — a notification that names no
+> channels is delivered there and nowhere else. So the delivery an admin is
+> most likely looking at is the one that never reads a Notification Template:
+> editing a template row here changes what email and SMS send, and changes
+> nothing about the in-app message. This page describes the wiring as it
+> stands; it does not forecast an inbox seam to these rows.
 
 ## Where to go next
 


### PR DESCRIPTION
Fixes #147

`content/docs/configure/notifications.mdx` described Templates as the render stage for **every** delivery. Only the email and SMS channels work that way. The in-app inbox does not — and `inbox` is the default channel, so the delivery an admin is most likely looking at is the one that ignores the Notification Template row they are editing.

## What changed (one file, prose only)

| Where | Before | After |
|---|---|---|
| Pipeline step 3 | "…and renders the message for the recipient's channel and locale (**Templates**)" | hands each accepted delivery to its channel, which renders it; email and SMS render Notification Templates, the in-app inbox does not |
| Routing-inputs table, Notification Template row | "the subject and body to render for the recipient's channel and locale" | "the subject and body rendered on the **email** and **SMS** channels", with a pointer to the new section |
| Notification Templates intro | "Templates turn an event payload into the subject and body a recipient reads…" | same sentence, scoped to the two channels that read the rows |
| New `### What each channel renders` | — | a three-row table (email / SMS / in-app inbox) plus a warning that `inbox` is the default channel |

## Evidence — call path traced on `objectstack` `origin/main` @ `9e0ba21`

The card measured at `2866d5f9` and the dispatch re-measured strings at `e452ad5`; upstream `main` has since moved to `9e0ba21`, so this was re-traced rather than re-read.

- `messaging-service.ts:884` — `const channels = input.channels?.length ? input.channels : ['inbox'];`. Confirms `inbox` is the always-on default.
- No central render step exists. `messaging-service.ts` fans each delivery out to `this.channels.get(channelId).send(...)`; each channel renders itself. `NotificationTemplateStore` (`template-renderer.ts`, `TEMPLATE_OBJECT = 'sys_notification_template'`) is imported by `email-channel.ts`, `sms-channel.ts`, `messaging-service-plugin.ts` and the barrel — **and by nothing else**. `git grep sys_notification_template` over `service-messaging/src` returns zero hits in `inbox-channel.ts`.
- `messaging-service-plugin.ts:249` and `:267` construct the email and SMS channels with `store: templateStore`. Line `:159` constructs the inbox channel with `{ getData, getEmail, getDefaultTemplateLocale }` — no store, so the notification-template renderer never reaches it.
- `email-channel.ts:225` / `sms-channel.ts:125` — `store.load(n.topic, 'email' | 'sms', locale)` then `renderNotification(...)`, whose no-row fallback is the notification's own title/body.
- `inbox-channel.ts:125-126` — `let title = n.title; let bodyMd = n.body;`, written into `sys_inbox_message` at `:164-174`. Title falls back to the topic at emit time (`messaging-service.ts:917`/`:949`, `str(payload.title) ?? input.topic`).
- `inbox-channel.ts:132-162` — the notify `template` path calls `IEmailService.renderTemplate` over a **`sys_email_template`** row resolved by `(name, locale)`, and returns `TEMPLATE_UNSUPPORTED` (graded permanent at `:206`) when no email service provides the method.

So the premise holds at current upstream `main`: email and SMS render the object this page documents, the inbox never does.

## One deviation from the dispatch, called out

The dispatch asked me to cite the upstream gap note — the `service-messaging` CHANGELOG sentence that the inbox "has no locale-capable rendering seam to the email-template subsystem today". **That sentence is stale, and stale within its own release.** It belongs to the `#9205` changeset under `17.1.0`; the `#9225` changeset in the *same* `17.1.0` block built exactly that seam ("the inbox channel consumes it — localized `sys_email_template` content now reaches `sys_inbox_message`"). What is still missing is a different seam: inbox to `sys_notification_template`, which no upstream note currently calls a tracked gap.

Citing the stale sentence would have put a false claim in the docs. So the page states today's wiring and explicitly does not forecast a seam ("This page describes the wiring as it stands; it does not forecast an inbox seam to these rows"), which is the intent of that instruction. Flagging it rather than deciding quietly.

## Scope

- One file, prose only. `sys_email_template` is named once, as the object the inbox template path consults, and links to [Email](/docs/configure/email#templates) — that page owns it (`configure/email.mdx:57`), so there was no ownership gap to file.
- The `role:` tier callout (now line 139, line 137 before this diff) is untouched — that region belongs to the in-flight card #153. Hunk ranges are 28, 44, 157 and 176; none reaches it.
- `operate/audit-logs.mdx` untouched. No locale siblings touched: `git diff --name-status` against the base is a single `M` line.
- A sibling claim on the same page — the field-table row saying a template's locale is "matched to the recipient" — is **not** corrected here. The delivery path never reads a recipient locale (`messaging-service.ts` has no occurrence of `locale`; the channels take `payload.locale` else a deployment default). That is a different claim from the one this card adjudicated, so it is recorded in #246 for triage instead of being ridden in.

## Verification — all runs on `0510eb8`, the head of this branch

Nothing was edited after these runs; the tree they measured is this commit.

- `pnpm turbo run build --force --concurrency=2` — `Tasks: 1 successful, 1 total`, wrapper `VERDICT command-exit 0`.
- `pnpm turbo run test --force --concurrency=2` — `Tasks: 1 successful, 1 total`, wrapper `VERDICT command-exit 0`.
- `node .github/scripts/check-locale-surface.mjs` from the repo root — exit `0`: "every advertised URL has a source file and every source file is advertised; both `llms` bodies carry every en-only page title and none from the other locales; and no page slug in the content tree contains a dot".

**The locale-surface oracle is unchanged, which is the positive evidence that this PR adds and drops no page.** The gate derives it from `content/docs/` and `apps/docs/lib/i18n.ts`; it reports **79 logical pages over 8 locales = 397 docs entries**, and `git diff --name-status --diff-filter=ADR` against the base over `content` and `apps/docs/lib/i18n.ts` returns **zero rows** — no file added, deleted or renamed, so the inventory the oracle is built from is byte-identical to base. The artifacts agree: `sitemap.xml` 409 URLs read, 409 expected, 0 unexpected, 0 missing; both `llms` bodies 60/60 with 0 unexpected and 0 missing.

No changeset: `objectos` has no `packages/` publish flow and this is a docs-content change.

---
_Generated by [Claude Code](https://claude.ai/code/session_016TUrhcggSFrYctvp5dsV1A)_