### PR TITLE
fix(docs): pin the fumadocs-core peek omission that encodes markdown as entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       "better-sqlite3",
       "esbuild",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "fumadocs-core@16.8.12": "patches/fumadocs-core@16.8.12.patch"
+    }
   }
 }

--- a/patches/fumadocs-core@16.8.12.patch
+++ b/patches/fumadocs-core@16.8.12.patch
@@ -1,0 +1,86 @@
+# Carry `Handle.peek` onto the wrapped serializer handlers in `defaultStringifier`.
+#
+# WHY THIS PIN EXISTS
+# -------------------
+# `page.data.getText('processed')` -- what `apps/docs/lib/source.ts` serves from
+# `/llms-full.txt` and from all 79 per-page `/llms.mdx` bodies -- emitted HTML
+# numeric character references into files that are not HTML, and two of them broke
+# the markdown link they sat in. Measured on `main` at 50aacb9, before this patch:
+# 67 numeric character references (58 encoding an asterisk, 5 a backtick, 4 a
+# closing parenthesis) and 4 of 661 link targets malformed, in each of the two
+# outputs. Two of those broken targets also made themselves invisible to the
+# absolute-URL rewrite in `app/llms-full.txt/route.ts`, whose `SITE_LINK` pattern
+# needs a literal closing parenthesis, so they were served relative in a file whose
+# whole purpose is to be read somewhere else.
+#
+# THE DEFECT
+# ----------
+# `defaultStringifier` (`dist/mdx-plugins/stringifier.js`) wraps every
+# `mdast-util-to-markdown` serializer handler through `modHandler`, and the wrapper
+# does not carry the handler's `peek` property. `containerPhrasing` uses
+# `Handle.peek` to read the NEXT sibling's first character cheaply and WITHOUT side
+# effects; with `peek` missing it invokes that sibling's full handler instead, and
+# the lookahead leaves `state.attentionEncodeSurroundingInfo` set from node N+1.
+# The loop then applies those flags to node N -- which is why an emphasis run's
+# opening marker is encoded while its closing partner is left alone.
+#
+# The fix is to copy `.peek` from the handler onto the wrapper. It is upstream's
+# bug, not this repo's, and this patch is byte-for-byte what upstream would ship.
+#
+# UPSTREAM STATE THIS TRACKS
+# --------------------------
+# Measured 2026-09-08 by unpacking the published tarballs: the defect is present in
+# 16.8.12 (installed here), 16.15.1, 16.15.2 and 16.15.8 (`latest` on that date).
+# The anchor line is byte-identical in all four. "Upgrade" is not a fix.
+#
+# Not reported upstream from this repository -- this session's GitHub access is
+# scoped to `objectstack-ai/*` and cannot open an issue on `fuma-nama/fumadocs`. A
+# ready-to-post upstream report is filed as a comment on
+# https://github.com/objectstack-ai/objectos/issues/197 and the maintainer routes
+# the filing.
+#
+# WHEN THIS FILE CAN BE DELETED
+# -----------------------------
+# When an installed `fumadocs-core` carries the fix itself: `grep peek
+# node_modules/fumadocs-core/dist/mdx-plugins/stringifier.js` finds something.
+# Delete this file, remove `pnpm.patchedDependencies` from the root `package.json`,
+# re-run `pnpm install`, and rebuild `apps/docs` -- the reference count must stay 0.
+#
+# ON A VERSION BUMP, THIS PATCH IS EXPECTED TO FAIL LOUDLY
+# --------------------------------------------------------
+# It is pinned to 16.8.12 by the key in `package.json`, so any other version simply
+# does not receive it and the defect returns silently -- which is why the counts
+# above are worth re-measuring on any bump. Beyond that, 16.15.x reformats an
+# `if` in the same function two hunks up, so a patch generated here does not
+# necessarily line up there. A Dependabot bump of this package therefore cannot be
+# merged on green: regenerate the patch against the new version in the same PR
+# (`pnpm patch fumadocs-core@<new>`), or drop it if upstream has landed the fix.
+#
+diff --git a/dist/mdx-plugins/stringifier.js b/dist/mdx-plugins/stringifier.js
+index cf19eea9336acb66414cf3e2e75f2b1aa2bfd138..636346eec49cd0760d84f874c2a352bd78a804fd 100644
+--- a/dist/mdx-plugins/stringifier.js
++++ b/dist/mdx-plugins/stringifier.js
+@@ -66,7 +66,22 @@ function defaultStringifier(config = {}) {
+ 	}
+ 	const customToMarkdown = { handlers: { _custom(node, _, state, info) {
+ 		const handlers = state.handlers;
+-		for (const k in handlers) handlers[k] = modHandler(handlers[k], node.ctx);
++		for (const k in handlers) {
++			const handler = handlers[k];
++			const wrapped = modHandler(handler, node.ctx);
++
++			// `Handle.peek` is how `mdast-util-to-markdown`'s `containerPhrasing`
++			// reads the NEXT sibling's first character cheaply and without side
++			// effects. A wrapper that does not carry it makes that lookahead invoke
++			// the sibling's FULL handler instead, which leaves
++			// `state.attentionEncodeSurroundingInfo` set from node N+1 and applies it
++			// to node N — encoding markdown punctuation as numeric character
++			// references in plain-text output. See the header of
++			// `patches/fumadocs-core@16.8.12.patch` in this repository.
++			if (handler.peek) wrapped.peek = handler.peek;
++
++			handlers[k] = wrapped;
++		}
+ 		return state.handle(node.root, void 0, state, info);
+ 	} } };
+ 	return function(root, ctx) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  fumadocs-core@16.8.12:
+    hash: 042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79
+    path: patches/fumadocs-core@16.8.12.patch
+
 importers:
 
   .:
