### PR TITLE
docs(quickstart): re-transcribe both boot samples against CLI 17.3.0

### DIFF
--- a/content/docs/quickstart.mdx
+++ b/content/docs/quickstart.mdx
@@ -41,7 +41,6 @@ You'll see:
 📦 Artifact: none (empty kernel — install apps via the Console marketplace)
 🗄️ Database: file:~/.objectstack/data/objectstack.db
 🎯 Environment: env_local
-🖥️ Console: http://localhost:3000/_console/
   → Starting server...
 
   ✓ Server is ready
@@ -61,12 +60,12 @@ You'll see:
 
 That's it. You're running ObjectOS.
 
-That block is transcribed from `@objectstack/cli` 17.2.0 booting an empty
+That block is transcribed from `@objectstack/cli` 17.3.0 booting an empty
 kernel. Home paths show as `~/…` — the CLI prints yours expanded. Your own boot
 also prints a `No objectstack.config.ts or artifact found` line before the
 server starts, plus startup advisories (local storage driver, dev crypto key,
-boot diagnostics) and the full list of loaded plugin names, both of which depend
-on your environment.
+schema-sync notes from the SQL driver, boot diagnostics) and the full list of
+loaded plugin names, both of which depend on your environment.
 
 ### What's running
 
@@ -161,14 +160,15 @@ You'll see:
 
 ◆ Compile
 ────────────────────────────────────────
-  ✓ Build complete (72ms)
+  ✓ Build complete (143ms)
 
   Data: 1 Objects  3 Fields
   UI: 0 Apps
   Logic: 0 Flows
   Security: 0 Positions  0 Permissions
+  Runtime: 0 plugins
 
-  Artifact: my-app/dist/objectstack.json (1.9 KB)
+  Artifact: my-app/dist/objectstack.json (1.8 KB)
 
   → Starting dev server (local mode)...
 🎯 Environment ID: env_local
