### PR TITLE
docs(configure): federation ships today, and defineDatasource() exists

### DIFF
--- a/content/docs/configure/data-sources.mdx
+++ b/content/docs/configure/data-sources.mdx
@@ -85,9 +85,14 @@ export default defineStack({
 });
 ```
 
-> There is **no** `defineDatasource()` helper. A datasource is just a
-> `Datasource` object you place in the `datasources` array — exactly like
-> the `examples/app-crm` stack does in the framework repo.
+> **A `defineDatasource()` helper is also available.** The plain
+> `Datasource` object above is a valid datasource — it is exactly what the
+> `examples/app-crm` stack does in the framework repo — and
+> `defineDatasource()`, exported from `@objectstack/spec` (and
+> `@objectstack/spec/data`), takes the same config and runs the
+> `DatasourceSchema` validation at the point of declaration, so a bad field
+> is reported where you wrote it. The framework's own federation guide uses
+> it.
 
 ## Binding objects to a datasource
 
@@ -229,26 +234,17 @@ configuration that backs the `default` datasource.
 - **Scope with permissions.** Object- and field-level permissions apply
   to connected data exactly as they do to native objects.
 
-## Roadmap: in-product External Datasource Federation
+## In-product external datasource federation
 
 The flow above — connect a database, model objects, generate them with a
-coding agent — works today with shipped building blocks. A richer,
-**turn-key federation** experience is in active design under
+coding agent — is the general path. The **turn-key federation** flow on top
+of it, specified in
 [ADR-0015](https://github.com/objectstack-ai/objectstack/blob/main/docs/adr/0015-external-datasource-federation.md)
-(status: *Proposed*). Planned, **not yet shipped**:
+(status: *Accepted*), **ships today**: bind objects to tables ObjectOS does
+not own, with validation gates around them.
 
-- A `schemaMode` (`managed` / `external` / `validate-only`) so ObjectOS
-  can bind to tables it does **not** own without trying to migrate them.
-- An `external` binding sub-record on objects mapping object fields to
-  existing columns.
-- An `os datasource introspect` / `validate` CLI to import a schema and
-  scaffold objects in one step.
-- Boot-time and write-time **safety gates** for externally-owned schemas,
-  plus a Studio wizard for the whole flow.
-
-Until those land, prefer the documented path: declare the datasource,
-bind objects (generated or hand-written), and verify against a
-non-production copy first.
+It is documented once, with the framework docs that own the surface —
+[External Datasources (Federation)](https://docs.objectstack.ai/docs/data-modeling/external-datasources).
 
 ## Where to go next
 


### PR DESCRIPTION
Fixes #250

`content/docs/configure/data-sources.mdx` carried two claims that a shipped
capability does not exist. Both are corrected here; nothing else on the page
changes.

## 1. The "Roadmap" section becomes a pointer, not a second description

The section titled **"Roadmap: in-product External Datasource Federation"** —
its heading, its "Planned, **not yet shipped**" framing, the four bullets and
the "until those land, prefer the documented path" closer — is replaced by a
short pointer to the framework guide that owns this surface,
`data-modeling/external-datasources`.

Linking rather than re-describing is the adjudicated direction on the card:
the mirror follows, it does not lead. Re-stating `schemaMode`, the `external`
binding, the CLI or the wizard here would recreate the second copy that
drifted apart in the first place. The ADR-0015 link survives; its
"status: *Proposed*" gloss does not, because the ADR's own status line no
longer says that.

## 2. The `defineDatasource()` denial is corrected

Line 88 said "There is **no** `defineDatasource()` helper." The helper is
exported. Note the shape of the defect: the plain-object form the page
teaches **still works**, so this was a wrong denial rather than a broken
example — the replacement names the helper as available and explicitly keeps
the plain `Datasource` literal valid.

## Premise re-check (re-run at dispatch time, not carried forward)

Card measured at `objectstack` `origin/main` @ `7cbe705b`; PM re-measured at
`90ff957`; upstream had moved again to `2514d49` by the time this ran, so
every leg was re-run there. All hold:

| Leg | Reading at `objectstack` `origin/main` @ `2514d49` |
|---|---|
| ADR-0015 status | `**Status**: Accepted — backend/REST/CLI implemented; Studio UI + extra dialect drivers pending` |
| `defineDatasource` | `packages/spec/src/data/datasource.zod.ts:816`; re-exported at `packages/spec/src/index.ts:171` and via `./data`. Control probe: the same pathspec returns 20 other `export function define…` hits, so the match is a real reading |
| Bullet 1 `schemaMode` | `SchemaModeSchema` at `datasource.zod.ts:238`, wired at `:651` as `schemaMode: SchemaModeSchema.default('managed')` |
| Bullet 2 `external` binding | `ObjectExternalBindingSchema`, wired at `object.zod.ts:1919` as `external: ObjectExternalBindingSchema.optional()` |
| Bullet 3 CLI | `packages/cli/src/commands/datasource/{introspect,validate,list-tables}.ts` all present |
| Bullet 4 gates + wizard | ADR-0062 R6 boot gate ✅ (`packages/runtime/src/external-validation-plugin.ts`), R5c write gate (double opt-in) ✅, R7 introspection + runtime Sync wizard ✅ |

Each of the four bullets was verified individually rather than as a group, so
that a single still-unshipped bullet would have split the edit instead of
being deleted along with the others. None was.

The page's own three lines were confirmed present before editing: `:232` the
Roadmap heading, `:238` the "Planned, **not yet shipped**" line, `:88` the
denial.

⛔ Deliberately not claimed anywhere on the page: which dialect drivers or
Studio surfaces remain pending. That forecast is what this lane keeps having
to delete, and the guide this page now points at is where the current state
is maintained.

## Gates (all at `feeeec8`)

| Gate | Its own verdict |
|---|---|
| `pnpm turbo run type-check build --filter=@objectos/docs` | `Tasks: 2 successful, 2 total` · `Cached: 0 cached` (the content change moved the hash — no replayed green) |
| `pnpm turbo run test` | `Tasks: 1 successful, 1 total`; `✓ 4 self-test(s) passed` |
| `apps/docs/scripts/gen-zh-hant.mjs --check` | `✓ zh-Hant: 73 generated file(s) match the zh-Hans sources byte for byte.` |
| `check-translations.mjs` | `✓ translations gate passed` |
| `check-translation-ownership.mjs` | `⚠ TRANSLATION_BOT_LOGIN is not set — ownership is not enforced yet.` `This PR touches 0 translation artifact(s) and 1 other file(s).` |
| `check-locale-surface.mjs` | `✓ every advertised URL has a source file and every source file is advertised…` |
| `check-node-floor.mjs` (+ `--self-test`) | `✅ Every declared floor clears what the dependency tree requires` |

Rendered output checked on the real build artifact
(`apps/docs/.next/server/app/en/docs/configure/data-sources.html`), not just
on the source: the new heading and the pointer link are present, and
`Roadmap: in-product`, `not yet shipped`, `status: Proposed` and
`There is no` all return zero hits.

English only, per AGENTS.md — the seven locale siblings of this page are
untouched and are now stale, which the freshness gate reports and the next
translation pass fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S)_