### PR TITLE
docs: scope "the runtime image" to ObjectOS where the claim depends on it

### DIFF
--- a/content/docs/build/marketplace.mdx
+++ b/content/docs/build/marketplace.mdx
@@ -57,7 +57,7 @@ You ─→ ObjectOS ─→ Marketplace tab ─→ pick app ─→ Install
 
 | Catalog | Source | When to use |
 |---|---|---|
-| **Default** | Pre-bundled with the runtime image | First-time eval, demos, offline |
+| **Default** | Pre-bundled with the ObjectOS runtime image | First-time eval, demos, offline |
 | **ObjectStack public catalog** | Public app registry | Latest community + first-party apps |
 | **Private catalog** | Your own published artifacts | Internal apps you don't want public |
 | **Local** | Files mounted into the runtime | Air-gapped, custom builds |

--- a/content/docs/deploy/air-gapped.mdx
+++ b/content/docs/deploy/air-gapped.mdx
@@ -81,8 +81,9 @@ with it.
 
 ## Getting the image inside the network
 
-The runtime image lives in a private registry that a disconnected site cannot
-reach, so the image crosses the boundary the way your other artefacts do.
+The ObjectOS runtime image lives in a private registry that a disconnected
+site cannot reach, so the image crosses the boundary the way your other
+artefacts do.
 
 Do the verification on the connected side, while you still have the registry
 and the tooling: check the **signature**, the **SBOM** and the **build

--- a/content/docs/reference/environment-variables.mdx
+++ b/content/docs/reference/environment-variables.mdx
@@ -156,7 +156,7 @@ they can be used.
 | Retired name | What to use instead |
 |---|---|
 | `OS_ARTIFACT_FILE` | `OS_ARTIFACT_URL`. Nothing in the shipped runtime reads `OS_ARTIFACT_FILE`; a deployment that sets it gets the boot it would have got with nothing set, and no error naming the mistake. A local file is `file://` on the replacement, and the replacement carries the integrity pin. |
-| `OS_ARTIFACT_PATH` | `OS_ARTIFACT_URL`. **The runtime image refuses a boot that carries a non-default `OS_ARTIFACT_PATH`**, naming the replacement. Two spellings for "which artifact do I boot" is one dialect too many, and the retired one never carried an integrity pin. |
+| `OS_ARTIFACT_PATH` | `OS_ARTIFACT_URL`. **The ObjectOS runtime image refuses a boot that carries a non-default `OS_ARTIFACT_PATH`**, naming the replacement. Two spellings for "which artifact do I boot" is one dialect too many, and the retired one never carried an integrity pin. |
 | `OS_BUSINESS_DB_URL` | `OS_DATABASE_URL`, or a datasource declared in the artifact. Nothing reads `OS_BUSINESS_DB_URL`; a deployment that sets it and nothing else has no database configured at all. |
 
 `OS_CLOUD_API_KEY` is **not** a variable a self-hosted deployment sets. It is

--- a/content/docs/reference/runtime-capabilities.mdx
+++ b/content/docs/reference/runtime-capabilities.mdx
@@ -56,8 +56,8 @@ when an optional package is missing during development — but in
 1. Treat capability warnings as deployment failures. Grep startup logs
    for `capability not loaded` (or your equivalent) and fail the
    readiness probe / rollout if any appear.
-2. Pin the runtime image to one that includes every package your
-   artifacts declare in `requires`.
+2. Pin the ObjectOS runtime image to one that includes every package
+   your artifacts declare in `requires`.
 3. When publishing an artifact, document its `requires` list alongside
    it so operators can verify the matching image.
 


### PR DESCRIPTION
Fixes #253

Scopes the bare phrase "the runtime image" to **the ObjectOS runtime image** at the four sites where the phrase is bare *and* the claim depends on which image is meant. Subject only — no behavioural claim is added, softened or removed anywhere in this diff.

## The rule applied

Scope the phrase where **the sentence's truth or the reader's action depends on which image is meant**; leave it where the sentence holds for both. A bare phrase in a referent-independent sentence is not a defect, and renaming it would be churn.

## What changed (4 sites, 4 files)