@@ -196,12 +196,13 @@ You'll see:
 ```
 
 That block is transcribed from `pnpm dev` on a scaffold created by
-`@objectstack/cli` 17.2.0. Project paths show as `my-app/…` — the CLI prints
+`@objectstack/cli` 17.3.0. Project paths show as `my-app/…` — the CLI prints
 yours expanded, and the `Build complete` timing is whatever the transcribing
 machine measured, so yours will differ. Your own run also prints pnpm's script
 header above the block, per-step compile progress, startup advisories
-(configuration load, dev secret-field crypto), the full list of loaded plugin
-names, boot diagnostics, and an MCP connection trailer below the banner.
+(configuration load, dev secret-field crypto, schema-sync notes from the SQL
+driver), the full list of loaded plugin names, boot diagnostics, and an MCP
+connection trailer above the banner.
 
 Note the dev server asks for port **3000**, the same port `os start` uses. If
 that port is taken it binds the next free one and says so:


### PR DESCRIPTION
Part of #141

Deliberately `Part of` rather than a closing keyword. This card is a watcher that is re-armed every round, and last round's PR used a closing keyword on it — GitHub closed the card on merge and the PM had to reopen it by hand. The keyword is kept away from the card number here on purpose: GitHub's parser matches it even inside backticks and even under a negation, so the only safe way to not close a card is to not put the word near its number.

## What this round measured

Both paths were booted on `@objectstack/cli` 17.3.0 as **independent pty captures** — Path B's banner was never assembled from Path A's — and each raw capture was diffed against its published block mechanically, line by line. Every difference was then classified against a **17.2.0 control** whose scaffold dependencies were pinned to exact versions, so the control could not resolve forward into a second copy of the experiment.

That separation is load-bearing again this round: of the four differences found, **two are genuine 17.3.0 changes, one is a declared machine-variable, and one is a pre-existing under-declaration that has been there since at least 17.2.0.** Without the control all four would have read as 17.3.0 drift, and the fourth would have been written into the docs as a change this release did not make.

| # | Item | Outcome at 17.3.0 |
|---|---|---|
| 1 | Re-transcribe both blocks | **Both were stale, in different ways.** Path A lost its `Console:` header row. Path B gained a fifth compile counter and its artifact shrank to 1.8 KB. |
| 2 | Port behaviour | **No drift.** Unchanged and re-measured with a live probe. |
| 3 | Both pins | **17.2.0 to 17.3.0.** |
| 4 | Declaration sentences | **Two corrections** — one new (the MCP trailer moved), one pre-existing (the SQL driver's schema-sync notes were never named). |

### Path A — the `Console:` header row is gone

The banner's console row is absent from two independent 17.3.0 boots and **present in the pinned 17.2.0 control**. That is what makes it a 17.3.0 removal rather than a capture artefact. The console URL is still reachable in the block through the `Console:` line in the ready list, and through the "What's running" table below it, so nothing a reader needs disappeared — only the duplicate.

### Path B — a fifth compile counter, published whole

17.3.0 adds `Runtime: 0 plugins` to the compile summary. It is published into the block rather than declared-and-omitted, following the group-completeness rule this page already sets: a summary group is published whole (Path A publishes all of `Mode`/`Driver`/`Tenancy`/`Plugins`), and only long continuations get declared and omitted. Publishing four members of a five-line group would show the reader a hole in the middle of something they see intact on their own screen.

The scaffold's artifact also moved from 1.9 KB to 1.8 KB — deterministic from scaffold content, present as 1.9 KB in the control, so this is real.

### The `Build complete` timing is re-transcribed, not frozen

#260 converted this number from an asserted literal into a declared machine-variable, and that declaration is doing its job — the timing differing is not drift. But the block is a faithful transcript, and once the pin says 17.3.0 the transcript has to be of a 17.3.0 boot, so the number is re-transcribed from this capture rather than carried over. It is not placeholdered or averaged.

### Item 4 — the two declaration corrections

Both found by diffing the raw capture against the published block, not by reasoning about what was probably left out.

- **The SQL driver's schema-sync notes were never named by either sentence.** They appear on both paths, and the control shows them at 17.2.0 too — in far greater volume (338 lines on Path A, 356 on Path B, against 5 each now). So this is a **pre-existing under-declaration**, not a 17.3.0 change, and it is described as such. Both sentences now name it.
- **Path B's MCP trailer moved.** At 17.2.0 it printed after `Press Ctrl+C to stop`; at 17.3.0 it prints between the dev-admin lines and the `Config:` banner. The sentence said "below the banner", which is now false, and reads "above the banner".

### Port behaviour, controlled both ways

Verified as a live probe rather than a bare grep that would pass either way:

- **Uncontended:** binds 3000, and the rebind message appears **zero** times.
- **Contended** (a real `os start` holding 3000, confirmed serving HTTP 200): binds 3001, and the published literal `server bound to port 3001 (requested 3000)` appears **exactly once**, byte-exact.

### Untouched on purpose

- The seeded dev credential and its dev-only caveat are **byte-identical** at 17.2.0, at 17.3.0, and on the page. Transcribed faithfully, not redacted or altered.
- The expired Path B `Warning:` admonition stays discharged: zero hits, with a live control confirming one other blockquote is still present in the file, so the zero is a probe that works.
- `reference/cli.mdx` and all seven locale siblings are untouched. The siblings are stale by design and are the translation pass's input.

## Verification

Gate union run on the final commit `4f41c03`, with `git status --porcelain` empty so the tree equals the commit. Exit codes captured before any pipe; verdicts quoted from each gate's own printed line. Turbo run with `--force` throughout — every reading is `0 cached`, not a shared-cache hit.

| Gate | Exit | Verdict line |
|---|---|---|
| `turbo run build --force` | 0 | `Tasks: 1 successful, 1 total` · `Cached: 0 cached, 1 total` |
| `turbo run type-check test --force` | 0 | `Tasks: 2 successful, 2 total` · `Cached: 0 cached, 2 total` |
| `check-locale-surface.mjs` | 0 | every advertised URL has a source file and every source file is advertised |
| `check-node-floor.mjs` | 0 | Every declared floor clears what the dependency tree requires |
| `check-node-floor.mjs --self-test` | 0 | 17 rule cases, every rule demonstrated able to fail |
| `check-half-states.mjs --self-test` | 0 | 1551 cases pass |
| `gen-zh-hant.mjs --check` | 0 | 73 generated files match the zh-Hans sources byte for byte |
| `check-translations.mjs` | 0 | translations gate passed |
| `check-translation-output.mjs --self-test` | 0 | 29 rule cases, every rule demonstrated able to fail |
| `check-translation-ownership.mjs` | 0 | 0 translation artifacts and 1 other file |
| `check-translation-output.mjs --files` | 0 | translation output gate passed (145 pre-existing findings reported) |

`check-locale-surface.mjs` first exited 1 with "no built artifact ... run `pnpm turbo run build` first". That is a **prerequisite not met, not a red gate** — the gate reads build output on purpose. It is re-run above after the build and passes.

Measurement evidence, which is the actual deliverable here:

- Path A captured **twice** from separate pristine homes; the two are byte-identical after normalizing the home path and timestamps.
- Every published line verified present in the raw 17.3.0 capture after editing: **count=0 published-but-absent** on Path A against both boots, and on Path B.
- **Order preserved:** a separate check confirms the published lines appear in the capture in the same sequence, since presence alone does not prove ordering.
- Control genuinely at 17.2.0: `spec`, `runtime`, `objectql` and `cli` all resolve to 17.2.0 in the control tree and 17.3.0 in the experiment tree.
- Every server killed by explicit PID resolved through `/proc`; ports 3000 and 3001 confirmed released afterwards by curl. Note `ss` returns nothing at all in this container, so port probes are curl-based.
- Control-character scan on the edited file: no hits.

## Reviewer's choice

Publishing `Runtime: 0 plugins` into the block is the group-completeness reading and is what this PR does. Declaring it instead is a one-line switch if you prefer the tighter block, but it would leave the counter group with a hole.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkauAsZBEemRbco2rEX9Lx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkauAsZBEemRbco2rEX9Lx)_