@@ -19,13 +24,13 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: 16.8.12
-        version: 16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+        version: 16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.0.7
-        version: 15.0.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.17)(fumadocs-core@16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 15.0.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.17)(fumadocs-core@16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       fumadocs-ui:
         specifier: 16.8.12
-        version: 16.8.12(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
+        version: 16.8.12(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3)
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.7)
@@ -6115,7 +6120,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
+  fumadocs-core@16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3):
     dependencies:
       '@orama/orama': 3.1.18
       estree-util-value-to-estree: 3.5.0
@@ -6149,14 +6154,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.17)(fumadocs-core@16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  fumadocs-mdx@15.0.7(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.17)(fumadocs-core@16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       picocolors: 1.1.1
@@ -6177,7 +6182,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.8.12(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
+  fumadocs-ui@16.8.12(@tailwindcss/oxide@4.3.3)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.3):
     dependencies:
       '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.3.3)(tailwindcss@4.3.3)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6191,7 +6196,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.12(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-core: 16.8.12(patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938b182ed8d79)(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.16.0(react@19.2.7))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.16.0(react@19.2.7)
       motion: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
Fixes #197

Route A, as decided by the maintainer: pin the upstream one-liner with
`pnpm.patchedDependencies` and fix the producer, so `/llms-full.txt` and all 79
per-page `/llms.mdx` bodies are repaired together.

**NOTATION.** `AMP` stands for one literal ampersand character, per the card's
convention: this tracker's body sanitizer decodes HTML numeric character
references, including inside code fences. `AMP#x2A;` means the six characters
that would otherwise be typed as ampersand, hash, x, 2, A, semicolon.

## What is patched

`fumadocs-core`, `dist/mdx-plugins/stringifier.js`. `defaultStringifier` wraps
every `mdast-util-to-markdown` serializer handler through `modHandler` and does
not carry the handler's `peek` onto the wrapper. `containerPhrasing` uses
`Handle.peek` to read the next sibling's first character cheaply and without
side effects; with it missing the lookahead invokes that sibling's full handler,
which leaves `state.attentionEncodeSurroundingInfo` set from node N+1 for the
loop to apply to node N. The patch copies `.peek` onto the wrapper.

The cause, the isolated A/B and the first end-to-end proof are on #197 and are
not repeated here. What this PR adds is the durable form of the same change and
the evidence that it survives a real `pnpm install`.

## Measurements — re-taken in this tree, at base `50aacb9`

Same harness before and after, reading the built bodies off
`apps/docs/.next/server/app`. Union re-run on the final tree at `5ce94d3`.

| | before | after |
|---|---:|---:|
| numeric character references, `/llms-full.txt` | 67 | 0 |
| numeric character references, 79 `/llms.mdx` bodies | 67 | 0 |
| malformed markdown link targets, of 661 | 4 | 0 |
| absolute site targets in `/llms-full.txt` | 560 | 562 |
| line count of `/llms-full.txt` | 12923 | 12923 |

Reference kinds before, in both outputs: `AMP#x2A;` x58, `AMP#x60;` x5,
`AMP#x29;` x4.

**Three before-figures differ from the ones the decision comment quotes, and
the newer ones are the real ones.** Link targets are **661**, not 650, and
absolute site targets **560**, not 549 — eleven on-site links have landed in
`content/docs/` since the investigation read `1ebd7b7`. The malformed count (4)
and the reference counts (67, 58/5/4) are unchanged. The absolute-target figure
still moves by exactly +2: the two `[AI Builder]` links whose closing
parenthesis the bug had turned into `AMP#x29;`, which `SITE_LINK` in
`llms-full.txt/route.ts` could therefore never match.

**Membership and order untouched.** The 93 top-level `#` page headings are
byte-identical in sequence, all 799 heading lines are byte-identical in
sequence, and the line count is identical. Decoding the before body and diffing
against the after body leaves **21** differing lines: 19 are GFM table column
padding (a cell that loses 5 characters narrows its column, so every row in that
table is repadded) and 2 are the AI Builder links acquiring their absolute URL.
Nothing else differs.

## The patch applies on a clean install

`node_modules` wiped in all three workspace projects, then
`pnpm install --frozen-lockfile` — which is what CI runs — exit 0. pnpm 10.28.2
prints no "patch applied" line on success, so the evidence is what the installer
itself wrote, read back off disk afterwards:

- the virtual store directory it resolved to is
  `node_modules/.pnpm/fumadocs-core@16.8.12_patch_hash=042796c0fe0ae66ccc2f1eadd4df4b8399a43c39c49facd3a0d938_.../node_modules/fumadocs-core`
  — the `patch_hash=` segment is the installer's, not mine;
- `grep` on that file, resolved through `apps/docs`' own module resolution,
  finds `if (handler.peek) wrapped.peek = handler.peek;` at line 81, and finds
  the pristine anchor line 0 times.

## The patch step can fail — both ways

A patch step that cannot fail is indistinguishable from one that applied, so
both failure modes were demonstrated:

1. **Perturbed anchor, install refuses.** One character changed in the patch's
   removed-context line (`node.ctx` to `node.CTX`, confirmed on disk by
   hash-object before and after), `node_modules` wiped, `pnpm install` exits
   **1** with `ERR_PNPM_PATCH_FAILED  Could not apply patch ...`.
2. **Pin removed, the defect returns.** `pnpm.patchedDependencies` deleted from
   `package.json`, `node_modules` wiped, install exit 0 — and the installed file
   carries the pristine anchor and no `peek` line. A full rebuild then puts the
   references back at exactly the baseline figures: 67 references, 4 of 661
   malformed, 695176 bytes, matching the before build byte count.

Both legs were restored from `HEAD` under an `EXIT INT TERM` trap and the
restore verified by `git diff HEAD` being empty, not by an exit code.

## Where the manifest key went

pnpm 10.28.2 put `patchedDependencies` in the **root `package.json`**, under the
`pnpm` block that already carries `onlyBuiltDependencies` — not in
`pnpm-workspace.yaml`. That placement is `pnpm patch-commit`'s own, left where
the installed tool wrote it and verified to work through a wiped
`--frozen-lockfile` install.

## Worker size gate

Three `wrangler deploy --dry-run` readings in this container, all far under the
61440 KiB budget (headroom ~2895 KiB):

| tree | `Total Upload:` |
|---|---:|
| pin removed (negative control) | 58549.15 KiB |
| this branch, `pnpm run build` then package | 58544.59 KiB |
| this branch, `pnpm turbo run build` then package | 58544.37 KiB |

The two readings of **this same branch** differ by 0.22 KiB, so a sub-KiB gap
between readings is not by itself evidence of a change in the bundle. No delta
is claimed here in either direction; the gate is green.

## Gates run before pushing, on `5ce94d3`

All exit 0, verdicts read from each command's own output:

- `pnpm install --frozen-lockfile` on a wiped `node_modules`
- `node .github/scripts/check-node-floor.mjs --self-test` and the real scan
- `node scripts/pm/check-half-states.mjs --self-test` (1551 cases)
- `node apps/docs/scripts/gen-zh-hant.mjs --check` (73 files byte-identical)
- `pnpm turbo run type-check --continue`
- `pnpm turbo run build`
- `node .github/scripts/check-locale-surface.mjs` — 409 sitemap URLs, 0
  unexpected / 0 missing, and both `llms` bodies still carry all 60 en-only
  titles and none from other locales
- `pnpm turbo run test --force`
- `opennextjs-cloudflare build --skipNextBuild` plus the size weigh-in above
- the pre-merge render check: `smoke-docs.mjs` against a local
  `opennextjs-cloudflare preview`, 4 pages rendered, its own negative control
  demonstrated red

## Upstream, and the next bump

The defect is present in 16.8.12 (installed), 16.15.1, 16.15.2 and 16.15.8
(`latest` on 2026-09-08), each checked by unpacking the published tarball; the
anchor line is byte-identical in all four. Upgrading is not a fix. This session
cannot open an issue on `fuma-nama/fumadocs`, so a ready-to-post upstream report
is filed as a comment on #197 for the maintainer to route.

#239 bumps this package to 16.15.2. The pin is keyed to `16.8.12`, so on any
other version the patch is simply not applied and the defect returns silently —
which is why the counts above should be re-measured on that PR, and the patch
regenerated against the new version in the same PR. 16.15.x also reformats an
`if` two hunks above this one in the same file. The patch file's header carries
all of this, plus the condition under which the file can be deleted.

## Not touched

`apps/docs/lib/source.ts`, `apps/docs/app/llms-full.txt/route.ts`,
`content/docs/`, and `.github/workflows/ci.yml` (in flight on #277). No consumer
edit was needed, which is the result Route A was chosen for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01ChPQM8jamxLUfUAxwFpJ8S)_