### PR TITLE
Revert "fix(docs): load MDX bodies on demand so the Worker fits Cloudflare's 64 MiB limit"

### DIFF
--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -240,11 +240,7 @@ export default async function Page(props: {
   const page = source.getPage(params.slug ?? [], params.lang);
   if (!page) notFound();
 
-  // `async: true` on the docs collection makes the compiled body and toc
-  // load on demand instead of being statically imported, so they are awaited
-  // here. Frontmatter (`title`, `description`, `full`) stays eager.
-  const loaded = await page.data.load();
-  const MDX = loaded.body;
+  const MDX = page.data.body;
 
   // Resolved once and handed to both controls, so they cannot drift apart and
   // so a third control added below inherits the locale-independent URL instead
@@ -287,7 +283,7 @@ export default async function Page(props: {
           dangerouslySetInnerHTML={{ __html: jsonLdHtml(item) }}
         />
       ))}
-      <DocsPage toc={loaded.toc} full={page.data.full}>
+      <DocsPage toc={page.data.toc} full={page.data.full}>
         <DocsTitle>{page.data.title}</DocsTitle>
         <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
         <div className="flex flex-row gap-2 items-center border-b pb-6">

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -5,29 +5,6 @@ import path from 'node:path';
 export const docs = defineDocs({
   dir: path.resolve(process.cwd(), '../../content/docs'),
   docs: {
-    /**
-     * Load each page's compiled body on demand instead of statically importing
-     * all of them into every server entrypoint.
-     *
-     * Without this, `fumadocs-mdx:collections/server` eagerly imports all 397
-     * `.mdx` files, so every route that touches `source` — the docs page, but
-     * also `/llms.txt`, `/llms-full.txt`, `/llms.mdx/*`, `/og/*`, `/api/search`
-     * and `/sitemap.xml` — pulls the entire corpus into its own chunk. The
-     * bundler then inlined the whole set five times over into one worker:
-     * 2.50 MiB of authored MDX became a 100.93 MiB `handler.mjs`, and
-     * Cloudflare rejects any Worker over 64 MiB uncompressed (`code: 10027`).
-     *
-     * The multiplier, not the corpus, was the problem: measured on the same
-     * tree, one probe sentence from a single English page appeared 15 times in
-     * the bundle before this flag and 6 times after, taking `handler.mjs` from
-     * 100.93 MiB to 48.47 MiB.
-     *
-     * The cost is that `page.data.body` and `page.data.toc` become
-     * `page.data.load()`. Frontmatter stays eager, so `title`, `description`,
-     * `seoTitle` and `full` are unaffected, and `getText('processed')` — what
-     * the llms.txt routes call — is still a method on the entry.
-     */
-    async: true,
     schema: pageSchema.extend({
       /**
        * Optional SEO title: what the `<title>` tag should say, when that is not


### PR DESCRIPTION
Reverts PR #263 (`1933e623`). Refs #261, #266.

**This does not restore the site — the Cloudflare rollback already did that.** This removes a landmine that the rollback leaves behind.

## Why this is needed after a successful rollback

The rollback put Worker version `69c79ee3-…` (2026-08-25) back on 100% of traffic. But `main` still carried `async: true`, and `deploy-docs.yml` fires on `apps/docs/**`, `content/docs/**` and `pnpm-lock.yaml`. **The next merge of any docs change would have rebuilt and redeployed the broken version**, breaking production again — with nobody expecting it, because the person merging would think they were landing a docs edit.

Reverting restores the pre-incident steady state, which is stable rather than merely quiet:

- the bundle goes back over Cloudflare's 64 MiB limit
- deploys are therefore **rejected at version creation**
- a rejected upload changes nothing, so `69c79ee3-…` keeps serving

So the site stays up on the known-good version, and no future merge can silently replace it. Stale, working, and safe to leave alone — where it was for the 10 days before I touched it.

⚠️ **Merging this fires a deploy that will fail, and that failure is the intended outcome**, not a regression to chase. It is the same rejection that ran 36 times between 2026-08-25 and today.

## What this does to #261

#261 goes back to being open and unfixed — the docs site cannot publish. That is the honest state. The fix in #263 was correct about the *cause* (the corpus was inlined once per server entrypoint, five times over) and its mechanism was verified under real workerd; what was never verified was **whether a docs page renders**, because those routes 404 in local preview on `main` too (#265).

So the order of work was wrong, and reinstating the fix should follow the corrected order:

1. **#265 first** — make it possible to load a real docs page in the Workers runtime before merge.
2. **#266** — a human gate on the deploy, so no agent can publish by merging.
3. Only then re-land the `async: true` change, verified against a rendered page rather than against an accepted upload.

## Deviations, stated

- Authored by the PM seat rather than a dispatched dev, during an active incident, on the maintainer's direct instruction to roll back. Same deviation already flagged on #267.
- Created via `git revert -m 1` of the merge commit rather than hand-edited: 2 files, +2/−29, no judgement applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkauAsZBEemRbco2rEX9Lx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkauAsZBEemRbco2rEX9Lx)_