| Site | Before | After | Why it is referent-dependent |
|:--|:--|:--|:--|
| `deploy/air-gapped.mdx:84` | "**The runtime image** lives in a private registry ..." | "**The ObjectOS runtime image** lives in ..." | The framework image is Apache-2.0 and public, so the sentence is simply false of it |
| `reference/environment-variables.mdx:159` | "**The runtime image refuses a boot that carries a non-default `OS_ARTIFACT_PATH`**" | "**The ObjectOS runtime image refuses a boot ...**" | The exact sentence whose unscoped subject produced the false conclusion in #251 |
| `reference/runtime-capabilities.mdx:59` | "Pin **the runtime image** to one that includes every package ..." | "Pin **the ObjectOS runtime image** to one ..." | An actionable instruction whose answer differs by image |
| `build/marketplace.mdx:60` | "Pre-bundled with **the runtime image**" | "Pre-bundled with **the ObjectOS runtime image**" | What a default catalog ships with differs by image |

Two paragraphs are re-wrapped to their file's prose width (77 and 70 columns respectively); that is the only reason the diff shows 7 insertions rather than 4.

## Carve-outs — respected, and here is the check

- **`reference/environment-variables.mdx:159`** — only the **subject** is made explicit. The refusal claim is byte-identical apart from the inserted word: no assertion that the refusal exists, no softening, no deletion. That question is #251's and stays open.
- **`reference/cli.mdx:54-56`** — **not touched at all.** It already writes "on the ObjectOS / runtime image" (wrapped across the line break), so it needed no edit.

The fault line held: this PR fixes *who a sentence is about*, never *whether that sentence is true*.

## The four bare uses deliberately left

| Site | Why it stays bare |
|:--|:--|
| `architecture.mdx:120` | Release-axis framing — true of either image |
| `configure/runtime.mdx:25` | Same claim, same reason |
| `reference/environment-variables.mdx:89` | "The runtime image and the app it serves are independent release axes" — the *same claim* as the two above, so it fails the test for the same reason |
| `resources/license.mdx:104` | Referent B, already scoped in-sentence by "in the framework repository" |

`environment-variables.mdx:89` is the judgment call worth naming: it sits in an edited file, so leaving it is a decision rather than an oversight. Scoping it would have made the corpus newly inconsistent — the identical release-axis claim scoped on one page and unscoped on two others.

## Sweep finding: the population is 13 sites, not 12

The card enumerated its sites. A single-line `grep` reproduces that list exactly, but a **multiline** sweep finds one more:

`deploy/docker.mdx:13-14` — "registry credentials for the private runtime / image" — wraps across a line break, so no line-oriented search can see it. Referent A, already scoped by "private", so it needs no edit. The same wrapping is why `cli.mdx:55` looks absent from a grep for "ObjectOS runtime image" while in fact being the one already-correct site.

Population: 13 occurrences over 10 files. Enumeration under-counted by exactly the site a line-oriented method is blind to.

## Locale handling

`runtime-capabilities.mdx` and `marketplace.mdx` each have **7 locale siblings**; `air-gapped.mdx` and `environment-variables.mdx` have **zero**. Per AGENTS.md, English is edited and the siblings are left to the translation pass — the freshness gate lists them under `Stale translations`, which is the non-blocking category by design. No sibling file is modified, and no `translation:` frontmatter is hand-written. `zh-Hant` is unaffected because `zh-Hans` is untouched.

## Gates

Run at `38cdd9a`. Exit codes captured by redirecting to a file first, never read through a pipe. Each gate's own verdict line:

| Gate | Its own conclusion |
|:--|:--|
| `gen-zh-hant.mjs --check` | `zh-Hant: 73 generated file(s) match the zh-Hans sources byte for byte` |
| `check-translations.mjs` | `translations gate passed` — the 4 pages' siblings appear only under `Stale translations` (non-blocking) |
| `check-translation-ownership.mjs` | `This PR touches 0 translation artifact(s) and 4 other file(s)` |
| `check-translation-output.mjs --self-test` | `29 rule case(s) ... every rule demonstrated able to fail` |
| `check-translation-output.mjs --files` | `translation output gate passed (139 pre-existing finding(s) reported)` — none in these files |
| `check-node-floor.mjs` | `Every declared floor clears what the dependency tree requires` |
| `turbo run type-check` | `1 successful` — **cache miss**, so it ran on this content |
| `turbo run build` | `1 successful` — **cache miss** |
| `check-locale-surface.mjs` | `every advertised URL has a source file and every source file is advertised`; 397 docs entries, composition unchanged |
| `turbo run test` | `1 successful`, but **FULL TURBO cached** — its declared inputs exclude `content/docs`, so it is not a measurement of this change |

The build logs 465 `Failed to load dynamic font` errors from OG-image generation (`self-signed certificate in certificate chain`). Pre-existing environmental noise from the sandbox proxy: the count is **identical (465)** in a build of the parent commit, and the build exits 0.

Rendered-output check: all four new strings appear in `apps/docs/.next/server/app/**`, and none of the four replaced strings appears anywhere in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S