### PR TITLE
ci: run the half-state sweeper's 1551-case self-test in the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,29 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      # `scripts/pm/check-half-states.mjs` is a verbatim upstream copy (#237)
+      # whose 1551 cases were run by nothing here. It is a STEP and not a
+      # registry entry because `tools/ci-scripts/run-self-tests.mjs` scans
+      # `.github/scripts` top level only, and that is load-bearing — it is what
+      # lets `.github/scripts/lib/` exist without tripping the
+      # unregistered-self-test rule. Widening the scan to reach one script would
+      # change this repo's gate topology; a step changes nothing.
+      #
+      # What it buys is a drift detector, not a hash-pin: #237's ablation
+      # mutated `DEFAULT_SWEEP_REPO` in this copy and 2 of the 1551 went red, so
+      # an edit here that changes BEHAVIOUR fails. One that changes bytes
+      # without changing behaviour still passes — pinning this copy to upstream
+      # byte for byte needs a cross-repo credential and is a separate decision.
+      #
+      # `--self-test` is the whole of it. Without the flag the script runs a
+      # live sweep needing a transport prerequisite this job does not have; that
+      # caller is `.github/workflows/half-state-patrol.yml`, on its own
+      # schedule. Zero-dependency and about a second, so it runs before the
+      # build rather than behind it.
+      - name: Half-state sweeper self-test
+        shell: bash
+        run: node scripts/pm/check-half-states.mjs --self-test
+
       # `content/docs/**/*.zh-Hant.mdx` and `meta.zh-Hant.json` are generated
       # from the Simplified siblings by `apps/docs/scripts/gen-zh-hant.mjs` and
       # committed, because `lib/seo.ts` tells a real translation from an English


### PR DESCRIPTION
Fixes #244

Adjudicated option B, transcribed: one step in the existing `build` job of `.github/workflows/ci.yml`. No registry change, no scan-surface change, no partial hash-pin. Diff is 23 added lines in one file; nothing else in the tree is touched.

## Premise re-verified at `562b9e6` — both legs hold, plus a third I checked

- `grep -n 'check-half-states' .github/workflows/ci.yml` → **0 hits** (grep exit 1). Control-probed rather than trusting a bare zero: the same pathspec yields `build:` at `:46` and named steps at `:33`, `:42`, `:69`, `:91`, so it reaches live content.
- `pnpm turbo run test --force` printed `✓ 4 self-test(s) passed` — **not 5**. `check-half-states` occurs **0** times anywhere in that run's output.
- Beyond the card: `.github/workflows/half-state-patrol.yml` is a standing caller of the script, but of the **live sweep**, not of `--self-test` — its only `self-test` occurrence is at `:248`, inside a JS comment string. Repo-wide, across all four workflows, nothing invoked `check-half-states.mjs --self-test`. Corroborating: `turbo.json`'s `test` task lists `$TURBO_ROOT$/.github/scripts/**` as an input and does not list `scripts/pm/**`.

## Carve-outs honoured, verified mechanically rather than asserted

- `tools/ci-scripts/run-self-tests.mjs` untouched. Its top-level-only scan remains load-bearing (`SCRIPTS = join(ROOT, '.github/scripts')` at `:73`, `readdirSync` without `recursive` at `:123`, deliberate per its own comment at `:95-96`).
- The three files PR #237 landed are untouched. `git diff --name-only HEAD` over them is empty, and the pinned script's blob OID is `9ffcdb7646c3b3aaceab2e81596f1c55c28a6984` both before and after all verification work here — identical to `HEAD:scripts/pm/check-half-states.mjs`.
- After the change, `pnpm turbo run test` still reports `✓ 4 self-test(s) passed`. The registry count being **unchanged** is the mechanical evidence that this landed as a step and not as a registry entry.
- The cross-repo hash-pin is not attempted, not even partially.

## The verdict line — observed LOCALLY, not in CI

This PR alters the very job that will execute the step, so CI's own execution can only be observed once this PR opens. What is reported below is a local run; it is not evidence that the CI step fired.

The step was extracted **verbatim from the committed YAML** (parsed, not retyped: `run` = `node scripts/pm/check-half-states.mjs --self-test`, `shell: bash`) and executed from the repo root under the runner's own shell, `bash --noprofile --norc -eo pipefail`:

```
✓ check-half-states self-test: 1551 cases pass.
```

Exit code 0, captured by redirect-then-capture, never through a pipe.

## Ablation: the step is a live gate, not a permanently-green one

Run against a **throwaway copy** in scratch, so the pinned upstream file was never written — this removes the restore leg entirely rather than relying on it. `DEFAULT_SWEEP_REPO` was mutated in the copy; the mutation was confirmed on disk before running (removed text count 1 → 0, injected text 0 → 1, blob OID `9ffcdb76` → `b922f997`):

```
✗ sweep repo: the objectstack runner resolves to the pre-change constant (got "objectstack-ai/objectstack", want "objectstack-ai/MUTATED")
✗ sweep repo: …and with only GITHUB_REPOSITORY set, identically (got "objectstack-ai/objectstack", want "objectstack-ai/MUTATED")
✗ check-half-states self-test: 2 of 1551 case(s) failed.
```

Exit 1 — reproducing PR #237's documented 2-of-1551 result exactly. Re-run under the runner's shell, the same mutated copy exits 1, so a behaviour-changing edit to this copy fails the `build` job.

## Placement and shape

The step sits after `pnpm install --frozen-lockfile` and before the zh-Hant check. The script is zero-dependency (node builtins plus one relative import of `scripts/invoked-as.mjs`) and takes about a second, so it belongs with the checks that need no build rather than behind `turbo run build` — the same ordering rationale the zh-Hant step's own comment states. `shell: bash` follows this repo's existing convention for `--self-test` steps (`ci.yml:33`, `translations.yml:80`); the command has no pipe, so `pipefail` is not what carries the exit code here — a bare `run:` does.

## Gates, each with its own conclusion, all at `d3bd9c6`

| Gate | Own conclusion |
|---|---|
| `pnpm turbo run test --force` | `✓ 4 self-test(s) passed`; `Tasks: 1 successful, 1 total` |
| the new step, verbatim from YAML, runner shell | `✓ check-half-states self-test: 1551 cases pass.` |
| `ci.yml` YAML parse | parses; `build` job has 10 steps, the new one 5th |
| control-byte scan of the edited file | no match (grep exit 1); file is UTF-8 |

No changeset: this repo has no `packages/` and no changeset flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S)_