### PR TITLE
fix(docs): serve prerendered pages from the static-assets incremental cache, and shrink the Worker under the 64 MiB limit

### DIFF
--- a/.github/scripts/check-prerender-cache.mjs
+++ b/.github/scripts/check-prerender-cache.mjs
@@ -1,0 +1,325 @@
+#!/usr/bin/env node
+/**
+ * Refuses to publish a docs Worker whose prerender cache is missing entries.
+ *
+ * ## The failure this exists to catch
+ *
+ * Every page on this site lives under `app/[lang]/`, so every page route is a
+ * DYNAMIC route prerendered through `generateStaticParams()`. OpenNext runs
+ * Next in minimal mode, where Next does not read prerendered HTML off a
+ * filesystem — it asks the configured incremental cache. `apps/docs` uses
+ * `staticAssetsIncrementalCache`, and `opennextjs-cloudflare deploy` copies
+ * `.open-next/cache` into `.open-next/assets` just before uploading.
+ *
+ * If those entries are absent, the Worker deploys with the cache CONFIGURED and
+ * EMPTY. Every lookup misses, `dynamicParams = false` refuses the on-demand
+ * render, Next raises `NoFallbackError`, and the request is answered by the
+ * prerendered `_not-found` route: the page 404s. Every page, every locale,
+ * every request — and the deploy step still exits 0, because the upload
+ * succeeded. That is exactly how 2026-09-04 went (#261), by a different route.
+ *
+ * A missing cache is not hypothetical. `.open-next/cache` is produced by a
+ * separate build invocation from the one a pull request runs, travels to the
+ * deploy job as a CI artifact, and is copied again by the deploy command. Three
+ * places it can be lost, none of which make any step go red on their own.
+ *
+ * ## What it asserts, and against what
+ *
+ * The population it checks is Next's own `prerender-manifest.json` — every
+ * route Next says it prerendered — not a number anyone wrote down. So a page
+ * added to the corpus is covered the day it is added, and this cannot pass by
+ * comparing a stale expectation to itself.
+ *
+ * Run it in the deploy job AFTER the artifact is downloaded and BEFORE the
+ * deploy step. A check that reports a bad artifact once it is already serving
+ * is a post-mortem, not a gate.
+ *
+ * ## Usage
+ *
+ *   node .github/scripts/check-prerender-cache.mjs                 # apps/docs
+ *   node .github/scripts/check-prerender-cache.mjs --dir PATH      # elsewhere
+ *   node .github/scripts/check-prerender-cache.mjs --self-test     # the rules
+ *
+ * Exit 0 only when every prerendered route has a cache entry.
+ */
+
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** Every rule this script enforces. The self-test asserts each one can fire. */
+const RULES = [
+  'no-open-next',
+  'no-build-id',
+  'no-prerender-manifest',
+  'unreadable-prerender-manifest',
+  'no-cache-dir',
+  'no-routes',
+  'missing-entries',
+];
+
+/** Where `.open-next` lives when nobody says otherwise. */
+const DEFAULT_DIR = 'apps/docs/.open-next';
+
+/**
+ * The prerender manifest, as packaged inside the server function.
+ *
+ * Read from the bundle rather than from `apps/docs/.next/` on purpose: the
+ * deploy job downloads an artifact and never runs a Next build, so `.next/` is
+ * not there. Checking the copy that travels with the bundle is also the only
+ * way to be sure the manifest and the cache describe the same build.
+ */
+const MANIFEST_IN_BUNDLE =
+  'server-functions/default/apps/docs/.next/prerender-manifest.json';
+
+/**
+ * The cache file a route's entry is written to.
+ *
+ * `/` is stored as `index.cache`; every other route keeps its path. Mirrors
+ * `staticAssetsIncrementalCache.getAssetUrl`, which builds
+ * `CACHE_DIR/BUILD_ID/KEY.cache` from the same key.
+ */
+function entryPathFor(route, root) {
+  const key = route === '/' ? '/index' : route;
+  return join(root, `${key.slice(1)}.cache`);
+}
+
+/**
+ * Judge one `.open-next` directory. Pure enough to drive from fixtures: it
+ * touches only the filesystem under `dir`.
+ */
+export function evaluate(dir) {
+  const findings = [];
+  const add = (rule, detail) => findings.push({ rule, detail });
+  const measured = { dir };
+
+  if (!existsSync(dir)) {
+    add('no-open-next', `${dir} does not exist`);
+    return { findings, measured };
+  }
+
+  const buildIdPath = join(dir, 'assets/BUILD_ID');
+  if (!existsSync(buildIdPath)) {
+    add('no-build-id', `${buildIdPath} does not exist`);
+    return { findings, measured };
+  }
+  const buildId = readFileSync(buildIdPath, 'utf8').trim();
+  measured.buildId = buildId;
+
+  const manifestPath = join(dir, MANIFEST_IN_BUNDLE);
+  if (!existsSync(manifestPath)) {
+    add('no-prerender-manifest', `${manifestPath} does not exist`);
+    return { findings, measured };
+  }
+
+  let routes;
+  try {
+    routes = Object.keys(JSON.parse(readFileSync(manifestPath, 'utf8')).routes ?? {});
+  } catch (error) {
+    add('unreadable-prerender-manifest', `${manifestPath}: ${error?.message ?? error}`);
+    return { findings, measured };
+  }
+  measured.routes = routes.length;
+
+  if (routes.length === 0) {
+    // A manifest with no prerendered routes would make every other rule below
+    // vacuous: zero routes, zero missing, a green that proves nothing.
+    add('no-routes', `${manifestPath} lists no prerendered routes`);
+    return { findings, measured };
+  }
+
+  const cacheRoot = join(dir, 'cache', buildId);
+  if (!existsSync(cacheRoot)) {
+    add('no-cache-dir', `${cacheRoot} does not exist — the Worker would 404 every page`);
+    measured.present = 0;
+    measured.missing = routes.length;
+    return { findings, measured };
+  }
+
+  const missing = routes.filter((route) => !existsSync(entryPathFor(route, cacheRoot)));
+  measured.present = routes.length - missing.length;
+  measured.missing = missing.length;
+
+  if (missing.length > 0) {
+    const shown = missing.slice(0, 10).join(', ');
+    add(
+      'missing-entries',
+      `${missing.length} of ${routes.length} prerendered route(s) have no cache entry ` +
+        `under ${cacheRoot} — they would 404 in production: ${shown}` +
+        (missing.length > 10 ? `, and ${missing.length - 10} more` : ''),
+    );
+  }
+
+  return { findings, measured };
+}
+
+/* ------------------------------------------------------------------ gate -- */
+
+function gate(dir) {
+  const { findings, measured } = evaluate(dir);
+
+  console.log(`prerender cache: ${measured.dir}`);
+  if (measured.buildId) console.log(`    build id : ${measured.buildId}`);
+  if (measured.routes !== undefined) {
+    console.log(
+      `    routes   : ${measured.routes} prerendered, ` +
+        `${measured.present ?? 0} servable, ${measured.missing ?? '?'} missing`,
+    );
+  }
+
+  if (findings.length === 0) {
+    console.log(
+      `\n✓ every one of the ${measured.routes} prerendered route(s) has a cache entry, ` +
+        'so the Worker about to be uploaded can serve them',
+    );
+    return 0;
+  }
+
+  for (const f of findings) console.error(`    [${f.rule}] ${f.detail}`);
+  console.error(
+    `\n✗ this bundle would publish a Worker that cannot serve its own pages — refusing to deploy`,
+  );
+  return 1;
+}
+
+/* ------------------------------------------------------------- self-test -- */
+
+/**
+ * Fixtures, one per rule. The runner asserts that the set of rules a fixture
+ * trips is exactly the set declared here, AND that every rule in `RULES` has a
+ * fixture able to trip it — so weakening a rule fails this, which is what keeps
+ * a green from being decoration.
+ */
+const FIXTURES = [
+  {
+    name: 'a complete bundle passes',
+    build: () => ({ routes: ['/', '/en/docs', '/zh-Hans/docs'], entries: ['/', '/en/docs', '/zh-Hans/docs'] }),
+    expect: [],
+  },
+  {
+    name: 'no .open-next at all',
+    build: () => ({ absent: true }),
+    expect: ['no-open-next'],
+  },
+  {
+    name: 'no BUILD_ID',
+    build: () => ({ routes: ['/en/docs'], entries: ['/en/docs'], noBuildId: true }),
+    expect: ['no-build-id'],
+  },
+  {
+    name: 'no prerender manifest in the bundle',
+    build: () => ({ noManifest: true }),
+    expect: ['no-prerender-manifest'],
+  },
+  {
+    name: 'a manifest that is not JSON',
+    build: () => ({ badManifest: true }),
+    expect: ['unreadable-prerender-manifest'],
+  },
+  {
+    name: 'a manifest with no prerendered routes',
+    build: () => ({ routes: [], entries: [] }),
+    expect: ['no-routes'],
+  },
+  {
+    name: 'the cache directory is missing entirely',
+    build: () => ({ routes: ['/en/docs'], entries: null }),
+    expect: ['no-cache-dir'],
+  },
+  {
+    name: 'one route lost its cache entry',
+    build: () => ({ routes: ['/', '/en/docs', '/zh-Hans/docs'], entries: ['/', '/zh-Hans/docs'] }),
+    expect: ['missing-entries'],
+  },
+];
+
+function materialise(spec) {
+  const dir = join(mkdtempSync(join(tmpdir(), 'os-prerender-cache-')), '.open-next');
+  if (spec.absent) return dir;
+
+  mkdirSync(join(dir, 'assets'), { recursive: true });
+  const buildId = 'TESTBUILDID000000000';
+  if (!spec.noBuildId) writeFileSync(join(dir, 'assets/BUILD_ID'), `${buildId}\n`);
+
+  const manifestPath = join(dir, MANIFEST_IN_BUNDLE);
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  if (spec.badManifest) {
+    writeFileSync(manifestPath, 'not json {');
+    return dir;
+  }
+  if (!spec.noManifest) {
+    const routes = Object.fromEntries((spec.routes ?? []).map((r) => [r, {}]));
+    writeFileSync(manifestPath, JSON.stringify({ routes }));
+  } else {
+    return dir;
+  }
+
+  if (spec.entries === null) return dir;
+  const root = join(dir, 'cache', buildId);
+  for (const route of spec.entries ?? []) {
+    const p = entryPathFor(route, root);
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, '{}');
+  }
+  return dir;
+}
+
+function selfTest() {
+  let failed = 0;
+  const fired = new Set();
+
+  for (const fixture of FIXTURES) {
+    const spec = fixture.build();
+    const dir = materialise(spec);
+    let rules;
+    try {
+      rules = [...new Set(evaluate(dir).findings.map((f) => f.rule))].sort();
+    } finally {
+      rmSync(resolve(dir, '..'), { recursive: true, force: true });
+    }
+    for (const r of rules) fired.add(r);
+
+    const want = [...fixture.expect].sort();
+    if (rules.join('|') === want.join('|')) {
+      console.log(`✓ ${fixture.name.padEnd(42)} fired [${rules.join(' ') || 'nothing'}]`);
+    } else {
+      console.error(
+        `✗ ${fixture.name}\n    expected [${want.join(' ') || 'nothing'}], got [${rules.join(' ') || 'nothing'}]`,
+      );
+      failed += 1;
+    }
+  }
+
+  const undemonstrated = RULES.filter((r) => !fired.has(r));
+  if (undemonstrated.length) {
+    console.error(
+      `\n✗ ${undemonstrated.length} rule(s) have no fixture able to make them fire: ${undemonstrated.join(', ')}`,
+    );
+    failed += 1;
+  }
+
+  console.log('');
+  if (failed) {
+    console.error(`✗ self-test: ${failed} failure(s)`);
+    return 1;
+  }
+  console.log(
+    `✓ self-test: ${FIXTURES.length} fixture(s) — all ${RULES.length} rules demonstrated able to fail`,
+  );
+  return 0;
+}
+
+/* -------------------------------------------------------------- dispatch -- */
+
+const argv = process.argv.slice(2);
+if (argv.includes('--self-test')) {
+  process.exit(selfTest());
+} else {
+  const at = argv.indexOf('--dir');
+  const dir = at === -1 ? DEFAULT_DIR : argv[at + 1];
+  if (!dir) {
+    console.error('--dir needs a path');
+    process.exit(1);
+  }
+  process.exit(gate(resolve(dir)));
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,55 +150,18 @@ jobs:
       # Last in the job on purpose: the artifact then only exists for a commit
       # that cleared every gate above it. And only on a push to `main`, because
       # that is the only event that deploys, so a pull request pays nothing.
-      # TEMPORARY (#261 round 3, reverted in this branch before review): the
-      # `pull_request` clause below is the only difference from the shipped
-      # step. `--skipNextBuild` has never once executed with the incremental
-      # cache configured, because this step is push-only; its first run would
-      # otherwise be the merge commit. If that path does not produce
-      # `.open-next/cache`, the Worker deploys with the cache CONFIGURED and
-      # EMPTY, every lookup misses, `dynamicParams = false` refuses the
-      # on-demand render, and every page 404s — the outage this PR diagnoses,
-      # reproduced by its own fix.
       - name: Package the Worker from the build this job tested
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
-          || github.event_name == 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: apps/docs
         run: pnpm exec opennextjs-cloudflare build --skipNextBuild
-
-      # TEMPORARY (#261 round 3, reverted with the clause above).
-      - name: TEMP — the cache the deploy depends on, as CI's own build makes it
-        if: github.event_name == 'pull_request'
-        working-directory: apps/docs
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -d .open-next/cache || { echo "::error::.open-next/cache absent after --skipNextBuild"; exit 1; }
-          echo "cache entries : $(find .open-next/cache -type f | wc -l)"
-          echo "cache bytes   : $(du -sb .open-next/cache | cut -f1)"
-          node -e '
-            const fs=require("fs"),path=require("path");
-            const bid=fs.readFileSync(".open-next/assets/BUILD_ID","utf8").trim();
-            const m=JSON.parse(fs.readFileSync(".open-next/server-functions/default/apps/docs/.next/prerender-manifest.json","utf8"));
-            const routes=Object.keys(m.routes||{});
-            const root=path.join(".open-next/cache",bid);
-            const missing=routes.filter(r=>!fs.existsSync(path.join(root,(r==="/"?"/index":r).slice(1)+".cache")));
-            console.log("prerendered routes:",routes.length);
-            console.log("missing entries   :",missing.length);
-            if(missing.length){console.error("::error::"+missing.length+" prerendered route(s) have no cache entry");process.exit(1);}
-          '
 
       # `include-hidden-files` is load-bearing, not tidiness: the compiled
       # OpenNext config the deploy reads lives at `.open-next/.build/`, and
       # upload-artifact excludes dotted paths by default. Without it the
       # download succeeds, the deploy exits 1 on a missing config, and the
       # cause is three directories away from the message.
-      # TEMPORARY (#261 round 3, reverted in this branch): `pull_request` added
-      # so the artifact really round-trips, rather than being reasoned about.
       - name: Upload the Worker bundle
-        if: >-
-          (github.event_name == 'push' && github.ref == 'refs/heads/main')
-          || github.event_name == 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: docs-worker
@@ -206,82 +169,6 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 3
-
-  # ==========================================================================
-  # TEMPORARY JOB (#261 round 3). Reverted in this branch before review.
-  #
-  # It runs the deploy job's own inputs on the artifact CI actually produced:
-  # download it, then call `opennextjs-cloudflare populateCache local` — the
-  # exact step `opennextjs-cloudflare deploy` performs before `wrangler deploy`,
-  # and for the static-assets cache a pure filesystem copy needing no
-  # credentials. Then `wrangler deploy --dry-run` weighs what would be uploaded.
-  #
-  # This exists because "probably fine on a path that has never run" is the
-  # reasoning that cost this repo a production outage on 2026-09-04.
-  # ==========================================================================
-  verify-deploy-inputs:
-    name: TEMP — the artifact the deploy would publish
-    needs: [build]
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-
-      # Byte-for-byte what deploy-docs.yml does.
-      - name: Download the Worker CI built and tested
-        uses: actions/download-artifact@v8
-        with:
-          name: docs-worker
-          path: apps/docs/.open-next
-
-      - name: The cache survived the artifact round-trip
-        working-directory: apps/docs
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -d .open-next/cache || { echo "::error::.open-next/cache did NOT survive the artifact"; exit 1; }
-          test -f .open-next/.build/open-next.config.mjs || { echo "::error::compiled config did not survive"; exit 1; }
-          echo "cache entries after download : $(find .open-next/cache -type f | wc -l)"
-          echo "assets before populate       : $(find .open-next/assets -type f | wc -l)"
-
-      - name: populateCache — the step the deploy runs before wrangler
-        working-directory: apps/docs
-        shell: bash
-        run: |
-          set -euo pipefail
-          pnpm exec opennextjs-cloudflare populateCache local
-          echo "assets after populate        : $(find .open-next/assets -type f | wc -l)"
-          echo "cache entries in assets      : $(find .open-next/assets/cdn-cgi/_next_cache -type f | wc -l)"
-          node -e '
-            const fs=require("fs"),path=require("path");
-            const bid=fs.readFileSync(".open-next/assets/BUILD_ID","utf8").trim();
-            const m=JSON.parse(fs.readFileSync(".open-next/server-functions/default/apps/docs/.next/prerender-manifest.json","utf8"));
-            const routes=Object.keys(m.routes||{});
-            const root=path.join(".open-next/assets/cdn-cgi/_next_cache",bid);
-            const missing=routes.filter(r=>!fs.existsSync(path.join(root,(r==="/"?"/index":r).slice(1)+".cache")));
-            console.log("prerendered routes           :",routes.length);
-            console.log("servable from static assets  :",routes.length-missing.length);
-            console.log("missing                      :",missing.length);
-            if(missing.length){console.error("::error::"+missing.length+" route(s) would 404 in production");process.exit(1);}
-          '
-
-      # The number #262 needs, measured in CI on the bundle wrangler uploads
-      # rather than scaled from a local ratio. Cloudflare rejects over 65536 KiB.
-      - name: Weigh the bundle wrangler would upload
-        working-directory: apps/docs
-        shell: bash
-        run: |
-          set -euo pipefail
-          pnpm exec wrangler deploy --dry-run --outdir "$RUNNER_TEMP/dryrun" 2>&1 | tee "$RUNNER_TEMP/dryrun.log"
-          grep -E 'Total Upload|Read [0-9]+ files' "$RUNNER_TEMP/dryrun.log" | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Defect 1 of #269: `deploy-docs.yml` used to hang off `push: branches:
   # [main]` exactly as this workflow does, so the two ran in PARALLEL and a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,18 +150,55 @@ jobs:
       # Last in the job on purpose: the artifact then only exists for a commit
       # that cleared every gate above it. And only on a push to `main`, because
       # that is the only event that deploys, so a pull request pays nothing.
+      # TEMPORARY (#261 round 3, reverted in this branch before review): the
+      # `pull_request` clause below is the only difference from the shipped
+      # step. `--skipNextBuild` has never once executed with the incremental
+      # cache configured, because this step is push-only; its first run would
+      # otherwise be the merge commit. If that path does not produce
+      # `.open-next/cache`, the Worker deploys with the cache CONFIGURED and
+      # EMPTY, every lookup misses, `dynamicParams = false` refuses the
+      # on-demand render, and every page 404s — the outage this PR diagnoses,
+      # reproduced by its own fix.
       - name: Package the Worker from the build this job tested
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          || github.event_name == 'pull_request'
         working-directory: apps/docs
         run: pnpm exec opennextjs-cloudflare build --skipNextBuild
+
+      # TEMPORARY (#261 round 3, reverted with the clause above).
+      - name: TEMP — the cache the deploy depends on, as CI's own build makes it
+        if: github.event_name == 'pull_request'
+        working-directory: apps/docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d .open-next/cache || { echo "::error::.open-next/cache absent after --skipNextBuild"; exit 1; }
+          echo "cache entries : $(find .open-next/cache -type f | wc -l)"
+          echo "cache bytes   : $(du -sb .open-next/cache | cut -f1)"
+          node -e '
+            const fs=require("fs"),path=require("path");
+            const bid=fs.readFileSync(".open-next/assets/BUILD_ID","utf8").trim();
+            const m=JSON.parse(fs.readFileSync(".open-next/server-functions/default/apps/docs/.next/prerender-manifest.json","utf8"));
+            const routes=Object.keys(m.routes||{});
+            const root=path.join(".open-next/cache",bid);
+            const missing=routes.filter(r=>!fs.existsSync(path.join(root,(r==="/"?"/index":r).slice(1)+".cache")));
+            console.log("prerendered routes:",routes.length);
+            console.log("missing entries   :",missing.length);
+            if(missing.length){console.error("::error::"+missing.length+" prerendered route(s) have no cache entry");process.exit(1);}
+          '
 
       # `include-hidden-files` is load-bearing, not tidiness: the compiled
       # OpenNext config the deploy reads lives at `.open-next/.build/`, and
       # upload-artifact excludes dotted paths by default. Without it the
       # download succeeds, the deploy exits 1 on a missing config, and the
       # cause is three directories away from the message.
+      # TEMPORARY (#261 round 3, reverted in this branch): `pull_request` added
+      # so the artifact really round-trips, rather than being reasoned about.
       - name: Upload the Worker bundle
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
+          || github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: docs-worker
@@ -169,6 +206,82 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 3
+
+  # ==========================================================================
+  # TEMPORARY JOB (#261 round 3). Reverted in this branch before review.
+  #
+  # It runs the deploy job's own inputs on the artifact CI actually produced:
+  # download it, then call `opennextjs-cloudflare populateCache local` — the
+  # exact step `opennextjs-cloudflare deploy` performs before `wrangler deploy`,
+  # and for the static-assets cache a pure filesystem copy needing no
+  # credentials. Then `wrangler deploy --dry-run` weighs what would be uploaded.
+  #
+  # This exists because "probably fine on a path that has never run" is the
+  # reasoning that cost this repo a production outage on 2026-09-04.
+  # ==========================================================================
+  verify-deploy-inputs:
+    name: TEMP — the artifact the deploy would publish
+    needs: [build]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # Byte-for-byte what deploy-docs.yml does.
+      - name: Download the Worker CI built and tested
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-worker
+          path: apps/docs/.open-next
+
+      - name: The cache survived the artifact round-trip
+        working-directory: apps/docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d .open-next/cache || { echo "::error::.open-next/cache did NOT survive the artifact"; exit 1; }
+          test -f .open-next/.build/open-next.config.mjs || { echo "::error::compiled config did not survive"; exit 1; }
+          echo "cache entries after download : $(find .open-next/cache -type f | wc -l)"
+          echo "assets before populate       : $(find .open-next/assets -type f | wc -l)"
+
+      - name: populateCache — the step the deploy runs before wrangler
+        working-directory: apps/docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec opennextjs-cloudflare populateCache local
+          echo "assets after populate        : $(find .open-next/assets -type f | wc -l)"
+          echo "cache entries in assets      : $(find .open-next/assets/cdn-cgi/_next_cache -type f | wc -l)"
+          node -e '
+            const fs=require("fs"),path=require("path");
+            const bid=fs.readFileSync(".open-next/assets/BUILD_ID","utf8").trim();
+            const m=JSON.parse(fs.readFileSync(".open-next/server-functions/default/apps/docs/.next/prerender-manifest.json","utf8"));
+            const routes=Object.keys(m.routes||{});
+            const root=path.join(".open-next/assets/cdn-cgi/_next_cache",bid);
+            const missing=routes.filter(r=>!fs.existsSync(path.join(root,(r==="/"?"/index":r).slice(1)+".cache")));
+            console.log("prerendered routes           :",routes.length);
+            console.log("servable from static assets  :",routes.length-missing.length);
+            console.log("missing                      :",missing.length);
+            if(missing.length){console.error("::error::"+missing.length+" route(s) would 404 in production");process.exit(1);}
+          '
+
+      # The number #262 needs, measured in CI on the bundle wrangler uploads
+      # rather than scaled from a local ratio. Cloudflare rejects over 65536 KiB.
+      - name: Weigh the bundle wrangler would upload
+        working-directory: apps/docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm exec wrangler deploy --dry-run --outdir "$RUNNER_TEMP/dryrun" 2>&1 | tee "$RUNNER_TEMP/dryrun.log"
+          grep -E 'Total Upload|Read [0-9]+ files' "$RUNNER_TEMP/dryrun.log" | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Defect 1 of #269: `deploy-docs.yml` used to hang off `push: branches:
   # [main]` exactly as this workflow does, so the two ran in PARALLEL and a

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -117,6 +117,33 @@ jobs:
           name: ${{ inputs.artifact_name }}
           path: apps/docs/.open-next
 
+      # #261: the second defect that card turned up, and the one with no
+      # symptom until it is live. `apps/docs` serves every page from a
+      # prerendered entry in `.open-next/cache`, which
+      # `opennextjs-cloudflare deploy` copies into the uploaded assets. If those
+      # entries are absent, the Worker publishes with its cache CONFIGURED and
+      # EMPTY: every lookup misses, `dynamicParams = false` refuses the
+      # on-demand render, and every page 404s — while THIS JOB STILL EXITS 0,
+      # because the upload itself succeeded. `check-deploy-version.mjs` would
+      # not catch it either: a new version really would be serving.
+      #
+      # The cache is produced by a build invocation no pull request runs,
+      # travels here as an artifact, and is copied again by the deploy command.
+      # Three places to lose it, none of which turn a step red on their own.
+      #
+      # Placed BEFORE the deploy, deliberately: a check that reports a bad
+      # bundle once it is already serving is a post-mortem, not a gate. It
+      # asserts against Next's own `prerender-manifest.json` inside the bundle,
+      # so a page added to the corpus is covered the day it is added.
+      #
+      # `shell: bash` for the same reason as the verdict step below.
+      - name: Refuse a bundle that cannot serve its own pages
+        shell: bash
+        run: |
+          node .github/scripts/check-prerender-cache.mjs \
+            --dir apps/docs/.open-next \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
       # Taken BEFORE the deploy and required to succeed: it is both half of the
       # "did anything actually change" comparison and the rollback target. A
       # deploy with no known-good version to fall back to is not one this

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -240,7 +240,15 @@ export default async function Page(props: {
   const page = source.getPage(params.slug ?? [], params.lang);
   if (!page) notFound();
 
-  const MDX = page.data.body;
+  // `async: true` on the docs collection makes the compiled body and toc load
+  // on demand instead of being statically imported, so they are awaited here.
+  // Frontmatter (`title`, `description`, `full`) stays eager.
+  //
+  // Under `dynamicParams = false` this await runs at BUILD time, in Node, on
+  // every one of the 1139 prerendered paths — the Worker serves the prerendered
+  // result out of the static-assets incremental cache and does not re-render.
+  const loaded = await page.data.load();
+  const MDX = loaded.body;
 
   // Resolved once and handed to both controls, so they cannot drift apart and
   // so a third control added below inherits the locale-independent URL instead
@@ -283,7 +291,7 @@ export default async function Page(props: {
           dangerouslySetInnerHTML={{ __html: jsonLdHtml(item) }}
         />
       ))}
-      <DocsPage toc={page.data.toc} full={page.data.full}>
+      <DocsPage toc={loaded.toc} full={page.data.full}>
         <DocsTitle>{page.data.title}</DocsTitle>
         <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
         <div className="flex flex-row gap-2 items-center border-b pb-6">

--- a/apps/docs/open-next.config.ts
+++ b/apps/docs/open-next.config.ts
@@ -1,3 +1,72 @@
 import { defineCloudflareConfig } from '@opennextjs/cloudflare';
+import staticAssetsIncrementalCache from '@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache';
 
-export default defineCloudflareConfig();
+/**
+ * ## Why this app needs an incremental cache, and what happens without one
+ *
+ * Every page this site serves lives under `app/[lang]/`, so every page route is
+ * a **dynamic** route as far as Next is concerned, prerendered through
+ * `generateStaticParams()` — 1139 paths in the prerender manifest.
+ *
+ * OpenNext runs Next in *minimal mode*: Next does not read prerendered HTML off
+ * a filesystem, it asks the configured incremental cache for it. And
+ * `defineCloudflareConfig()` with no arguments resolves `incrementalCache` to
+ * `"dummy"`, whose `get()` throws on every call by design. So the lookup for a
+ * prerendered page always misses.
+ *
+ * What happens next depends on one route-segment flag:
+ *
+ *   - `dynamicParams` unset (Next's default, `true`): the miss falls through to
+ *     an on-demand render. Pages are re-rendered on every request, wastefully
+ *     but correctly, and the site works.
+ *   - `dynamicParams = false`: Next refuses the on-demand render and raises
+ *     `NoFallbackError`, which OpenNext answers with the prerendered
+ *     `_not-found` route. **The page 404s. Every page, every locale.**
+ *
+ * `content/docs/` is never re-read at runtime and nothing here revalidates, so
+ * the on-demand render was pure waste — but it was load-bearing waste, and
+ * nothing recorded that.
+ *
+ * ## The outage this comment exists to stop repeating
+ *
+ * `export const dynamicParams = false` was added to `app/[lang]/layout.tsx`,
+ * `app/[lang]/docs/[[...slug]]/page.tsx` and `app/og/docs/[...slug]/route.tsx`
+ * on 2026-08-26, across five separate PRs about 404 semantics, each correct in
+ * itself. The last deploy Cloudflare accepted was 2026-08-25 — the Worker went
+ * over the 64 MiB limit that evening and every upload after it was rejected, so
+ * the flag sat on `main` for nine days without ever reaching production.
+ *
+ * On 2026-09-04 the size fix landed (PR #263, `async: true` in
+ * `source.config.ts`), the upload was accepted for the first time in nine days,
+ * and the site 404'd. `async: true` was blamed, reverted, and is innocent:
+ * measured on this tree under real workerd, `main` WITHOUT it fails the
+ * repository's own `smoke-docs.mjs` with 21 findings — `/`, `/en/docs`,
+ * `/docs/quickstart` and `/docs/build/interface/views` all 404 — and `main`
+ * WITH it fails with the same 21. The size fix published a defect that was
+ * already merged; it did not introduce one.
+ *
+ * ## Why the static-assets cache specifically
+ *
+ * It reads prerendered entries straight out of the Workers static assets this
+ * Worker already binds as `ASSETS` (under `cdn-cgi/_next_cache`, a prefix only
+ * the Worker can reach). No R2 bucket, no KV namespace, no new binding, no
+ * spend — `opennextjs-cloudflare deploy` copies `.open-next/cache` into
+ * `.open-next/assets` before uploading, and `preview` does the same locally.
+ *
+ * Its one documented restriction — read-only, for apps that "do NOT want
+ * revalidation and ONLY want to serve prerendered data" — is exactly this app:
+ * `revalidate = false` on every route handler, no ISR anywhere, no on-demand
+ * revalidation, and content that only changes when the site is rebuilt.
+ *
+ * ⚠️ If a future page ever needs real revalidation, this override is the wrong
+ * one and its `set()` will log an error rather than cache anything. Move to
+ * `r2IncrementalCache` then — do not remove this line and go back to no cache
+ * at all, because that is the configuration that 404s every page.
+ *
+ * Measured after this change, under real workerd (`opennextjs-cloudflare
+ * preview`): `smoke-docs.mjs` passes all four pages with its negative control
+ * still going red. Before it: 21 findings.
+ */
+export default defineCloudflareConfig({
+  incrementalCache: staticAssetsIncrementalCache,
+});

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -5,6 +5,39 @@ import path from 'node:path';
 export const docs = defineDocs({
   dir: path.resolve(process.cwd(), '../../content/docs'),
   docs: {
+    /**
+     * Load each page's compiled body on demand instead of statically importing
+     * all of them into every server entrypoint.
+     *
+     * Without this, `fumadocs-mdx:collections/server` eagerly imports all 397
+     * `.mdx` files, so every route that touches `source` — the docs page, but
+     * also `/llms.txt`, `/llms-full.txt`, `/llms.mdx/*`, `/og/*`, `/api/search`
+     * and `/sitemap.xml` — pulls the entire corpus into its own chunk, and the
+     * bundler then inlined the whole set five times over into one Worker.
+     * 2.50 MiB of authored MDX became a ~100 MiB `handler.mjs`, and Cloudflare
+     * rejects any Worker over 64 MiB uncompressed (`code: 10027`).
+     *
+     * The multiplier, not the corpus, is the problem: one probe sentence from a
+     * single English page appeared 15 times in the bundle before this flag and 6
+     * times after.
+     *
+     * The cost is that `page.data.body` and `page.data.toc` become
+     * `page.data.load()`. Frontmatter stays eager, so `title`, `description`,
+     * `seoTitle` and `full` are unaffected, and `getText('processed')` — what
+     * the llms.txt routes call — is still a method on the entry.
+     *
+     * ## This flag did NOT break the site on 2026-09-04, and the record matters
+     *
+     * It shipped once (PR #263), the upload was accepted, the site 404'd, and it
+     * was reverted (PR #268) on the reasonable assumption that the new thing was
+     * the cause. It was not. Every page route on `main` was already unservable
+     * for an unrelated reason — see the long comment in `open-next.config.ts` —
+     * and had been since 2026-08-26, invisibly, because no deploy had been
+     * accepted since 2026-08-25 to publish it. Measured on this tree: base
+     * `main` with this flag ABSENT 404s on `/`, `/en/docs`, `/docs/quickstart`
+     * and `/docs/build/interface/views` under real workerd, identically.
+     */
+    async: true,
     schema: pageSchema.extend({
       /**
        * Optional SEO title: what the `<title>` tag should say, when that is not

--- a/tools/ci-scripts/run-self-tests.mjs
+++ b/tools/ci-scripts/run-self-tests.mjs
@@ -69,6 +69,13 @@
  * Cloudflare, so on `main` they may not run for real either. What keeps them
  * from being decoration in the meantime is exactly this: their fixtures assert
  * that every rule they enforce still produces a red, and that runs on every PR.
+ *
+ * `check-prerender-cache.mjs` joins them on identical footing (#261). Its gate
+ * mode reads a `.open-next` bundle that only exists in the deploy job, so on a
+ * pull request it can never run for real; its fixtures are what prove it can
+ * still refuse a bundle whose prerender cache is incomplete — the bundle shape
+ * that publishes a Worker returning 404 for every page while the deploy step
+ * exits 0.
  */
 
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
@@ -88,6 +95,7 @@ const SELF_TESTED = [
   'check-locale-surface.mjs',
   'check-deploy-version.mjs',
   'smoke-docs.mjs',
+  'check-prerender-cache.mjs',
 ];
 
 /**


### PR DESCRIPTION
Part of #261. The mechanism behind #265 is established and fixed here too — that card can be closed by hand once someone agrees with the account below; no closing keyword, deliberately.

⛔ **This is not PR #263 re-applied.** It contains PR #263's change, plus the thing that was actually broken, plus a gate so it cannot come back. The first section is the evidence that these are two different defects.

## The diagnosis: `async: true` did not break rendering

Nobody had diagnosed the 2026-09-04 outage. The record said "PR #263 merged, upload accepted, site broke, rolled back", and the only account of *why* was a guess that the new thing was the cause.

It was not. **`main` was already unservable before `async: true` existed on it**, and had been for nine days.

Run against real workerd (`opennextjs-cloudflare preview`), using this repository's own `.github/scripts/smoke-docs.mjs` — the check that gates production, which asserts an `h1` with matching text, a visible-prose floor measured after script and style are stripped, a same-site link floor, the document language and the final path:

| tree | `smoke-docs.mjs` | `/`, `/en/docs`, `/docs/quickstart`, `/docs/build/interface/views` |
|:--|:--|:--|
| base `main` @ `d6f5dda`, **no `async: true`** | ✗ **21 findings** | all four 404 |
| `main` + `async: true` **only** (= PR #263) | ✗ **21 findings** | all four 404, identically |
| this PR | ✓ **0 findings** | all four render, negative control still red |

The middle row is the exoneration. The failing tree in row 1 does not contain the change that was blamed and reverted.

### Why every page 404s

Every page on this site lives under `app/[lang]/`, so every page route is a **dynamic** route prerendered through `generateStaticParams()` — 1139 paths in the prerender manifest.

OpenNext runs Next in **minimal mode**: Next does not read prerendered HTML off a filesystem, it asks the configured incremental cache for it. `defineCloudflareConfig()` called with no arguments resolves `incrementalCache` to `"dummy"`, and the dummy cache's `get()` throws `IgnorableError('"Dummy" cache does not cache anything')` on every call. So the lookup for a prerendered page **always misses**.

What happens after the miss is decided by one route-segment flag:

- **`dynamicParams` unset** (Next's default, `true`) — the miss falls through to an on-demand render. Every request re-renders the page, wastefully but correctly, and the site works.
- **`dynamicParams = false`** — Next refuses the on-demand render and raises `NoFallbackError`, which OpenNext answers with the prerendered `_not-found` route. **The page 404s.**

Observed directly in the workerd log on unmodified `main`:

```
✘ [ERROR] Uncaught Error: Internal: NoFallbackError
      at responseGenerator (.../handler.mjs)
      at handleRevalidate (.../handler.mjs)
```

and on the wire, `x-nextjs-prerender: 1` with `x-nextjs-cache: MISS` and a 404 body.

`export const dynamicParams = false` was added to `app/[lang]/layout.tsx`, `app/[lang]/docs/[[...slug]]/page.tsx` and `app/og/docs/[...slug]/route.tsx` on **2026-08-26**, across five separate PRs about 404 semantics (#190, #192, #209, #211, #213), each correct in itself. The last accepted deploy was **2026-08-25** — the Worker went over the 64 MiB limit that evening and every upload afterwards was rejected. So the flag sat on `main` for nine days and never reached production.

PR #263's merge produced the first accepted upload in nine days. It published nine days of merged work, one item of which turns every page into a 404.

**Confirmed against the live site**, which this container cannot reach, by dispatching the smoke workflow onto a runner (run `33886707832`): `/docs/quickstart?os261-cachebust=a1` — a URL that has certainly never been requested before, so no CDN copy of it can exist — returns 200 with `h1` "Quickstart" and 9101 visible characters. The live Worker really does render on demand, because the version serving it (`69c79ee3-...`, from `8feb90db`) predates `dynamicParams = false`. That is the whole reason the site is up.

### What the previous round's ablation could and could not show

The round-1 dev's own post-mortem on #261 is right, and this PR agrees with it from the other direction: breaking a lazy thunk and watching `/api/search` go 200 → 500 proved **module resolution**, and `/api/search` renders no components, so it could never have failed on **rendering**. Every route that round measured byte-for-byte — `/api/search`, `/llms.txt`, `/sitemap.xml`, `/og/*` — reads page bodies without rendering them.

None of those routes are used as rendering evidence here. The evidence above is rendered HTML judged by the production smoke check, plus a real browser (below).

## The fix

`staticAssetsIncrementalCache` reads prerendered entries straight out of the Workers static assets this Worker **already binds** as `ASSETS`, under `cdn-cgi/_next_cache` — a prefix only the Worker can reach. `opennextjs-cloudflare deploy` copies `.open-next/cache` into `.open-next/assets` before uploading, and `preview` does the same locally.

- **No new infrastructure and no spend** — no R2 bucket, no KV namespace, no new binding, no plan change.
- Its one documented restriction, read-only and for apps that "do NOT want revalidation and ONLY want to serve prerendered data", is exactly this app: `revalidate = false` on every route handler, no ISR, no on-demand revalidation.
- All **1139** prerendered routes have a cache entry, cross-checked against the prerender manifest — **0 missing**, so there is no partial-outage tail.
- `x-nextjs-cache` goes **MISS → HIT** on `/docs/quickstart`, `/llms.txt` and `/sitemap.xml`.
- `/cdn-cgi/_next_cache/.../quickstart.cache` returns **404** to a public request. The 277 MB of prerendered payloads are not publicly enumerable.

A side effect worth naming: the Worker no longer renders a docs page at request time **at all**. `await page.data.load()` now runs only at build time, in Node — which is where the previous round could verify it. Proved by ablation rather than asserted: corrupting one page's cache entry produced a **404**, not an on-demand render.

`async: true` is restored for its own, separate reason — the size defect #261 was filed about. Without it `fumadocs-mdx` eagerly imports all 397 `.mdx` files into every server entrypoint that touches `source`, and the bundler inlines that set five times over.

## The gate that ships with it

This fix creates a new way to break the site silently, so it ships with the check for it. If `.open-next/cache` is ever absent or incomplete, the Worker publishes with its cache **configured and empty**: every lookup misses, `dynamicParams = false` refuses the render, and every page 404s — **while the deploy step exits 0**, because the upload succeeded, and while `check-deploy-version.mjs` passes, because a new version really is serving. It is just serving 404s.

`.github/scripts/check-prerender-cache.mjs` runs in `deploy-docs.yml`'s `deploy` job, **after the artifact download and before the deploy step**, so a bad bundle is refused rather than published and then reported. It asserts against Next's own `prerender-manifest.json` from inside the bundle, not against a number anyone wrote down, so a page added to the corpus is covered the day it is added.

**Demonstrated able to fail, twice.** Fixtures: 8 cases covering all 7 rules, and the runner asserts every rule has a fixture that trips it, so weakening one exits 1. It is registered in `tools/ci-scripts/run-self-tests.mjs`, which independently fails by name on an unlisted script that declares a `--self-test`. And live, against a real 1139-route bundle:

```
intact     1139 prerendered, 1139 servable, 0 missing    EXIT 0
mutated    1139 prerendered, 1138 servable, 1 missing    EXIT 1  -> names /en/docs/quickstart
restored   1139 prerendered, 1139 servable, 0 missing    EXIT 0  (md5 f465ea19, byte-identical)
```

## CI's own build path, exercised rather than assumed

`Package the Worker` and `Upload the Worker bundle` are push-only, so `opennextjs-cloudflare build --skipNextBuild` had **never once executed** with an incremental cache configured — its first run would have been the merge commit. That is the same shape as the defect this PR diagnoses, so it was measured instead of reasoned about: commit `fb7259b` temporarily added a `pull_request` clause and a probe job, and `3e037d6` reverted it, leaving `.github/workflows/ci.yml` byte-identical to before.

What CI run `33889336935` produced, on its own split-invocation artifact:

```
Package the Worker (--skipNextBuild)     success, cache present
artifact docs-worker                     93,597,106 B, sha256 7c354e53...
cache survived the round-trip            yes, with .open-next/.build/ intact
populateCache local                      "Successfully populated static assets cache"
assets after populate                    1697   (cache entries in assets: 1662)
prerendered routes                       1139
servable from static assets              1139
missing                                  0
wrangler deploy --dry-run                2260 files, Total Upload 58549.06 KiB
```

The probe's own check carried a failure branch (`::error:: N route(s) would 404 in production`, `exit 1`) — it is the same code now shipping as the permanent gate. CI on the final head `ee99ae5` is green with those steps `skipped` again, which is what confirms the revert took.

## Size, measured rather than projected

PR #263 projected ~52.9 MiB / 82.7% by scaling one local-versus-CI ratio on `handler.mjs`, and CI then measured 58541.00 KiB / 89.3%. `Total Upload` covers more than that one file, so this PR measures the bundle wrangler would actually upload.

| reading | KiB | % of 65536 KiB |
|:--|--:|--:|
| run #105, last accepted deploy before the outage | 62747.87 | 95.75% |
| runs #106–#141, rejected | over 64 MiB | — |
| run #142 (`async: true`, measured in CI) | 58541.00 | 89.33% |
| this PR, `wrangler deploy --dry-run` locally | 58551.04 | 89.34% |
| **this PR, `wrangler deploy --dry-run` in CI on the real artifact** | **58549.06** | **89.34%** |

The local dry-run and CI's agree to within **1.98 KiB**, so the local figure was not a projection standing in for a measurement.

`handler.mjs`: **105,808,656 B → 50,827,882 B** — 100.91 MiB to 48.47 MiB, a **52.0%** cut. Note how little of that reaches `Total Upload`: 52.4 MiB comes off one file and the upload moves ~4 MiB. ⛔ Do not quote the −52% as the deploy's headroom; that is the error PR #263's projection made.

**The ceiling is settled: 65536 KiB.** #261 used both 64 MB and 64 MiB in one card, 1.5 MiB apart. Run #140's own rejection text reads *"Your Worker exceeded the uncompressed size limit of 64 MiB"* — Cloudflare's wording, so the denominator is **65536 KiB**, this PR is at **89.34%**, and headroom is **6986.94 KiB / 6.82 MiB**. #262 can set its budget from that without re-deriving it.

Static assets are uploaded separately and do not count toward the Worker limit. The asset store goes from 35 files to 1697 (2260 as wrangler counts them) against a 20,000-file cap; largest single asset 795 KB against a 25 MiB cap.

## Verified BEFORE merge

Everything below ran against `opennextjs-cloudflare preview` — real workerd, no Cloudflare credentials — on the built bundle, not `next start`.

- **`smoke-docs.mjs` green against local workerd, with its live negative control still going red in the same run.** This is the first time this repository's rendering check has been run against a real Workers render before a merge; that is #265's ask.
- **All seven locales render** with the right `lang` and localized headings: `/zh-Hans/docs/quickstart` `快速开始`, `/zh-Hant/docs/quickstart` `快速開始`, plus `ja`, `de`, `es`, `fr`, `ko`, each with a populated table of contents.
- **30 randomly sampled prerendered page routes** (seeded, drawn from the 1139) — 30/30 rendered with an `h1`.
- **Real browser** (AGENTS.md rule 2), headless Chromium against the workerd preview, `/docs/build/automation/approvals`: `h1` "Approvals", 7 `h2`, 18 table-of-contents anchors, 22 sidebar links, 6 rendered code blocks, 13558 visible characters. The same probe against the negative-control path returns the 404 shell — 138 visible characters, `h1` "404" — so the browser check demonstrably discriminates.
- **CI's own `--skipNextBuild` path and the artifact round-trip**, on a runner, with the numbers in the section above.
- **The new deploy gate**, both fixture-driven and live, with a byte-identical restore.
- **Route handlers byte-identical to base**: `/api/search?query=approval` 22890 B, `/llms.txt` 14693 B, `/sitemap.xml` 392938 B, `/docs/quickstart.mdx` 11909 B, one OG card 60871 B.
- **Routing and 404 semantics preserved**: unknown slug 404, non-locale first segment 404 (#209), `/cn/...` 308, `/EN/docs` 308, `/zh-hant/...` 308.
- **Ablation on the served cache, with restore proven byte-identical.** Corrupting one page's cache asset took `/docs/quickstart` from 200/178884 B to 404/11462 B while `/docs/build/interface/views` and `/llms.txt` stayed at their exact byte counts; md5 restore returned it to 200/178884 B. Mutation was confirmed on disk before any reading was taken.
- **Gates**, exit codes captured before any pipe: `type-check` 0 · `turbo run test --force` 0 · `check-locale-surface` 0 (sitemap 409 URLs, 0 unexpected, 0 missing) · `gen-zh-hant --check` 0 (73 files byte-identical) · `check-node-floor` 0 · `smoke-docs --self-test` 0 · `check-prerender-cache --self-test` 0 · `run-self-tests.mjs` 0 (7 self-tests) · `check-half-states --self-test` 0 (1551 cases). **CI green on the final head `ee99ae5`** (run `33890142955`).

## NOT verified before merge, and cannot be

1. **That Cloudflare accepts the upload.** Measured at 58549.06 KiB in CI, 89.34% of the 65536 KiB ceiling; acceptance is still Cloudflare's call and the deploy only runs on `main`.
2. **The live site itself.** This container gets `403 CONNECT tunnel failed` for both `docs.objectos.ai` and the `workers.dev` host. Local workerd is the same bundle and the same `ASSETS` mechanism, but it is not the live edge.

The third item this list carried on the first draft — CI's own split build invocation — is no longer on it; it was measured, above.

⛔ The #269 verification layer is the backstop for 1 and 2, not the verification. It has never executed the chain *deploy succeeds → smoke fails → rollback fires*, and this PR is not the place to find out whether it works. What is different from the last attempt is that the assertion that failed last time — a docs page rendering under workerd — is no longer on this list.

## Deviations

- **Two defects and a gate in one PR.** `async: true` alone would keep the site 404ing; the cache alone would keep the upload rejected. Neither ships anything on its own, and separating them would mean merging one known-broken deploy on purpose. The gate is here because the fix creates the failure mode it guards.
- **`.github` and `tools/ci-scripts` are outside the dispatched `apps/docs` surface.** Declared rather than widened quietly. The temporary CI probe and the permanent gate were both asked for during review, after the `apps/docs` change was accepted.
- **The temporary probe is on the record as two commits, not squashed away.** `fb7259b` adds it, `3e037d6` reverts it, and `git diff f35234f 3e037d6 -- .github/workflows/ci.yml` is empty. Its evidence lives on CI run `33889336935`.
- **`Part of #261`, not a closing keyword.** Acceptance is a green `Deploy Docs` with a new version id **and** a green smoke check on the live site — both only exist after merge.
- **The smoke workflow was dispatched once against the live site** as a read-only measurement (run `33886707832`; `workflow_dispatch` cannot deploy, and `file_issue` defaults to false, so no card was filed). It shows `failure`, and the only findings are `final-path` on the two deliberately cache-busted probe URLs — the query string is not part of the final path. Both probes returned 200 and rendered; that run is the live-site evidence quoted above, not a regression.

## Authorship

Written by Claude Code (session `01GkauAsZBEemRbco2rEX9Lx`), https://claude.ai/code/session_01GkauAsZBEemRbco2rEX9Lx — as prose rather than a trailing footer block, because a PATCH edit of a pull-request body drops that block: the one this PR was created with did not survive the update that added the sections above. Recorded once, here, rather than re-posted on every edit.